### PR TITLE
fix(figma.utils): error now exits the process gracefully"

### DIFF
--- a/packages/cli/src/commands/init/utils/repo.ts
+++ b/packages/cli/src/commands/init/utils/repo.ts
@@ -37,14 +37,14 @@ export const commandSetupGit = async (dir: string) => {
   } catch(error: any){
     console.log(chalk.red(error?.message));
   }
-  
+
   // check to see if the folder we just cloned exists
   if(!fs.existsSync(dir)){
     throw new Error(`The repo directory ${ dir } does not exist`);
   }
 
   await execSync(`cd ${ dir } && rm -rf .git`);
-  await execSync(`cd ${ dir } && git init -b main`);
+  await execSync(`cd ${ dir } && git init main`);
 };
 
 export const logSuccess = (designSystemOptions: any) => {

--- a/packages/cli/src/commands/styles/command.ts
+++ b/packages/cli/src/commands/styles/command.ts
@@ -74,20 +74,6 @@ export const styles: CommandModule<Options, Options> = {
 
     const { template, dryRun } = args;
 
-    if (!figmaUrl) {
-      logger.error(
-        'Figma URL Not Found, please run styles command again and provide the URL: '
-      );
-      process.exit(1);
-    }
-
-    if (!figmaToken) {
-      logger.error(
-        'Figma Token Not Found, please run styles command again and provide the token: '
-      );
-      process.exit(1);
-    }
-
     const options: Options = {
       url: figmaUrl,
       userToken: figmaToken,

--- a/packages/cli/src/commands/styles/lib/radius-styles.ts
+++ b/packages/cli/src/commands/styles/lib/radius-styles.ts
@@ -36,9 +36,7 @@ export const generateGlobalStyles = async ({
   assert(userToken !== 'none', 'Environment variable FIGMA_TOKEN is empty');
   assert(typeof url === 'string', 'Figma url must be provided');
   const renderTemplate = renderers[template];
-
-
-  // Needs to be extracted
+  
   //const input = fs.existsSync(figmaFile) ? Promise.resolve(figmaFile): getFileNode(fileId,[nodeId]);
 
   const tokenGroups = await loadFile({ url, token: userToken }).then(getTokens).then(groupByType);

--- a/packages/cli/src/commands/styles/lib/radius-styles.ts
+++ b/packages/cli/src/commands/styles/lib/radius-styles.ts
@@ -1,20 +1,18 @@
 import {
-  assert,
   DesignToken,
-  getTokens,
-  processFigmaUrl,
-  setup
+  getTokens
 } from '../utils/figma.utils';
+import { assert } from '../utils/common.utils';
 import { groupBy } from '../utils/common.utils';
 import renderers from './templates';
 import path from 'path';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { logger } from '../../../logger';
 import chalk from 'chalk';
-import fs from 'fs';
+import { loadFile } from '../utils/figma.loader';
 
 const token = process.env['FIGMA_TOKEN'] || 'none';
-const figmaFile = './__mocks__/figma-file-2021-09-03T00:53:20.007Z.json';
+// const figmaFile = './__mocks__/figma-file-2021-09-03T00:53:20.007Z.json';
 
 export type Options = {
   url: string,
@@ -38,11 +36,13 @@ export const generateGlobalStyles = async ({
   assert(userToken !== 'none', 'Environment variable FIGMA_TOKEN is empty');
   assert(typeof url === 'string', 'Figma url must be provided');
   const renderTemplate = renderers[template];
-  const { getFileNode } = setup(userToken);
-  const { fileId, nodeId } = processFigmaUrl({ url, token: userToken });
 
-  const input = fs.existsSync(figmaFile) ? Promise.resolve(figmaFile): getFileNode(fileId,[nodeId]);
-  const tokenGroups = await input.then(getTokens).then(groupByType);
+
+  // Needs to be extracted
+  //const input = fs.existsSync(figmaFile) ? Promise.resolve(figmaFile): getFileNode(fileId,[nodeId]);
+
+  const tokenGroups = await loadFile({ url, token: userToken }).then(getTokens).then(groupByType);
+
   const files = renderTemplate(tokenGroups);
 
   if (consoleOutput) {

--- a/packages/cli/src/commands/styles/utils/common.utils.ts
+++ b/packages/cli/src/commands/styles/utils/common.utils.ts
@@ -1,3 +1,5 @@
+import { logger } from '../../../logger';
+
 export type GroupOf<
   T,
   K extends keyof T,
@@ -36,3 +38,13 @@ export const toKebabCase = (s: string) =>
 	            : letter
 	    )
 	    .join('');
+
+export const assert = <T>(x: T, msg?: string) => {
+  if (!x) {
+    if (typeof msg === 'string') {
+      logger.error(msg);
+    }
+    process.exit(1);
+  }
+};
+

--- a/packages/cli/src/commands/styles/utils/common.utils.ts
+++ b/packages/cli/src/commands/styles/utils/common.utils.ts
@@ -48,3 +48,6 @@ export const assert = <T>(x: T, msg?: string) => {
   }
 };
 
+export const regexSingleMatch = (str: string, regex: RegExp) => {
+  return str.match(regex)?.[1] ?? '';
+};

--- a/packages/cli/src/commands/styles/utils/figma.loader.ts
+++ b/packages/cli/src/commands/styles/utils/figma.loader.ts
@@ -1,0 +1,21 @@
+import * as Figma from 'figma-api';
+import { FigmaFileParams, processFigmaUrl } from './figma.utils';
+
+export const setupFigma = (key: string) => {
+  const api = new Figma.Api({
+    personalAccessToken: key
+  });
+  return {
+    getFile: (fileKey: string) => api.getFile(fileKey),
+    getFileNode: (fileKey: string, ids: string[]) =>
+      api.getFileNodes(fileKey, ids)
+  };
+};
+
+export const loadFile = ({ url, token }: FigmaFileParams) => {
+  const { getFileNode } = setupFigma(token);
+  const { fileId, nodeId } = processFigmaUrl({ url, token });
+
+  const input = getFileNode(fileId,[nodeId]);
+  return input;
+};

--- a/packages/cli/src/commands/styles/utils/figma.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figma.utils.ts
@@ -39,17 +39,18 @@ export type FigmaData = {
 
 export const assert = <T>(x: T, msg?: string) => {
   if (!x) {
-    logger.error(msg || 'Please make sure you entered a valid URL and token and try again');
-    // logger.error('Please make sure you entered a valid URL and token and try again');
+    if (typeof msg === 'string') {
+      logger.error(msg);
+    }
     process.exit(1);
   }
 };
 
 export function assertFigmaData(d: unknown): asserts d is FigmaData {
   const { fileId, nodeId, token } = (d as FigmaData) ?? {};
-  assert(typeof fileId === 'string', 'Please check your Figma URL');
+  assert(typeof fileId === 'string', 'Please put a valid URL');
   assert(typeof nodeId === 'string', 'node-id not found');
-  assert(typeof token === 'string', 'token not found');
+  assert(typeof token === 'string', 'Please put a valid token');
 }
 
 export const processFigmaUrl = ({ url, token }: FigmaInputData): FigmaData => {

--- a/packages/cli/src/commands/styles/utils/figma.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figma.utils.ts
@@ -39,6 +39,8 @@ export type FigmaData = {
 
 export const assert = <T>(x: T, msg?: string) => {
   if (!x) throw new Error(msg || 'Assertion failed');
+  console.log('Please make sure you entered a valid URL and token and try again');
+  process.exit(1);
 };
 
 export function assertFigmaData(d: unknown): asserts d is FigmaData {

--- a/packages/cli/src/commands/styles/utils/figma.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figma.utils.ts
@@ -38,9 +38,11 @@ export type FigmaData = {
 };
 
 export const assert = <T>(x: T, msg?: string) => {
-  if (!x) throw new Error(msg || 'Assertion failed');
-  console.log('Please make sure you entered a valid URL and token and try again');
-  process.exit(1);
+  if (!x) {
+    throw new Error(msg || 'Assertion failed');
+    console.log('Please make sure you entered a valid URL and token and try again');
+    process.exit(1);
+  }
 };
 
 export function assertFigmaData(d: unknown): asserts d is FigmaData {

--- a/packages/cli/src/commands/styles/utils/figma.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figma.utils.ts
@@ -1,5 +1,4 @@
-import * as Figma from 'figma-api';
-import { GroupOf, toKebabCase } from './common.utils';
+import { assert, GroupOf, toKebabCase } from './common.utils';
 import {
   filterByDescriptionSpacer,
   filterByElevation,
@@ -11,22 +10,10 @@ import {
   NodeKey,
   TokenTransform
 } from './figmaParser.utils';
-import { logger } from '../../../logger';
 
 const tokensV2Flag = true;
 
-export const setup = (key: string) => {
-  const api = new Figma.Api({
-    personalAccessToken: key
-  });
-  return {
-    getFile: (fileKey: string) => api.getFile(fileKey),
-    getFileNode: (fileKey: string, ids: string[]) =>
-      api.getFileNodes(fileKey, ids)
-  };
-};
-
-export type FigmaInputData = {
+export type FigmaFileParams = {
   url: string,
   token: string,
 };
@@ -37,23 +24,14 @@ export type FigmaData = {
   token: string,
 };
 
-export const assert = <T>(x: T, msg?: string) => {
-  if (!x) {
-    if (typeof msg === 'string') {
-      logger.error(msg);
-    }
-    process.exit(1);
-  }
-};
-
 export function assertFigmaData(d: unknown): asserts d is FigmaData {
   const { fileId, nodeId, token } = (d as FigmaData) ?? {};
-  assert(typeof fileId === 'string', 'Please put a valid URL');
+  assert(typeof fileId === 'string', 'Please enter a valid URL');
   assert(typeof nodeId === 'string', 'node-id not found');
-  assert(typeof token === 'string', 'Please put a valid token');
+  assert(typeof token === 'string', 'Please enter a valid token');
 }
 
-export const processFigmaUrl = ({ url, token }: FigmaInputData): FigmaData => {
+export const processFigmaUrl = ({ url, token }: FigmaFileParams): FigmaData => {
   const [, fileId] = url.match(/\/file\/(.*)\//) || [undefined];
   const [, encodedId] = url.match(/\?node-id=(.*)&?$/) || [undefined];
   const nodeId = encodedId && decodeURIComponent(encodedId);

--- a/packages/cli/src/commands/styles/utils/figma.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figma.utils.ts
@@ -1,4 +1,4 @@
-import { assert, GroupOf, toKebabCase } from './common.utils';
+import { GroupOf, toKebabCase } from './common.utils';
 import {
   filterByDescriptionSpacer,
   filterByElevation,
@@ -18,27 +18,6 @@ export type FigmaFileParams = {
   token: string,
 };
 
-export type FigmaData = {
-  fileId: string,
-  nodeId: string,
-  token: string,
-};
-
-export function assertFigmaData(d: unknown): asserts d is FigmaData {
-  const { fileId, nodeId, token } = (d as FigmaData) ?? {};
-  assert(typeof fileId === 'string', 'Please enter a valid URL');
-  assert(typeof nodeId === 'string', 'node-id not found');
-  assert(typeof token === 'string', 'Please enter a valid token');
-}
-
-export const processFigmaUrl = ({ url, token }: FigmaFileParams): FigmaData => {
-  const [, fileId] = url.match(/\/file\/(.*)\//) || [undefined];
-  const [, encodedId] = url.match(/\?node-id=(.*)&?$/) || [undefined];
-  const nodeId = encodedId && decodeURIComponent(encodedId);
-  const data = { fileId, nodeId, token };
-  assertFigmaData(data);
-  return data;
-};
 
 // type Unpromise<T extends Promise<any>> = T extends Promise<infer X> ? X : never;
 type FigmaFileNodes = {

--- a/packages/cli/src/commands/styles/utils/figma.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figma.utils.ts
@@ -11,7 +11,7 @@ import {
   NodeKey,
   TokenTransform
 } from './figmaParser.utils';
-
+import { logger } from '../../../logger';
 
 const tokensV2Flag = true;
 
@@ -39,15 +39,15 @@ export type FigmaData = {
 
 export const assert = <T>(x: T, msg?: string) => {
   if (!x) {
-    throw new Error(msg || 'Assertion failed');
-    console.log('Please make sure you entered a valid URL and token and try again');
+    logger.error(msg || 'Please make sure you entered a valid URL and token and try again');
+    // logger.error('Please make sure you entered a valid URL and token and try again');
     process.exit(1);
   }
 };
 
 export function assertFigmaData(d: unknown): asserts d is FigmaData {
   const { fileId, nodeId, token } = (d as FigmaData) ?? {};
-  assert(typeof fileId === 'string', 'fileId not found');
+  assert(typeof fileId === 'string', 'Please check your Figma URL');
   assert(typeof nodeId === 'string', 'node-id not found');
   assert(typeof token === 'string', 'token not found');
 }


### PR DESCRIPTION
The error now exits the process gracefully

Fixes # (issue)
```
script/dist/commands/styles/utils/figma.utils.js:65
        throw new Error(msg || 'Assertion failed');
              ^

Error: fileId not found
    at assert 
```
now exits gracefully with a message for the user


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
