### PR TITLE
Bug/38

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@DogaIster @jasonsantos @sumitarora @smoogly @seanmay @rafRangler @Bohdan-Anderson-Rangle
+@DogaIster @jasonsantos @sumitarora @smoogly @seanmay @rafRangler @Bohdan-Anderson-Rangle @usrrname

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,10 @@
 {
+	"[typescript]": {
+		"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+	},
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
 	},
-	"eslint.validate": ["typescript"]
+	"eslint.format.enable": true,
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     }
   },
   "devDependencies": {
+    "@types/fs-extra": "^9.0.13",
+    "@types/inquirer": "^8.2.1",
     "@types/node": "17.0.21",
+    "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "5.15.0",
     "@typescript-eslint/parser": "5.15.0",
     "cz-conventional-changelog": "^3.3.0",


### PR DESCRIPTION
# Description

- adds `@types/yargs`, `@types/inquirer`, `@types/node`, `@types/fs-extra` dependencies to allow `npm run cli:init` or `yarn cli:init` command to be run from project root 

Fixes # (issue)
#38 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
