### PR TITLE
refactor: changing the way we retrive nodes and styles

### DIFF
--- a/packages/cli/bin/radius
+++ b/packages/cli/bin/radius
@@ -2,7 +2,7 @@
 
 "use strict";
 
-const radius = require("../dist/radius");
+const radius = require("../dist/src/radius");
 const parser = radius();
 
 // eslint-disable-next-line no-unused-expressions

--- a/packages/cli/src/commands/styles/lib/__mocks__/publish.components.json
+++ b/packages/cli/src/commands/styles/lib/__mocks__/publish.components.json
@@ -1,0 +1,11908 @@
+{
+    "data": {
+        "error": false,
+        "status": 200,
+        "meta": {
+            "components": [
+                {
+                    "key": "0100cc34eb0c616d7a541dd606e04b3354d1cb65",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15254",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/BFq/dLZ/VbvWSVSn9DJHpauW/component_thumbnail_129.png?Expires=1655683200&Signature=AMn7FTKwC-pCzTg7XFRyY9XmPwDdqjapQ7~ojExuSoNYFgr8Vw5TDVYHaL~-Ms4Bkxdna9bidA2Ouj9Svlp6LE~c-hrjoBq-Y9l7q6ktAV0DWwUHgPxWvvTBDsi7-7YVCsJsaHRr2khha-4-y3zosA79bMpbZN3VRV4EHFpI3XvNwM2Y0FiFnmy-N24yDlcQ-V3Rb7hJMaXcdsKnedb7HE1IYc4woy7OE4TThznMqQIhnQwlL9KuR-1OAFzUI8fN3BS6Zq6wRkfEau78XPNv2CCvA4fV6S8JfNUdRlRZ-ErIueGgl1cFppWyaOGQ5~3S74KAyoybYh-kKRnFgdEFYQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Base font size CLI test",
+                    "description": "#16px",
+                    "created_at": "2022-05-09T18:35:30.595Z",
+                    "updated_at": "2022-05-19T19:14:53.865Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7e98aa179261d96c3ef22cdc27d333394acd70ae",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15255",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Ws4/MLl/bgPVZFz8ZrIw68B2/component_thumbnail_104.png?Expires=1655683200&Signature=g8gYKJ39kdOr7-3xwATpacg3oC004yWY-VoI2ra7VDs3Tn6DXUFMpYgNERBWY6F8tDp6VamosYsAB85BI1FUKDtEvflfP3kNM4zAfUW602GhuRGY87e~D6zkir85rtgyl4MN0UPxboVjpm4CdptdF2Wxo7U~FBGvNG-xXLMybiJ2L-BrV-sTI8AKC0Qd4OEkxl1-MF93kDZ~Zk-ZyY2eu~lInwREDRu0E~9avEp2CYNd3ISidaKACTwGj6Ktt3ct02cyhJ4aZWj-ViWNP5LmXaajMrd8UWsluws9ThaHMshAMHSzLcCBsuiRA3GWlKOIzjyY7DhjCZkspdtqeizcjg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Font family CLI test",
+                    "description": "#Roboto",
+                    "created_at": "2022-05-09T18:35:09.973Z",
+                    "updated_at": "2022-05-19T19:14:51.563Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d21b8103f777a92d744bf22e98a9ab0127fa030a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21437:12931",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/fzd/86j/0QX35V3ZYEvFbUUQ/component_thumbnail_150.png?Expires=1655683200&Signature=TCHG~UbbomBMtUBa53jaNF58zksYlWrvZPsd5nDTYlhNXdATcu81XBB6Rrv~yuia7dbfYBiMeVuYX4X~lDf~fg5ful32m9wcqSIGPA9L2puFfLYOTb6DQ3L~pxZaTePm7xQeWnuU3C1OInjFweEuxYOPg2gutbkqPa9GG3~bKZuV7MCO3iukSA--ncGPpvX8ujJXUpK8Np1t7T6oGqbLbZtCWZJmL-MKf~AclbIq5U1VAos4fdUpJKWueNv3YXDD7cQj30wes9dqnUtUgaRbA~-rI-yFjo-eEpFcqMztd5-d1a1qKill5GyYiLzUb19nPfAYnYRdo6RTQ1aQdfoDFw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Component",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:00.957Z",
+                    "updated_at": "2022-05-09T18:57:13.731Z",
+                    "containing_frame": {
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "be165da8e097084340f9f71284aa9f3476a40e74",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:26556",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/M9Q/HMR/v6DTLm21LDlzA9Hm/component_thumbnail_125.png?Expires=1655683200&Signature=OppX7s5N0Nv2Ja7DkMhx8F4z5-IzwY4cshieljjNqago3FFbf-TUHmmNCU6jjOXuIF1YIshbMTJBSLfOzo9TF4CvPNYSYMwh3wQu6uaBZaoTIcq-BsRmsDWUVZlQHwAp5thGj2ncA4LrhvSCdpDx9FMwLxBAnzUL5mfI1sq4ir9RoFKCcfHw454EQ6D3S0xn2mQKZQnkH7vswyMJxM6NvS3un7veo-oZDiQhJNueCwDyyqUNBQr3AiXnl2LcwYIZhGQ0osZ5YW8h6L6Ps0g9Bx0k0FXwljzvLjxeljy12LD86na18FTmR8iW0utwDGCwx3owtgWVwtOACVAh3tGO3A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Example",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:00.825Z",
+                    "updated_at": "2022-05-09T18:57:13.693Z",
+                    "containing_frame": {
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ddaa2593e1287683580ae9290ba8a3d783838e89",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20629:4772",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ULP/RtD/meMmgvSP2WL7GsMi/component_thumbnail_169.png?Expires=1655683200&Signature=T2zKFlEatiUSAf4pjEm40Bt8uQkTOaTZlBxOUwdC6hz9ARuF-9S4x5bkRyKK2eu5H00Gt0APeIEfpBbr6HjxZlBYK9xJig~aenXKqC~aY7NRB8lQaf1srRfD4ikajdI9efF1yFg4751B22u-9wjm3Gb3gh1NCkx7yyqPvXAYe-5l8JedFgdJ4EW9EQejjakEJF4kQkYVvZATEubqHc-dbwvfiekZ1xKj5rFnc62RLnZrzQKvOX4uUO8QcqnZMhp3ScTMi~ITl~v5R-4-wNqwFbNaf9isX5KRXCqSsObPvnb4Jj6V~WAfWTlt3mdQ3bFy-i~9x7gQtdDBl-9U2Ct~Xg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color Variant=Positive",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.424Z",
+                    "updated_at": "2022-05-09T18:36:03.424Z",
+                    "containing_frame": {
+                        "name": "Attention box",
+                        "nodeId": "20629:4753",
+                        "pageId": "21536:12434",
+                        "pageName": "✏️  Alerts (WIP)",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Attention box",
+                            "nodeId": "20629:4753"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "60a588752e4175a201a5060af5b87ce570f6b9e4",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20629:4766",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/kol/GQc/nrC3LuBlSuIFhRUP/component_thumbnail_168.png?Expires=1655683200&Signature=fZUW9YfCEvAWU-93vIz~42u3vs8TP3lAnelvwJCou27LJwT7cSXOqTSx4zpiUycMvc1VjBQtt4xbEdQVPdpx9gMCWpx3FvGimc5tSFzah3L31FqEWc869Vakf9Ix5uUUre6TWRHkC48k29N997rke9gK85y8dEtzz3UmgdieOM4lXSoQkrus1EjuuDqbqHPXkGQwbPHVLmi~9LTuSZgVxu~M6Go6BAJFgtqGtAVeuJmV9bNDkTgzs0DAOYMfq73E9IjWENEAKLxHfMsOWPdlfUzDok14IDK56AZqHH7pKe7Iy75k4LZVnKnaXm5JSRamJnww-Ev9~dUOwzQjyGQ6Bw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color Variant=Negative",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.417Z",
+                    "updated_at": "2022-05-09T18:36:03.417Z",
+                    "containing_frame": {
+                        "name": "Attention box",
+                        "nodeId": "20629:4753",
+                        "pageId": "21536:12434",
+                        "pageName": "✏️  Alerts (WIP)",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Attention box",
+                            "nodeId": "20629:4753"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4a79a78b1ad02d07c1d9c99d60d12ff8225d2c40",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20629:4760",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/GMs/shw/wpcOWgKzYGMvY717/component_thumbnail_167.png?Expires=1655683200&Signature=hlpqd3pkxu~dDuvpCL3pqqhq9En9gDd0Vb3cB2E454SNzIAEc9BuzD~9Z1MW~DAFWGele76cJuqAmTlnBoyhmLr5Q68PCX~Zm-5-eVUqYwk15ganvHFn4~AlX8HE0PwJ4Ay9qMuBJqIoTy4eDqTM90Swoy-7Ub3HAfH97uK24vuNyvgO-OQjOTmUHiqloh~9k8tdaQIGzxTD1w8dcF8dJxkZNPt6H-ax13ovv~r1FmZ6w1Zs3tBBvRK1y0h0kY0rkBKjwx8bd7npSQd9SSVtmnTNZ0wRZymNoI20hTYgG7D3mESKJMJtzIacjD0ecPHfjSpv3uK2uTboHVwpiGHCcA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color Variant=Netural",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.411Z",
+                    "updated_at": "2022-05-09T18:36:03.411Z",
+                    "containing_frame": {
+                        "name": "Attention box",
+                        "nodeId": "20629:4753",
+                        "pageId": "21536:12434",
+                        "pageName": "✏️  Alerts (WIP)",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Attention box",
+                            "nodeId": "20629:4753"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0907a117e6a879509361f3e7f19d551140754b21",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21386:10136",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/4JZ/u4L/ABpB0E6d1HkXQxYY/component_thumbnail_166.png?Expires=1655683200&Signature=g5iAFbaFwybOVkpDx6RwDfdM3y3Ape8DrBpSXq6~kHkAFZUovI5ocWRj9A0d2390Hm9rHzlf3MuS~MYCJg0jxy7~N36~R09djEuK10VZj-S5XeI8aIpsLTPj0bYWUM1rHGiXvOIcJ1eHtWtPMorRG07AAai0V9l0xEXRTg5y4AcxNusSvTBvs2zsfTTJY6QxZuKC4mk-LNNf5ZaegM83B-fWJgNnOB53RvHdN9HYoUpEI25iT3iev4Pu6yc8Woy2ACgGnXpRQxvvbfeH4S0RR7RGVFsOaqbL1HvatCGZd-LB1MA4dnO1~3prtBjv2bBocYoUwTLI3h-wqagwQIoiqw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color Variant=Primary",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.405Z",
+                    "updated_at": "2022-05-09T18:36:03.405Z",
+                    "containing_frame": {
+                        "name": "Attention box",
+                        "nodeId": "20629:4753",
+                        "pageId": "21536:12434",
+                        "pageName": "✏️  Alerts (WIP)",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Attention box",
+                            "nodeId": "20629:4753"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b7d70f8f388e448d3a932a749d226aa673de34d5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21465:16741",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/kNI/BKA/wMGl9YgaGHO3KGJy/component_thumbnail_165.png?Expires=1655683200&Signature=M2vdkMDk5MMyDm6HbsltPecw2RZgfHUtTM3UWcPMA5pJVDLukbBO9HXyZXGren2qPe-Z43JGyvZgI7bY40pfQ4whIO~g9HLyrpTgvSgqJSQzl~IMeY4KQvt7Xt45tMO3BMAKYJcP8KAkJ1o7JuCHUugG465ZjRBfvsya1YMUeF1jfKILWOTTez68wTyzimfFHpS3F5aBeQb2O1nyPvJbdxDpmBjGreEmRaCuRqbAxQ7HzGuNXkaTT7byJVj0uWhPqVD0bJgmp9dUjjU97KaY7WBolgVxFEuhXxP1-JFgndah8~B564PgDViav9heI0C2Ofq6CCHLP98zDR-midc-IA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Checkbox, Property 2=Set",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.399Z",
+                    "updated_at": "2022-05-09T18:36:03.399Z",
+                    "containing_frame": {
+                        "name": "Fieldset",
+                        "nodeId": "21465:14096",
+                        "pageId": "21465:14093",
+                        "pageName": "✏️ Fieldset (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Fieldset",
+                            "nodeId": "21465:16719"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8791404acf3c716b805ead59735ccbc141fbb236",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21465:16797",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/vLL/44X/k5RN4PBMpecBEYmX/component_thumbnail_164.png?Expires=1655683200&Signature=bmPgQym-mPvbwItLlNaROUs0LOzbZj4AFwaH8gYqeGXQgjY~Ig759RNqS~nyUfCo4PQ71Ukefq8w2hfTFLcVGB~Lp3wvpVj9yFEHwHW8JSW1chMFTCo6UPMna8AcT~5yclfcLTSunaihigQobm69k4x6d8mgxp5fEzbhALqfQPaDHTJRMZY9CNN1QzIpnjPumUAj2Euc0iO5nsE20MS-VmIua2OmhQmxHvkHJ2BGInXDqjUJfHFeqzp6CZvN6oELOW-g1CFhgh6sGHlioMw8rmBrVtNjayv4vutO-7Vp8uQokVgMQPS5DOOF0FA910KAf6QEf6dKjoHCu3wSiIWv4A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Radio, Property 2=Set",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.393Z",
+                    "updated_at": "2022-05-09T18:36:03.393Z",
+                    "containing_frame": {
+                        "name": "Fieldset",
+                        "nodeId": "21465:14096",
+                        "pageId": "21465:14093",
+                        "pageName": "✏️ Fieldset (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Fieldset",
+                            "nodeId": "21465:16719"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9f52ea0fed2c8bfea92b519d251e5877b117c36c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21465:16718",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/1j8/BXj/yw8s9vGoFxppMYge/component_thumbnail_163.png?Expires=1655683200&Signature=dlfJb1iMkdVA1OC-xdS406hhgNs0CiWJ38wASumuv~UP~q8S~rG8tr6-q3QHeBk6PQUej1syiVcI6kxXGahsXxEXr5xRLYi7Qih42Xp2mjQy4K4jwF9v4OR9UVp9A92TY5Tctz1HNXDmIGxIYycX2lB7BIUe0xXBI7Hz3aXzobvhgGKD4KPy0kafwx7NzII5PKzqSTTz2seH33Aa2QS77L6IAbQ-V~-GL0JQRPK3PGzq99afiitDv2-ARCFXsDgBbHwTlDsiXeGplRsYxyLx9XjPbJmYkwW~884GvscgsoUu6QF5Q9N2EcPrftquBgeB6g3l~DUFED6ShfoOt6a3qA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Checkbox, Property 2=Single",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.387Z",
+                    "updated_at": "2022-05-09T18:36:03.387Z",
+                    "containing_frame": {
+                        "name": "Fieldset",
+                        "nodeId": "21465:14096",
+                        "pageId": "21465:14093",
+                        "pageName": "✏️ Fieldset (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Fieldset",
+                            "nodeId": "21465:16719"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b020282d428c98ce2c9342b462853b569499c5af",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21465:16733",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/AKl/jrh/548TnekOIUAfmC7A/component_thumbnail_162.png?Expires=1655683200&Signature=GiHXejyXi9bg0jdGFIku00KFvxUGgDhPxCgVg9e-Pp8PhiWf8qvq8tyLyEXd8zJQbrcCwrA~nPRAXSD~Lf9yYEkIvtMa8FWyVMJ9WTOGaySos7-Xu0PX5-GnxPwGMP4mj~d5vkmcY52hLxQqinxpvrMWEoDCaZUYKGqo43R~9a6HDqVOUHy5xNhnUaELWgKuBayIpLCTiXpBsWf8j--3Nf8F9YsdXn1WTt4ZipZru4-9aPyu6bLL6BtTW7ArjzUT4hoF3IMDl9Oq1kDGfCYowy5lmNtJ5i31r-l9Bbsq33KwW-uZngSTfcYXrNJ4oygShfoF0en4Yiz1K281NqQj7w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Radio, Property 2=Single",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.382Z",
+                    "updated_at": "2022-05-09T18:36:03.382Z",
+                    "containing_frame": {
+                        "name": "Fieldset",
+                        "nodeId": "21465:14096",
+                        "pageId": "21465:14093",
+                        "pageName": "✏️ Fieldset (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Fieldset",
+                            "nodeId": "21465:16719"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "050016ab5ff90f258faefa17d1e8cda263cf46f0",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20861:6627",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/LA5/Z6D/PviIDB9Rq46rxcVw/component_thumbnail_161.png?Expires=1655683200&Signature=gWPXPP36upo2OUCBpbL403InSKE7ZKvjV9iGmXSL1rm8GZ6LnDg4CXgn7pZ3j~GjnmXva71D1xRqagyE3Q-Is~yBTP-lyw2s278WuT5Vd277pPZzqN1pu0qz-Mb~fSsP6q4XuQpzjX-HWAAG3gvcRByEacC2rHxU9mz4wJiLN0zpuJyGL5K67HDkwzEsrb2TDp25CDcF7jcPo~diqMTuTpN6SB00OqW9bieXZrDWQFHK9~gw9aVbl2jpcRpbZVpNnEzk~s83J1idnvwXtQPXGG-GxCZ1GQgHuZ7kBU07KTYviElRxFEoFlp~bbEylwahB2oYcQgvK5IiAjGkpuq1kQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=hover",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.377Z",
+                    "updated_at": "2022-05-09T18:36:03.377Z",
+                    "containing_frame": {
+                        "name": "Slider",
+                        "nodeId": "21465:13514",
+                        "pageId": "21465:13512",
+                        "pageName": "✏️  Slider (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "slider",
+                            "nodeId": "20861:6638"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ac3e2d1f8f3964214f95844d58feac371bcfdac6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20861:6633",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/m5Z/DLw/dngM8dKTd0bopKQ9/component_thumbnail_160.png?Expires=1655683200&Signature=GZANKn8jL3xPYWgUFnJ9PewmsG1IHnDC7Cm3XharAZwidfCWJJp1IdLcsg2aqTmlmwiQHsMdPtBeID98FpH~JDjyyTHw8YVzPTl3moh~WUUmXKmlyonoPR2LsQo9cmXv0oqNihzmryrsWubtRC1tqFY7M4cwo-cj5FPqwdB607tU9DXaTWYWC2YUd8j2ndhfx18-JV45B9NmJKaoNv5CDJLyFVWPPJoNx3kES00qS14mSllURw73rbkO~XgwEsnZCehTxn8AeZtFhUp0LuRSsrcnS-QuXr0YkK2K32ls2rECujUP~GFYXzAbfgH0Ffbp9hazyrQ9FSoNaVABQZ~0lw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=disabled",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.371Z",
+                    "updated_at": "2022-05-09T18:36:03.371Z",
+                    "containing_frame": {
+                        "name": "Slider",
+                        "nodeId": "21465:13514",
+                        "pageId": "21465:13512",
+                        "pageName": "✏️  Slider (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "slider",
+                            "nodeId": "20861:6638"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6b79871859a38a07c1e7d5c480be5b5e36070fe3",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20861:6632",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Uca/mnH/QkVihDDanj6iS8UA/component_thumbnail_159.png?Expires=1655683200&Signature=F~UPBcKTPlWRVT8-oHfL3ybyJh58EJgreVLflOj-qpkeTrYxAudWUI6DXEduM9XAax1eHWkYF2YkkLcFq5xbIiArTeg~QVWLWIfYpW5b1EcU763GAnR1VEALdvvq3Ai1s-CkEIBR9bt30s~iXdF~rybnrn-PWNcCEccfGJVJRZ4qJafz5uhsiXlTEi2kp2iYWTe5R2zHYKo3SgwG4cjagbazWIxmXM4CCtSsikc18iLQrTKus1x~KOXX0uy7lL-VgMBfOlsfpC4rbI5FZHd2GcxIbaY40htdWNCdRKdyoTFdgLe8CNS2qpsCXd2BdW9w7GAastYpnCeiQzJQ2eXwIA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=active",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.364Z",
+                    "updated_at": "2022-05-09T18:36:03.364Z",
+                    "containing_frame": {
+                        "name": "Slider",
+                        "nodeId": "21465:13514",
+                        "pageId": "21465:13512",
+                        "pageName": "✏️  Slider (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "slider",
+                            "nodeId": "20861:6638"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "971f6ebbeada1fbd7e8dccbb028c0e66c85bfa41",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20861:6622",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/329/tnF/ZvIRVFSKH3X7m96o/component_thumbnail_158.png?Expires=1655683200&Signature=ED2LxxwlzaBGle59-OGPsHtQ5iYSN6~eknNV6CEDo5XW5kuPAJjhFMIfltVLyJFxMVUfiBasFwrz37lIOXc~nX8zEMGA-ut6Q3MtMumaTtfj4GV3E4SFWc9po8w7nTh0Y52BdTtFqqBrUbf7M99hKEcEbG2p5rHYAI~yGoj8nePsBE35mh1HdiglNPK7~bqKcBoWj3khL0BQExXMAi04oPG47qY0GKiPUPkSYpkeswVPXzBUdmwTe2sH3Bb4DvYBOj7uUANWuuRB-BKEPoSeQB3v9~CbcTrdXshexRMv2-zSp4GtQd5vjUQXJ8mjv6RBO1b5SOxFv08RX3EDtdKaBg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.357Z",
+                    "updated_at": "2022-05-09T18:36:03.357Z",
+                    "containing_frame": {
+                        "name": "Slider",
+                        "nodeId": "21465:13514",
+                        "pageId": "21465:13512",
+                        "pageName": "✏️  Slider (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "slider",
+                            "nodeId": "20861:6638"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "bac3bb730f267ee54a6f141a2798ded5cfd24e97",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20241:3344",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/l5D/SpW/VRqRBy5KRCitPXWf/component_thumbnail_157.png?Expires=1655683200&Signature=FGKng8EvrFYx1M8dKt2rYUbe7fKRSqVuhrMPeKyOGFfxcczKHtBGknk5ODhjJ3HkSyG87beiSb7X2E~ltK-NzSMr00ODJM0KwqHpFn~H5ADHboyLNLQlF3UxjVMuSkwTsa6c-qgCxezJQblNqwjFVHiAMZQQAN73Yx94RuzLMPkSSw~bWCMspJy-yseFcePsz~wh6jX6eTpfV0J6DpZRajOlWcYbk05ZEYnt8DswHP83MT1e1OZScQpVZDiwG94W9iV9iceL3zV~P61w9apn-IoVIM-dZQkLZChX7H-N1uJr8uyuXF7eLILHqhDqoibrCGPiKYm~9PzeCLEpoRqfyA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=disabled, Property 2=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.352Z",
+                    "updated_at": "2022-05-09T18:36:03.352Z",
+                    "containing_frame": {
+                        "name": "Toggle",
+                        "nodeId": "21465:12787",
+                        "pageId": "21465:12785",
+                        "pageName": "✏️ Toggle (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "toggle",
+                            "nodeId": "20241:3346"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "74ac66dbf1795e90546256d3e8ac91bdfc2a3eb9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20241:3345",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/fnu/1OD/tdpU0PICDzOAw8Oo/component_thumbnail_156.png?Expires=1655683200&Signature=GYXbtZyTijeJ4zJC9gi~KpqesVogERsq0KAWHiOfXLliy28IW3ZVvmhFe37vgvvoK66MH5T7yRlzSOGUdJxElD4IK7cjzi5AWNNwJxrWC3DXtIZm5C71fXfeJo8~BvJQUF-V1BikspdXmoqSoJHUVy1PgNWiRyjyPnlmnQrgk27gU9putzNZC5JxlKoY1pL~qA4eDTMxrjPSkajzgD9V0WllGsrhiwEMjTEApYIJdbYDfbQgJz1tQUBqCB3h6w4BRkl~NszzpjFGV~S~YQN9rvfQ6ZCOzaSrxriMn~0fpit5bdJEsW3a4aj~9JG3yMhSk~wECPjRB1MoDBgmGt2fkw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=disabled, Property 2=off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.345Z",
+                    "updated_at": "2022-05-09T18:36:03.345Z",
+                    "containing_frame": {
+                        "name": "Toggle",
+                        "nodeId": "21465:12787",
+                        "pageId": "21465:12785",
+                        "pageName": "✏️ Toggle (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "toggle",
+                            "nodeId": "20241:3346"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "48f0bd6bcb847e0742e8ef6db605797fbe224be7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20241:3342",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Hlp/YQX/KLfHJCDvU7Io0Ibz/component_thumbnail_155.png?Expires=1655683200&Signature=aVIUTqf~aVe0q30JW3MayK2qF7DgZ8Ly2VtFjS-c5diBccUACW1zOJu8QTJDgQ5fk6HB73AI-Pbbaj7T9dBUxEonVU2e8CF95zeOSeuMgP5oMkwsbTmkpYgFuHDqG42TW5l~2nXTCSBetNen0jIABo2jbGNyO1hOG6lLsPB2BioioPbNEO7WyjR9DrtH12Fha4XCBS0vFSe2dNqzRp4lCPUGXK2LRD12aCOEmqFnlzxCLE4U14KsQ8tm9zHZ4jH6yaDs0G2SvnXm8idadb-E0xZXcifQ5kCrFQ~8n2ObbPi6Z97IUFcgRNuJmgHApojMdqMswUq77FAdMIqUbrZyig__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=hover, Property 2=off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.338Z",
+                    "updated_at": "2022-05-09T18:36:03.338Z",
+                    "containing_frame": {
+                        "name": "Toggle",
+                        "nodeId": "21465:12787",
+                        "pageId": "21465:12785",
+                        "pageName": "✏️ Toggle (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "toggle",
+                            "nodeId": "20241:3346"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "cbf25efc9656bdbeed344b0762cfaa7fb10cf6a7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20241:3343",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/RBb/3BB/6FG8FGsZGP7Hxy4U/component_thumbnail_154.png?Expires=1655683200&Signature=LFx85wzO1pSH9iYlk7En819w6KHIgXx4jvca8odJrfkikMEIAeI7yz8LlzEFBTUOG6kS53BsH2TZwTGRZSxcGuRg0WaW~fP9g8A-0hIB8sXp9gwQrmjLpENLemaNOle4pBNQh4KG~eofQgt0fh52C4PlOCTALNkMx3urk-fly-SSHep74EQvhtk6OoU~bPdN7pF~fn2yVxNEQfoVcA5wB5e7IadM6AMIAvcAax9AVkTjodU5ibqeF2lr3NgPILUhR4NMUNc6LNfFeRjywjyzO4bsofpYPho5NVRqkzd8q9q9pu0WcFH1SEkt0hamvLA1OsLpqUYixEKhtn-v55CeOQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=hover, Property 2=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.332Z",
+                    "updated_at": "2022-05-09T18:36:03.332Z",
+                    "containing_frame": {
+                        "name": "Toggle",
+                        "nodeId": "21465:12787",
+                        "pageId": "21465:12785",
+                        "pageName": "✏️ Toggle (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "toggle",
+                            "nodeId": "20241:3346"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0a237e6bb735b07c06a2cae3684ee076c0a029a8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20241:3341",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UTs/ZYx/gvw6z2rrQAOGlXkV/component_thumbnail_153.png?Expires=1655683200&Signature=TxzVIhnygmPBXhNM3XXXwt4O638lc-o7tDh5yK9KWzl1QdgQKVxnu8zcratCEuTzhzH2rR9EafQO84PC~mFR7tnqmyNLpZCncn3xQDUzdZajxNpaXzEbRNwCoSempClKtM2MxguAWNK9GfKGx3k39OtT9rSK15ytgu3FIBj1p4BJIAO2dPUfJFR4QnCPbf0BjQjPFixazaRv6uNiSbRK8CCYbmjqMf20mI6iubDxSR1awIfsI219Au~VceaR2hTwNoGLCw7XvsDorPiIKBjHHbRjpyNtKA1Uf6kNaB4BeeJ-dMtFgU9-WqRXw-JyP91Uo6Ya4KEC2ihIQ1~6vDayKw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=default, Property 2=off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.326Z",
+                    "updated_at": "2022-05-09T18:36:03.326Z",
+                    "containing_frame": {
+                        "name": "Toggle",
+                        "nodeId": "21465:12787",
+                        "pageId": "21465:12785",
+                        "pageName": "✏️ Toggle (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "toggle",
+                            "nodeId": "20241:3346"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "368975c67d8c9a99e15a50b4dbbcb056ab9389f8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20241:3340",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Jb0/uis/gkiZo3zsSZGEROlO/component_thumbnail_152.png?Expires=1655683200&Signature=fGoXMKmX4KJ9DLp~pNR0U64wqTbWu6Pr3vWgjrIbdjD63C01C16XkV1F6R3SZta49GH2wN022Oyv6Pw5RMfW9TL23CYvz7vqvZBCrcUTFBcIrX~qlWfnOOOn7g68Lp6y0Jv~JNNvGMqKvZZECvV~BAx9eMcMYRPOTOk5-6LX-Xcoeh4rbjAPu53qvtpyKx9bWxDdH1~c3GW1Ff3eP1~ZUJAOxj3aOv9z6AfP4-iRXdHjQXATwv9uMmwcpG7tpcGybGgqul3ADyeFdw2YL1pefFhJXZc~q6uiNcrRqVZiXexRUc20VGm5Nb0LY0jD0sDsyhtE~iHuMRt0Ti7nwtBv5g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=default, Property 2=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.320Z",
+                    "updated_at": "2022-05-09T18:36:03.320Z",
+                    "containing_frame": {
+                        "name": "Toggle",
+                        "nodeId": "21465:12787",
+                        "pageId": "21465:12785",
+                        "pageName": "✏️ Toggle (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "toggle",
+                            "nodeId": "20241:3346"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "169dd0f765c395c967fcfafd6b13a750fbaa68af",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7499",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/LME/DW7/9F27rWG2gi9LPnro/component_thumbnail_151.png?Expires=1655683200&Signature=R~RpDsqQ7Dz3s~MZmnMj1ihdG-d3EHt3XEGOP91mVEY95pMYVOZE0IFkPiBfvnPiQ5yK6HtHfLTRN9cvIs4AILBIYKbmI-UfTxHJTLaeWQ~T9D2GlgIXpbspSIMXsOKQv4DrPagX9Wv1VTM9QfB7Ycj9SacyCUP3wilQTyRxuZrVhQAUQt5jzQRfDdwvDMooosaceeQWE-O73YGDFIXqpRn9hkjUZ21hzNeWkSgcW3JifOaz06PsE-9UrkNNp6~zOP8UvELEt6GYP1X6NnVtsBo6fDYuSi1ig8V~qF9v3l6w1VlxUgVrxWpeHi5bp4eLPGYoAytyq-maVrR8RgRfPw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=disabled, Selected=On, Error=Off",
+                    "description": "Radio-button: disabled/selected/no-error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.314Z",
+                    "updated_at": "2022-05-09T18:36:03.314Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "09e25f4157cca362352aa80e2abeb218d381e277",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7498",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Btc/3ya/l8f9OjQLDLt426TE/component_thumbnail_150.png?Expires=1655683200&Signature=DZjiQr~z4AhNHDJViDIw0qom2IhvsRscKpCKzgASS49ds0zxTdV6qFGYWMeZSqc~qTb8-Wpgcl4fGcPKi2-ocUkqhrErRhFGMSuG6pkDr19-DHNnQ6vcfhusWAEQjZeNr9NK4bn-cjj~Y30xdEMkkwKBOb61y7eAXPiOo9lQ-0B6TS-jjR1~hs~eNVdSvjD7QTCToXkRZrU1LDcrab2CETMMKlk-QQUd5iAaE2PchP58HkfH9f-aMipkPnhytSMvdhVHy~vc4ZWrA--V5TTahdVOBv2GZ51i7wLU9hQXPWnkksxOfhyXAGu0VAiv7nra~CEL9OkUU8lbtW6PTCvA6g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=disabled, Selected=Off, Error=Off",
+                    "description": "Radio-button: disabled/unselected/no-error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.309Z",
+                    "updated_at": "2022-05-09T18:36:03.309Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e34e5fd4856f43825be13d5900c54fcf0a9e3eb6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20169:5774",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/xkw/jw4/Igcnd1VAEan0RThL/component_thumbnail_149.png?Expires=1655683200&Signature=hsdel~J9tYEeylWOBYEXvoJ9lYmF3pV12iMEz8zAtJkSX~VT0YBRlNTG7kX74oz77Z0xMIjZEpGH-qJdTn2EZYgtBSYyGH6IY01e24gSathePeQnMz9eZLqoWAL5LkIaEyPjTQxTM7oRLEdPebq1rcM5w8~HEqYBzXUA-bntMCfXaOGZZGtqH1Bj~GA5Yl4M7QoBl~3MQ3q4IK4Pqw3J-fk6hamvzlo3tR3n3UUNplmLRAMuQZkurRAfgmk6czEW9UzriUO73XXCMmGGyycgdVWf255QVaSFT4R8wi2tujctwrLvl2TCaSF3TrYLQI2SiX~7yDrFjLo90DBwuJl6uA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=hover, Selected=On, Error=Off",
+                    "description": "Radio-button: hover/selected/no-error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.303Z",
+                    "updated_at": "2022-05-09T18:36:03.303Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1dc4de5c4b63ed791780380481c5f4ab318c5cc9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7497",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Hq6/2hY/UC8eYZ5DDZoiQa8k/component_thumbnail_148.png?Expires=1655683200&Signature=bnDG-G56-y3fF04d~hQ15DoIwldoDvGdqBrSCUl~ql7wJRvpr6zdB2REppEytRGiFZ~CaQ-Kj8PviziIfhInL21S5Do3LdEKqTOxQsiXcjUkoVGgkNcNL3rh7E0sUx50e7p1qzE7Wh68sw0K9SHAVdHgVnu~-8yCrkqeY5kDHL4okTQqIHcI-Aa6~nOR7LE62VsIcd8lEIQnSQI3~mhoLbF7z-bvbQSSm1dT~vHhUNc9yDgKPrc6Khlp08kEraxPivcCPopJCFpb~L2zKlZbjGgZTgji1w2GxhmyUYkDPSScpnwTj3JdSm1Hy7CrW0OmUcFFN9lQEkqjoJXiUIqxtQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=default, Selected=On, Error=Off",
+                    "description": "Radio-button: default/selected/no-error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.298Z",
+                    "updated_at": "2022-05-09T18:36:03.298Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3fcb8f37c144f2d69666091e436fc064eafa1b4b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20169:5775",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/rfe/Upj/qZeoILEK93Q7IE4A/component_thumbnail_147.png?Expires=1655683200&Signature=LZUBKewO~ug-db7NgIfG1irf5sNC-3F8WXvurUeQkRJDwp~eWx7V1bRZqyW16omG2CkamR-g6YIhyWwCdbLCsBT8yI7ksiRAw1JrsgXPTIa2euUCHYNkk~zD7gewZ~GMows5abMvv3BoSzXGZdssgOb7VfWWO7~qeP3Z20H0iANIBI9OsmobBSxL81YWWjQq~nvepzfx2butwYah6ObQykq~EL2Xv2J6QO1v73ppSxUd6z3BHkJW2U-VLBymnq5rnGpysLqZSsWGwKu8z~g3fWv25CJKSRWrHg0AVnnvzZlIEgvSEm7EJpc2tcIznIC7MDL1488pHzL3w638H3SJMQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=hover, Selected=On, Error=On",
+                    "description": "Radio-button: hover/selected/error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.292Z",
+                    "updated_at": "2022-05-09T18:36:03.292Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "26b96c295cf737ec50565c5825e3d333b1b494da",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7501",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/7We/J2z/sWUP8vBYmeEKnzVQ/component_thumbnail_146.png?Expires=1655683200&Signature=BSqh7nScWSyafSHFrt4~8OkiHDHM9y6SjoT-YoamdDEAjHtwA5mrZIDZGelTlSw0lWp1jil1WVjdTY3KKgvKXZgfZ-dCg13FAh-M-EI1niGmE1I0QO7KtnmAUIR9HLDleh1oeQid5PD9hOwtn3T0GHIrj0Km8OkYQbvP2-tKESIFc-QK3vX5Kf3DgMBSDsNkoIH6IP~UBj4MiBQ9B6eUZpVWNZ6uL3kzVKjh0xPUYSLEO9LVRYxmo~XB3NLfherxP~rviDY71JKrbhT-~N8NM3fQi9PgH-uh8Ayspm3fPl1Cm-2nwx~ZqzEj7GmV1CugXT7YtYby0LYqkHoOQL8UZA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=hover, Selected=Off, Error=On",
+                    "description": "Radio-button: hover/unselected/error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.287Z",
+                    "updated_at": "2022-05-09T18:36:03.287Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2c5625dd211132a3b5ff5e1fc52880a3741ef345",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7500",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/o2B/iY3/9TeRY8eFzkVH5mzs/component_thumbnail_145.png?Expires=1655683200&Signature=JJqwZUS5UBonOD6-sJevDj2pIYwOpqh6p9iX7RcNkpu5FKKi25n9QvleDP2Uju4qvj8XWUYSs10JDM5HhNJoxhx3zimZm-m4JMUQLFv4EPLPXwWwLx0wJ0bb44J6U7l~LNRM~7wxFCx1gps1qTkze8Vw~6ORMANYv1jwkYOmUHCmFA5cWYNpN71bz1479YwgRVKWZExwVHLcoOP-isQpSwPpT-GmN3oEz7IZnwHMXRctqYxAYHACGg2IxThQQE2xU92o6rxwyuved08Qk~lOXT~r3mIy8-JhLW4~sd9tB7mETjbuWfxpyUksmEIHBNEPf0FrncES61HtBFquuLXZcQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=default, Selected=Off, Error=On",
+                    "description": "Radio-button: default/unselected/error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.281Z",
+                    "updated_at": "2022-05-09T18:36:03.281Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8dcdbf65ca997359a809051a21207a8943bd1152",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7496",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/oJF/de0/ATQn0nlC9n3mvsrK/component_thumbnail_144.png?Expires=1655683200&Signature=VAj5DM77uOHcV7gsjoUkZHAeiyrQJqdZuzocMICi2CDZoGktX4AXgJpShmzib9Ju5TrfpSXYSfNpfrfSAYapTP1SbwmknMJQ16kpQqqv~E25aPjPdbtf3m6LXgZctjtYuAxh~cA40GIPXqVJ-MDfNyYUEx6z2C4udDTbgKvGMtgsu9FOFhJv6WRPu19wxp9PQujMaSiKClKxQLfSxJidapF4aBdsVSXUp8g4BGxi24KlLpDfOyNUxTCsju-~fw-mHkTaC~dLFB4xLYkHakibeRAKJKoOrff~-8lNNqNdwEBJWjZsq1NYxzkOdy~pLFUBEiJsr-2Fj7Ra-4lZG7GX7w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=hover, Selected=Off, Error=Off",
+                    "description": "Radio-button: hover/unselected/no-error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.275Z",
+                    "updated_at": "2022-05-09T18:36:03.275Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "34bcd8657fe28de3f20e62ae19892853bec61fdc",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7427",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/6bB/jAi/GOYXerOsIAxm1l7l/component_thumbnail_143.png?Expires=1655683200&Signature=ghylOJ9u6HZL1pL4J1xmqNDRy43ItPSWXQmXFJnZ6eN~g4qJ7G-J0kgJqR2JbHpApWhysbRacIXWGGFqL~HOv2E-NB0EscG2H-D63-dPASYuW6jFq82A4m6eLik2Zivr9WKFTg6Ee2N0TTD8p7w1Cxec2L5eEz6L7DZK0YoEZFdvhU6IPvynbd-yglaqrudjlcHtLgABaXZxGx7TpN4D1tWtNbw3GEtPzLAREG3C8vsuepINY5Zi5WEEsXUDQBU9-LPvjlsWVm5wFvZb5KeE5HZKDD3hF91Hm6NyL3P2aK2vPxNcn-AMdjwNykWA8UmUmWMvb0VJUfOlcpCWFz7lXA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=default, Selected=Off, Error=Off",
+                    "description": "Radio-button: default/unselected/no-error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.270Z",
+                    "updated_at": "2022-05-09T18:36:03.270Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "11c4171bb8c47553775ad26800eacbe3cd29590a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7502",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/P6J/Snb/A6qB2FgPwFRAfWfZ/component_thumbnail_142.png?Expires=1655683200&Signature=IsE~euRC7-xg317csI~Ecoq~egVsJJzfohKveV6kab6Ee4QYFLjue0nMpDRzQrG2KsWZftEtpQfEpmDEru0oSgj7xPamRakZBZmUvbeCtDCx6-9iHsonvtHrbhfWRnf5CFJmUjgKGo~n0TO4l~D~hn11AiBUAcbX5HnvWE6JroprcpwrGIuOAMC0Iy0Z-3IKat7p-3DlbFmh-A4n-qYK5gIIja48lzQjkGWMLuI6c81GdtGZgsvoalbBXDz6i~DOP031m7YB79sLhwLQ7VJHsqAp5leMp1ThseJZ8owS-GxPSZKrAciRv-rEZr5kX7oi539uzkaaZa0J-JWCzVcXmw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=default, Selected=On, Error=On",
+                    "description": "Radio-button: default/selected/error\n\n(#Form)",
+                    "created_at": "2022-05-09T18:36:03.265Z",
+                    "updated_at": "2022-05-09T18:36:03.265Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "radio-button",
+                            "nodeId": "20173:5801"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4231ac76ff10833f30b603e8759ca1430f565c6b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21514:17874",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/bgg/mB3/sCko2fZZDCKRByiX/component_thumbnail_141.png?Expires=1655683200&Signature=bgnC4MkhA5HWTOt2nzpmzer1E2XXiuQSvYyKM20Acc3k5KwXk2TIiBI8J3tvZjkQGAiOcoXL16m-Y7QvVf7CCHY5dCRBeDUrX2WfBBIvTLUvrBSlTNMdT~sbNQAx2C42W5IwIMTpvvsMiHAtQd9gGQgMu2E7ZD2icn41X7Ee8E0F~xkzC0UMdOhqeRcm-NCvWFh4El4fu8nelij6HggrsiJlbeZTois1dS8~4W5lhYu4PpgZC2KTfzlj2mCBbc~N0gl8fv6MfLCTGM8axt0JpT-EiyLG8Z17tmY3tPYlTSCRfpuaNXQ9J237dVU1gwF4yNIWyisAW3KfpXou-U9bpg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=1-color, State=Over Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.259Z",
+                    "updated_at": "2022-05-09T18:36:03.259Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-primary",
+                            "nodeId": "21409:14056"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d705ed1f69bd0fee67673fccadfda84f5c7dca27",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21514:17876",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/fEF/RD0/447tX3ckF7sjtbQc/component_thumbnail_140.png?Expires=1655683200&Signature=flnWLnK1rukDfehnFpyPKEC9FLOPTDwQWHE9acQfFQQFRjdkLpWY87O5i3vYaOSjyBhp0p~14PG6iHK60bOfwjiXl2FqAtIk~rP19wuBNar65g8VBR9PKWg3iaq1LMVbPcUtDP9Cm4uid60s5w7Rc7LyFrgMYz~xX6zGkz~t0kLNVBAUzeo-d70njiCZ58x6FWAOJg~-6nqKV4unRrLDWq-phYDW1sVi83AORLQ-8oGNiJWQbEWs866rMN2jVpKT05DVPfsZPXgl1xFa7ryoeTTq366~uv9f9YbPVaSsyPd2UjVT6q0DyIfK9bESzd5yWGav9r7HEMkAm0EDRzcBow__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=2-color, State=Over Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.253Z",
+                    "updated_at": "2022-05-09T18:36:03.253Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-primary",
+                            "nodeId": "21409:14056"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fbecd5dde1a88f3631bc1aeca33b2aa067ffc1cb",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:13664",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/D7U/1zR/70cuf1ZIATavmLF9/component_thumbnail_139.png?Expires=1655683200&Signature=d6N7-d-2QMb6FCuPNyHWt0DqP7HpG~8h7y3RFuHeTbxfYM8DPYhFj03OK5zdH4vtkb92uPzyln-AZAVDLFRcsAM7sUb-UUKXjCjZi5lU97P7wssBpYAJ7k3GO7LFy4uIIjr9m0-i6wJ6XhRpsZ~ldbI1qu24WyZXDUIQYhvv4ViE87V0yiailHFpGTy8qhxKiC7fszuXdOJH9CQfsHbicTjtZ-kfRaBk3aYP1DTuwB2ls3Wnjklu7ER6Sz2u~-cotb5VhFNb2iHYbqRA04cV9WVfJr~62DuHnqZlNAHEuQbIvXzoDgQlMMIFN7hHc4IBkMK~Uf70AyVbBykorsSD1w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=2-color, State=Over Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.247Z",
+                    "updated_at": "2022-05-09T18:36:03.247Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-primary",
+                            "nodeId": "21409:14056"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a26928d3eb5a49934355843b0c3e8e1fb37973bb",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:14074",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9nB/iCY/zBWCu7x11iFZXPMa/component_thumbnail_138.png?Expires=1655683200&Signature=NMR2ZZyQvCv7DRuKiAY2OzKNrGYmcbgb5TdyXfM5PcTQId3qznxLUgw3YA1jdLd5B-JJv0~Oupdcdz0q4PLiewQxG7APeXnuIdfKoh-zNTkjapuOhjYIjEiYOsB7KVJybSDd96gWF6CbIQqfy19aEEZODArPwnZooBZbBnG1V0OL-VOcPtAD8a9RLSgP1LeLz-5Va9pUdW8nmIZbzi0Svf-fJrcG0yUmKAVf9LFpNbkjwxJCxA1dc53Pl312ta3TioJjujhGF5359t~m5amcRH~PT7-Jr~9wINR9EKAnEo~qzf9~Y2a5BX~tksmngmelQ7-7kfHI5Sr4WHSwqBnRIw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=1-color, State=Over Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.242Z",
+                    "updated_at": "2022-05-09T18:36:03.242Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-primary",
+                            "nodeId": "21409:14056"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "415cfca30bdc70dbd0653ca9c5a05193e34c2316",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:14070",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/pNv/vWV/TQRU1KEYLJla43ux/component_thumbnail_137.png?Expires=1655683200&Signature=Y6CE1~Sb6Zj5q2OTVwGKHRbw2HP9Uy2eDpex-uaEmqt5fG44Kq4vnd86HjO6ZpqhT2GTYF28JoBqdOUQPKWDE2vkOjorYiidQv2N5hFgS-ak99MXPCCpcJdUy0Ajwr7ICe81QfO9FOyMpJwkPZ7tkqZr3Na0Ob2ylLxt27yW0pwcveFMqUQNrDI2il6RyQKyhiSlmVBJvpFPot~RYwc-~iMxddeiJ574HvjsnbL26Gln5IfKQXs9INauGhO3OZyUI9lwYONPAac2zoHeDddm2bI5~EJLJ7Lk4YJzay-d3f945ASEsZ3I1c5xK1AjsEMXJzL2OcdRBD8JGpThRMrmrA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=1-color, State=Over Color",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.236Z",
+                    "updated_at": "2022-05-09T18:36:03.236Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-primary",
+                            "nodeId": "21409:14056"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "cba62e9541cb8030543292987f72cf66ed54947f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:14055",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/XLG/cDE/7mign8NbeRHd723T/component_thumbnail_136.png?Expires=1655683200&Signature=UXwWbd5SAiGxEeO~PSXCTA3uO~hI0wI3bAhH9pMsMO0pYGbeM3lG~kqEg~Q1eC4ACciDKDB3rjK~OHZnifRHY6jZxjRem8VKKYKWPPbHizwmFN3BTkIvqIQs1Wm9WcCZlQ1SRn7HmR8WkTfoSIR1WH~tQ0WRNzCHJ~Az7zMA4BPyjgLuXrYPAPOChqYxoYSQ4~mC5NkvBnipmpMtA0mqjiab-0G-uULwsVk9i-e2nkm18befV8EKtHQg2wDbI1NL~63lCfgt9Wi5ysppCWPVymNcHWsWmGfbsivhJ0ca9cA-LlCQ6d-Kafrzu3LgnNHPidZxf147cc8uRYc5pjzZ4w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=2-color, State=Over Color",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.231Z",
+                    "updated_at": "2022-05-09T18:36:03.231Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-primary",
+                            "nodeId": "21409:14056"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3f30b1622359eba0de24da73a4c7a61d43e45f62",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:17668",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Z78/eb8/vfgIYD8zfOa5imyC/component_thumbnail_135.png?Expires=1655683200&Signature=fNXR4aYsZaZMv8GbW12OuOS6yoUjuSDlPz7Qjx9LiZk5vWc4ut54rg40wyA~lGwpkDR8m4JMZaLUQ0cSerWJtO1UFYZsppfJwbQX5wID3sSexvCrEqAEJXQ5Z4k6JvvV0N8Q5kwr54j6mH8tk6aYvZZeHvbKM0mSZY1oe3vW6r1YOMbWQNuBFazXQdhDObwx~BGOB1SZTpkBvhMeZN9XoThUMy4qu193ESivudunBm62oJUvSS3GL4LdX5-RTvrb4yFMPrXRNZHduYfisyylfJ~fG7qoAtE0Ig~fze3gRbt7eef5RUtL~oQqkY~xG6oPb~hf1gcMQUeatgMMcDRKMw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Color, Configuration=Vertical",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.225Z",
+                    "updated_at": "2022-05-09T18:36:03.225Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-1",
+                            "nodeId": "21409:17595"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8e4a1739ebf2bec9421e89235f8dec3a764a2cce",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21514:17902",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Nsx/hTI/RHDiy7KWJfT4Fp5A/component_thumbnail_134.png?Expires=1655683200&Signature=VmLkwxFkxQv6Y9CqA-Tms7eGeSqkDsJfvUHs1gg1rY77bGOtrHQ7lbHY5coo49tjV-c5Jf~4BNYPJxMeFHIqNuAKsV-Ptz8lmO0i5M2AmHKydjHTJGDEwwwi3-QO4FFsemzh7vVep7SfImsxWDKHzMjHYiZh1KfWUK5o7JfEVuny-vb3tZuUI-3kxLNZvJVRucbtVFbwHy7T9RcypIdVL4eOYn8EW6dqSpdDYj9sNkzrLrwKsIyXji7TKnoYRz0ZfcEOMLyutdwG1cNQBSWsYpZ2Vx9gPCr1cLUCN9cSUJ6jfBypuDgueWWGxNf~tyKMjU7fp1TWlVejQSrZW4em5g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Dark, Configuration=Vertical",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.220Z",
+                    "updated_at": "2022-05-09T18:36:03.220Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-1",
+                            "nodeId": "21409:17595"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "724388239f06c8f53560b3b14dace942d03e5551",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21514:17905",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/zlq/Jcy/jH0m2X0FnKyhVA2c/component_thumbnail_133.png?Expires=1655683200&Signature=Hpyttv1Wf7LsPbWnqExKIhCIHfVL3nxa4u9BpUrHcmGRsvvY1wB4VCPVyYu5wqEiP2SWCZrk1rxdXo5BGmlfuRa7Al1JX63TZXDhWjAvw26aKo~kApKZLM-wY9d1PH3fhZ2z9gkf21atN4VMxZxGNlloXGw9fE57X~g5fDqgSSg2xESdhg8UFEALhXC2iuBcnNT1PaUJZo28zGOYdkPMsBv7puXsZulHT3yLxb2lSmuZWyIVC6iZDSLCNkVlL0lJul8aUoUJf8A4wH2Z3U0LW4I7u-snghuiyFu4rTDqygYJEWI6E4nEzYC3UNzc7HTHp3EtY8T-hKvlxT-uwHPUxg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Dark, Configuration=Horizontal",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.214Z",
+                    "updated_at": "2022-05-09T18:36:03.214Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-1",
+                            "nodeId": "21409:17595"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c2736de5dc04901ff4d5238dba151f76d9b09c11",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21302:8056",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/7NX/xGu/tNaRt6ietDWSi9ps/component_thumbnail_132.png?Expires=1655683200&Signature=WWw9vW4ghV0YycvfTuNsQOjRwonbXsQgwwrJm-uOUy35WTBotLOqs5SPmkNe5yR-oM0b9w9gl0bdU70GOjPkjf-I7MbrWnRjTSJDLDwwpR4pQDfp7o90uA4IvFmaO9fo44GUs3n9o26lV9AlhJZJNF8LsEFsYLHMBZ9rxKPz06VghjCfnmhDN0GdK6yAohgSh~fHwXRGqZ9MD5JcdUNhqHqdWaWTAO1MzuouGj~Svi1tti-SDlCgrXBvGCnCBo0j4iRKfrAoRl2HYTRxqAPdTgu55G3hg-fIdDnOJgTHdYe33daI9UVXL2n9qL43F2h9TY00-V0sDvXyrdGqaZ8Diw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Light, Configuration=Horizontal",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.209Z",
+                    "updated_at": "2022-05-09T18:36:03.209Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-1",
+                            "nodeId": "21409:17595"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6cacdd697011b52d4ad00fd097a730a19d488021",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21302:8439",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/5jB/bNC/3pybYdEQpTeL9wKw/component_thumbnail_131.png?Expires=1655683200&Signature=GRxeqgf9SeUuLGmrr~LRM3pDWrCNdaUH4OzbwvQAANm2INhWJ0wZoyPPAITUIebAooeFbaYTBNy1xjhuLGCARF5dp622dmtydOiGv4QE4CFQeHostMqw4AJL4Neh5jvC2NkazZWe~4I3yWg6Vco8MYx7-aV4n6j73DvzszTG0DxBz2fW-vbVdIe7kGbYWeuS5ZfOBYHlmy9IFpeFihD6YQTDjNAJn-TJxRaoeBm1qB8ghMWGvXkdBgBDLc30F89pRmYvo-X6B-rVcGiQvt5u-GBfKTQPZmD1zAAwZTqfkr9IOSSFvu2QQB0fOFS20StXFmo55CI161WivrltKYbkUw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Light, Configuration=Vertical",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.202Z",
+                    "updated_at": "2022-05-09T18:36:03.202Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-1",
+                            "nodeId": "21409:17595"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "76cdb101bfff91d66775e8f89efd293e7efd415c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:17671",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/h9C/OTZ/vdCxmmYTaJILN23P/component_thumbnail_130.png?Expires=1655683200&Signature=VHVNOHJksSBbPe5s8Cc8rWWn1rEJRLIozYMTRE6GMmQPd63ukMoEwaHOlRpYACh-eDiKQdmQmuBYQxbQWhN-pKKp89xzX13N~uCrDsoHJpH6LzNDRqOYn9LXX~LqhKPlfgC6xA7MhtJXfi-t0LBHSZFzsGW2dfRnsrGE2PpmHNNiOrrExI7VqSWGPnnKTfrIeVIrycjFO~N-P2J-f~b2Q0ex8lELqnp1cuYM23pi3wYGvshL1Zn8QcSisakPr824QkeGUYByeC6lfdgQBricS1NfheCAUOKvNOHLbbuJZsmSbhvMvpbkeneoTtPrT3o-5RxtqCPGt5tEig1p5upDFQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Color, Configuration=Horizontal",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.196Z",
+                    "updated_at": "2022-05-09T18:36:03.196Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-1",
+                            "nodeId": "21409:17595"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0ca4765b21fad1d9b9728863e72f4ad65d4d6fb4",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21302:8034",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/QFc/nib/YCmq5xZgAzVgE8x4/component_thumbnail_129.png?Expires=1655683200&Signature=EkLmmvwbRfXXhg~V3lmIHfj5kSwvevoeaVvj8voWoiikcTWhGUsHh-BTUkDMdlVQE4tX4b4upiharjKCiljfE4Zyv67R2OtwrfTmKTgMphpJNzjyNBh9mH-TMJ1OFNnZ4jfGwW7~2bVIQsLlA9zq6fOIlXnZiILDNcx8zonUIXn91CPrpyI59kZxwzX~SZunW9~-4XRSo5VDco8ZXTATOHD~pI4~6k2Zwef~xiBP49AvMc81rORQmhchF4GsttUAGxwTPGQhOdgAj--Rc-ymMBaxuJqcStGGeW6dzuiYmkoaZuaCiRQ8VEEOhMNiq82vE6zaRd41IgLEeDMOp~pobA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Coloring=Over Color",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.191Z",
+                    "updated_at": "2022-05-09T18:36:03.191Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "Tagline-1",
+                            "nodeId": "21302:8029"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7bf4cd0bf2363c861d433a07d1c277abf80f518e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21302:8028",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/yMx/5ka/sFx7Q38R5wqtsbhn/component_thumbnail_128.png?Expires=1655683200&Signature=Q2~v0gv318OC3IzkOU2H5dtS5-TXOHZf4zWV0DgARRhURFQ1Rho6RlTomNBmCbicSVx-FgR6CwPj8yZL3rsJzkNZIxnWg87d24api8ZTjcFIoPQcxmIAw4IX1EXYJPUumcsWSCh81Vx9GOKWK64H2xH5Fo-6iOrHjprF8gBJ7767zV0I6fmaY2y5SiIMuHrw5UcTTunoegs7Df9zTiKO1Lk8f9v3lgVEqIcb-5YVhk7lJWZW-3dSz2RmuIViaC7sONVjHmWViSTxsXUa1AOK6utLq0XPjrmL87vNQ5ItwbmpHwSn0hga4Wou6LUqC5Gteu9045rWe6X-7AV1aitiyw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Coloring=Over Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.186Z",
+                    "updated_at": "2022-05-09T18:36:03.186Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "Tagline-1",
+                            "nodeId": "21302:8029"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "427a785c710072cabcdceaa40ab781c8bbc3f0cc",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21302:8030",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/dif/52C/fPjoJ3nSRgXPdos7/component_thumbnail_127.png?Expires=1655683200&Signature=QEazxepa9rwxLAX6OsEQs1cjFjy8CfNOwI7VpL7-BAjzH8x~9PNyySL3bxIbIQGZmJyVQiF7BC4AOjWviRTjsz9gNzHFGpyzoztB~smcJFnQUFcqMj3FykP1vMbq6-I~YydDV7qjwcc27cR7dRorlRUFjspm9bugDMBnlwYw~7uu58hmaOmZG3owQ1kxcx7wKaKp~lDvLcssmA54hh-CVfxgI4dqSvakoB4dDbpmG2cLfe7lJv4YRFa0CsguuOQkkMMJAgzsDxI6Fog1Wi9hVWCehqeQEKF5FUjQn4urhWJpeole8luDnRukOIA-rxnkvYpzEZqLczjaJAL7WS9Jkw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Coloring=Over Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.180Z",
+                    "updated_at": "2022-05-09T18:36:03.180Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "Tagline-1",
+                            "nodeId": "21302:8029"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8479deb400d78024b4390229b07af5ba5e42e9f1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21910:11982",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Mh3/2QJ/LiQ8QJWHkEIUFz8s/component_thumbnail_126.png?Expires=1655683200&Signature=TU0IwV92yAdfLsG64GXucc2IuUdqV5rgat-ryQpAiH2x9hRaGHMlDcUduLBg8eOcsxYk7MGNZ~nq8Aa5tCksEwmPmOgTv9yhK2ooK7INdcBuynbZcAGuF8mWqfAx~fEvWphiBnk0-3zQue2R-X7fXRpACba38I23gDKcmAdrvK~c0T5xir5EjtE7lj9nzmB6amCoosPUwO0bS6QIuaG9lpDvj0W7qMm6acMT3TAkMC0PiidgUdKzaUGnyQfqkay~mytCzyXnSM6HIb4Zp9pEzxNaAITAcHEoA0muQw5MbbBnl9uFky2igXv7ss9Olag57ZnT8miQhGJtsinWFv~e-Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Pause",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.175Z",
+                    "updated_at": "2022-05-09T18:36:03.175Z",
+                    "containing_frame": {
+                        "name": "Progress Bar",
+                        "nodeId": "21978:12642",
+                        "pageId": "20629:8196",
+                        "pageName": "✏️  Media (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Media Player",
+                            "nodeId": "21910:11983"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f95d8f20e737199b4ecffcdeb7f778c6e831dab8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21910:11981",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/fmZ/x9G/fpdxssk3S8EGSpbk/component_thumbnail_125.png?Expires=1655683200&Signature=Y9pRtL1otFRH5cNRi6FkkbljAdoNOLLEb7yo-vgqzChIogEpj6B60Or56cH0cmzU2ld257QzkH7avf7mIZNgPpuTexFSvL8NndB9Xxetbiq3lz4NFbj4jT-K-DK5WApzLCFkfAZuLWlWYN8qWEo0-e-whRTipEumdzuDowyCfn~uI5glLkNO0tiWXy1fje8VlvPvNqeA9u3nvDQTtt71QfrMJZaps0MCFztMyHTeq-etQ59N7tTs38~Wn05kRHehmA8Rl6eBv0vEZv3-3AbB5B~smUonIbS55a-PCNuDB6nvvMyNYl8OEmEFd9SwifkOnqdQrQm0g~on1q72l101PA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Play",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.169Z",
+                    "updated_at": "2022-05-09T18:36:03.169Z",
+                    "containing_frame": {
+                        "name": "Progress Bar",
+                        "nodeId": "21978:12642",
+                        "pageId": "20629:8196",
+                        "pageName": "✏️  Media (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Media Player",
+                            "nodeId": "21910:11983"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f0deee673575cdc8047ac63ed362d5f640f51cba",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21556:12296",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/oeu/U3H/zi2bzLIgXTJUgtKA/component_thumbnail_124.png?Expires=1655683200&Signature=G4VfGw8fkkr6EFbrMWBkxwzp8McYZ2c5UHaRu8WrLTjjBsw-IPLd6ko1wOHSbVoJMimmGEizoEAA~gXU6067FWk6vHuAxbgM7cAzsg8uNtw7f3DY63rbNdUfSgB963pT65AbmLs9ZjOIcnSddDfS8zEL3vBbTS5L9hApnJ-DDaVhEPj0CmUy6hKblL1urb4ATbunASK1zzUqO5f8gmCGgQmeXX5TmUKgSWv5UZfIhCzbg7slCukWyLPDDziqU4Z77wL1dfbvcjnRptY-4YaKtPpofarSf7ypojl1RDaJnqgnR66cnGwKIL~aGjhos5aaSuT8mB-YcvtAx9JyLakRuA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Icon, Filename=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.163Z",
+                    "updated_at": "2022-05-09T18:36:03.163Z",
+                    "containing_frame": {
+                        "name": "Download",
+                        "nodeId": "21556:11799",
+                        "pageId": "20629:7699",
+                        "pageName": "✏️  Files (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Download",
+                            "nodeId": "21556:12246"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8736e50b0b8a6170a2d1795bfd94d39a11d57a90",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21556:12247",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/loP/flq/64rQm1oC8UYdhmgh/component_thumbnail_123.png?Expires=1655683200&Signature=XFRvvIODgAp3RP8Yt8ChYAgTvpKaY024rFdTIoGp5y-OmsXuOpyz8geWvfpSYYm0Ex-LRaTKOLz9XuDWGd3No1P2wB8rN0Fegm4qmMHfRvOEpB1f5qJDz3jp6rmnnVlttamIJ8dHIBvdr4~HfsuXE3Qqg3UkDZoM7U9MH-6CylHLBNc4VSFMT3Z2wsawGJ9rpcM3gJIpnHlQrT-0hGopvQUvAj~bpUDW2flgLUcRu-R6pTF6RubZ8jz~qfzDKpgHchoqMb6NsjU1t1MMAY8pOGDdDHE0MtwIRzAy~uHxbyYEtjytT9cIeHlM-5SLB3OWZGpHvqCWjJMKNA2ZS0th7Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Icon, Filename=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.158Z",
+                    "updated_at": "2022-05-09T18:36:03.158Z",
+                    "containing_frame": {
+                        "name": "Download",
+                        "nodeId": "21556:11799",
+                        "pageId": "20629:7699",
+                        "pageName": "✏️  Files (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Download",
+                            "nodeId": "21556:12246"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "086203ec81ed6cdb1fa7c592720fe7fe0a8c741c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21556:12298",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9q9/Lgl/otjlCHrAVHwdwZVA/component_thumbnail_122.png?Expires=1655683200&Signature=MA4PU4psoVz-kjUDb5l7CtDWIm~VnxSt4n41Ihdwvlbpbmhthozf8J96GHoOKSmVF1CObchQ2hs~HejDY-0DpH4IdDHkEP9tLMZivqjuYcXFOc6x13ZyrU9K1y3z-1vaTKxYMti61QPkJz1u--QMNGVgUY7O9DsD3Z7JS2pUZ1pk~SeFHcaMaUW94LjwmxTi1Fjonvog3hLy4A4B1sQTCO2kg67xXPuojrKCm5uGKmjTMr78XvwZTlDJCfp60uHUziVlr2VghNORAYBxMAPe4MD4yf2GNs7qMd56h~PbVU8PMJpUXd5votgb9IZY4jRxdVg42yIB0YaLo3HsrHHQRg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Image, Filename=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.152Z",
+                    "updated_at": "2022-05-09T18:36:03.152Z",
+                    "containing_frame": {
+                        "name": "Download",
+                        "nodeId": "21556:11799",
+                        "pageId": "20629:7699",
+                        "pageName": "✏️  Files (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Download",
+                            "nodeId": "21556:12246"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a37eb9e44de2e5b7ce3dba20634d7d20ffc905c7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15279",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/xmC/CfD/7nvpsON66DlhHgRs/component_thumbnail_155.png?Expires=1655683200&Signature=Uvx32OkMy9ifGddjpXqC6J6q0qB3UJg-L5wMGsNwUD53a9ydnaXpj31Bp7vpNVUYT~3mCMbBXqdqQXVZO1zFTgqk3OX-GCOrQ9V8vBKxARmLLoD4nYymThdGN-xbBgHIRx2hSM7g3ozRDIjpGnPJy1PzNGNEfiX29IkJORuHhXbzENVHKtxPAr3MiPByrUIVu~sZBas5lKRHyfEKlRtGDYbNjeyVJIwaCXDBfFzFK-aCDc2juR23Hb1-wRWZ3rRZvJSW50zbc5lSS84C4-6MLuU35TmV3jFbybVCDSNBLhjf0sH2NQos5XEJ4IEoEaPcSo4tdgQV7bsfHxUJK6o-Ig__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=0",
+                    "description": "#0",
+                    "created_at": "2022-05-09T18:35:47.153Z",
+                    "updated_at": "2022-05-09T18:35:47.153Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Letter spacing ",
+                            "nodeId": "23067:15294"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "57226654cc014b39653721cd76e00f0eda405a02",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20548:3781",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/puB/M6p/w2gYNsJ3vygCx9Tb/component_thumbnail_154.png?Expires=1655683200&Signature=FmyIjHJXSzlFVlaxAXNtblqt4jtz8v8J1-UNTycQaXVIgZcYthdvzNxo7ePjGYPKidhHgM26qoZUNFB4VaVjkwjyIydYjYdcasT~67hg4rJ5x6v~N6OhYMqskmzV1QcMttdDqaUqQ-Et7pRPDFzH6oLgN5RE-Xymfdfh7OEKVDRP0IM~vR0HisjT-aRcgAsNfgVGw5Ag~fr2yWDP~v3gDFPoddJ-DJ7khvlHQPfQ~So2Trmdpo1m237yern7HEZ5XzWW8nQIwzdhcrNyiMiLWGmyLJqfSsmVuhsyCX8lE3HgfW-06tZ0w1ToaoRAAbTz8A0lBI~RIuwztpOBDLaoAg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Filled, Error type=No Error, Left icon=Off, Right icon=Off",
+                    "description": "form-field:default/filled/no-error\n(#form-field)",
+                    "created_at": "2022-05-09T18:35:47.148Z",
+                    "updated_at": "2022-05-09T18:35:47.148Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9f0a3b907e92af6c1c6882857b8b1693457753ff",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20554:3962",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/DqS/4B4/pgiWi7LpqkyDoacX/component_thumbnail_153.png?Expires=1655683200&Signature=b9l8-IBYgwj3xl6vCALRpLIvcIcQzJYAi221W8bK0jFzimm8YX5kaKsWY7wMRAz61NmgWyXCJGR8Ei~nxRoLcgrMs17Y4dsja9-UmWZq0~c5tLoYRWGsrBXPF6caEcGWRHPBSL6DqVNkAgNRRVsydVtC6b4M2ZR3n1BQn~WroK-0hmCcy4Nj2btZjOGGNO7f3dCj4zvY7G78-GK2XxOk8x1pAE93M3iutJPR97M5jXPh4dJTOxYLOOz3-8qSLML6dVYrlk8aXXfHVEPQ0zDNBjIDgujivey-ITO1lzfMcdEQcnfZXmMGOL5-W4-PhY~~MCZDKLNi86WIYhoz-njeOw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Unfilled, Error type=No Error, Left icon=Off, Right icon=Off",
+                    "description": "form-field:default/unfilled/no-error",
+                    "created_at": "2022-05-09T18:35:47.142Z",
+                    "updated_at": "2022-05-09T18:35:47.142Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6307db255e940afde189721fb9a74efd4797c5b2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20554:3969",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/gPo/4J7/JEsOlpsrwwplapJl/component_thumbnail_152.png?Expires=1655683200&Signature=cMuzAgxPwoCs~6H98sRTbGHjHMC1~GUbvHiW4usAGlP0UNbxv3DnUvhhhc29f3N4j2StHlxosxtmKCmnGshukAApPl1diJ4nSQuGR9FiTKFEfuG-gb1H5S8~RgjiNG5jZnHkq648HVaU9z9b~iJcLrBt3C0yfgu2P8~HojG3HOkOvm49xhPVKRbm3fjZs5bAInlkC4-zNQWZaTPB99-jA0Op9ZJNcheBOyRVnGr8c0K8bSNcRgLsums3kpoCUawIS6NUyNpCkQF9n7TEDYhSnPcJ3Ma7M6pNMDAlMcjQN5t2uRa5TZewG0x-NJNzyLTT7jWyK2wwpmAqHE7mvpZpeA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Disabled, Input=Unfilled, Error type=No Error, Left icon=Off, Right icon=Off",
+                    "description": "form-field:disabled/unfilled/no-error",
+                    "created_at": "2022-05-09T18:35:47.136Z",
+                    "updated_at": "2022-05-09T18:35:47.136Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a7323ceacf277794a829d9d8568611a3fecc4913",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20516:3870",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/m05/gje/XAuGszAbl65ZYYZg/component_thumbnail_151.png?Expires=1655683200&Signature=J~5n-mTthQ-alq4Q53JPVI--mjwyPLzlnmuyHqU2-Lwv7P0ZPvpLyMea0vcTSmy~1LB-2bJPvsUtI7cJf8Tf~V~B9ZAnxKIdKtIRtxMD0TmHNb9JTEK8LMk4ZPGI9BCbLH~n~BnafVUJ4v-X7BICZchW-6mfRxcHeRMNjniXb8htZBf1LhKwXO2NMwHIgLjgI42BHk1Z6fxqe5evm9MUwKzaaXH8QhTtX2finiFnfvE9xCsfHq25Ws09uP3PrL~EwHPQYAkxiiHOwu9WUORHNK1ztiLL0oyPz5eLR0oG5HZ1a9VEH1a7Ip1OsQrupY~YAXEd2FPO56wiUq3m3uwKkw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Filled, Error type=No Error, Left icon=On, Right icon=On",
+                    "description": "form-field:default/filled/no-error\n(#form-field)",
+                    "created_at": "2022-05-09T18:35:47.130Z",
+                    "updated_at": "2022-05-09T18:35:47.130Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "123948396bd3cb538068cd3a13905d975176e6cd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20556:3983",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/5Pm/JlA/7cGRpmmD4G25klKB/component_thumbnail_150.png?Expires=1655683200&Signature=SekbFNJXMBHGFpnJC36kmXRJIvE9g1QtTuK4tqfOK1YIuRAVUdnpha7KQi6tBIc~~49TADiRaFoJsGz1FDTD9RJexyc5k0dyD-kNl4tIgaXJ1T23j84rfregEv7b55-L6h-H3l4Q-twCFMLPY2z0O2PjmJujnjr--tIdf-cwV74yQHn0~DAqr7RgT2vp2YEBp416HgxAX6gxqooMMBdpkpNjdHRRsXhdpFzyY6wOqzZX10rNKxip3WC0KILFsKvv5PlgN3zMDIzjWR9jfiEBq9TblX3SXDB5q2TP1mBpH-d~HDOAo~SBK6fRGWy3YrffJ9S0E7DobP0fLx1A6UBNLQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Filled, Error type=Error, Left icon=Off, Right icon=On",
+                    "description": "form-field:default/filled/error",
+                    "created_at": "2022-05-09T18:35:47.124Z",
+                    "updated_at": "2022-05-09T18:35:47.124Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3efb45b18489e778bc6c34b1cea166a3e99eb59a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20520:3707",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/a2h/Mrp/JaFPqAhfN5ifhGWk/component_thumbnail_149.png?Expires=1655683200&Signature=LWlwPt89W~AfvW4f7eUEZiutkLtJxSKQVjhkllu~BAzMCL9UV3BHtf7iON8gY4D207Xgg0TuBPC7egpPZCGEOuTYaDfxntvJYkCpKg0yAm~e~QMgqxXxT~Vj722MBPU4NF8oXo37x7aw2UILPDxUtfJxA3k83b8h21m-CIIYpNCzCTch6MYcgg5cfPXBmB-BMvbSDJg99RFj9SR8lERRw0pg-WkehvkePtnjcshLs8mS2Y~xrQ155s-sGjFeDuNca-JZjor-TX1mXPHCZ7EwIPhjJsxBLOptZPYgRirvR4RE0E99Xv2HgYVAzykRt2BXQIU71FvQwouvpyCepjbuuA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Filled, Error type=Error, Left icon=On, Right icon=On",
+                    "description": "form-field:default/filled/error",
+                    "created_at": "2022-05-09T18:35:47.118Z",
+                    "updated_at": "2022-05-09T18:35:47.118Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6b0c8a3baa76e1a074419164492566425991b84d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20554:3901",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/r8X/i9j/f97PoEcqb2rIEGBe/component_thumbnail_148.png?Expires=1655683200&Signature=GPBBvGlgnBeEt24sgqQ9AdwQyCPE9JxX5lVdSR4vkdVeXmwcxuA379Xa4Mk89jNuhSPpycpcKWgPbg~LsTSr~dX1ekoVZBFNzzr0OmteAWxuDGzX9cHCzknv7KE48oSLEd3pqOAhbVhhDfeJg8eWtrcnGL~98UCbZSkQDVrouUzuZT-sf6lp9ZReRizRK1EflG95e86w6r4fGpl7ghnoN6iTNHEqzqZMpMziHaL7zkQYnUBw7X5XjfOa~pCMkBleLI-bp0ao7lE53Lh2z20yE-4kttMYOYJ4X3NeI7wEygLuReRnCXf9TpRQgH~ZbfkGrU4JEhIobQqvgrX8xbxHuQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Read-only, Input=Unfilled, Error type=No Error, Left icon=Off, Right icon=Off",
+                    "description": "form-field:read-only/unfilled/no-error",
+                    "created_at": "2022-05-09T18:35:47.112Z",
+                    "updated_at": "2022-05-09T18:35:47.112Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "69ed388ab3652b6ed1c0a8a80e37ccaa5ba71c58",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20554:3899",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/J99/MjW/uyG6uWOb1i36IcCP/component_thumbnail_147.png?Expires=1655683200&Signature=IJMaM1bwWqPmvIIGY3IUmqH6-7pTJ6TSP9LNyIdVgyNQSMPUMPJsuT2HkabOenqPUz21Zp7tv9m7FUAUQT1dByrPWzfcVnJM4U2VSw~0Bts3HC8n8frrCOJcnI5h-9uCl1xVdWujPA7wcXex~EpmBW6Kb1HyvpAXc369YyMrFls~hEy8iFDGaLXEjZ8ZBfF6RCTRgd6b8gsAoPWVlUESpsjvfdd~lfL4Yoz1Qo8sBLzP~hNzFMQVhj858zbniX~rjncB2Oxmn0sjM65y6qXFDx9WHhFXy8dASGV8pTKJ-EEgQvOQvI7-46oyVv248j4sUrSLgZVXNYizAFFd8dKgeQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Disabled, Input=Unfilled, Error type=No Error, Left icon=Off, Right icon=On",
+                    "description": "form-field:disabled/unfilled/no-error",
+                    "created_at": "2022-05-09T18:35:47.106Z",
+                    "updated_at": "2022-05-09T18:35:47.106Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9c301d414cd735bb7383bc7b4a8c477fe5704e2a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20520:3694",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/yvQ/QSk/ODmYWNM9k1QEagJ0/component_thumbnail_146.png?Expires=1655683200&Signature=UvmjcCeTqP29I7z3MElU2~4mVSQnO-QgZ1P6ekWZFEW8RtxejxaG9yVa9Jt8f0BJD3~fVkodkTWRL49EHuQSmD2kbfx0vIKpo0tljcLONCKEWR4ySjtqL9OwSal0w6QcoVoQsHRzt7tDe6DsyVQBuNuQxSLrkfU6ETwsMl4~8d7Sgj6yQj88claS8tUP5GWEMGJVQgyalxiiMSpCKyjV78L1svekyH7LfxFBn0lIrgd3q3HESH2j2JgMV0IID9rSo3yFvM9jQnOLUbGsFWr4tZAsD9akDAL7GDtLtd5Pit17g4hSMI~JtF1~oHHOM2LIWJEY66~6RIwMnG14q5KMtA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Read-only, Input=Unfilled, Error type=No Error, Left icon=On, Right icon=Off",
+                    "description": "form-field:read-only/unfilled/no-error",
+                    "created_at": "2022-05-09T18:35:47.100Z",
+                    "updated_at": "2022-05-09T18:35:47.100Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fcc03574fe14b691c16b79ae6ec8fd47c7afdb18",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20554:3877",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/zId/LJH/56tt9BpYnNDCTXJL/component_thumbnail_145.png?Expires=1655683200&Signature=HUCnz2ai8bI4njLXlyt7d3Lrqy9KnEmb07Xd2eh7lrzWvKOIFFvr~uKPQxJOMQMToj5Z237P3mNQgex3gP2xb822tjKnRot8rSPUg8DjpvwB3cKbwNi60vKn8NhL7LlqYhpiCmwsHkeNb88Q~DpvE2ccZgWfkHKHWOy6vutSuNdO7uZSz1VbiwCZRge6zcVCaCd~~7qaxXsXbtVoFBq3EvzjdvL1uMQ0ReOLdaoicxBVNoeBUMpxy4sxJKWsoJZ~09RsaVm8F944E5un827IygqYw-~gIgwWPSuPZdkaM2HRo8X2EIwvnWzu6lqIBN5U1vUHl~bekAGGgq3v0bLTUA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Read-only, Input=Filled, Error type=No Error, Left icon=Off, Right icon=Off",
+                    "description": "form-field:read-only/filled/no-error",
+                    "created_at": "2022-05-09T18:35:47.094Z",
+                    "updated_at": "2022-05-09T18:35:47.094Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "781ce11316375e6a074dcbff93d0f9889d5b1815",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20520:3626",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/5ur/9IF/21ZpDOpkjyx2rU1y/component_thumbnail_144.png?Expires=1655683200&Signature=TF8kALN~tG45PVVQyPk97qUBtUg7afh5hAilmsvs5FC9eNvGKO1CQZn4RYxsuQgJ9IetZJwk7sz-MkJkyP42ptqJzVLXH-p32m5QTDbRXguIOt0PeHKr5TUqogIc~UV8izJsSMF-Jj2UWh68qIOO6S18Z~9t~3SQdIOozysuBZ13BRPZ4bTqyfnYqUGS1p-YGFS0SC6otctT7ZKkaNignlncdrAHzgje~EpOp1iWjOJziV1j4TloWcg5L4Wyf6iRh3L8KHOusp~Arx99LquX3qucFiqwO~Px3hxKjQSavKsBdPP4~46oDwlqaCVkH1z5aQpIlo8KZrawMbhnLLRmzA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Read-only, Input=Filled, Error type=No Error, Left icon=On, Right icon=Off",
+                    "description": "form-field:read-only/filled/no-error",
+                    "created_at": "2022-05-09T18:35:47.089Z",
+                    "updated_at": "2022-05-09T18:35:47.089Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a56f6f0415729ab2daa0ec712d2e17e5ecf44030",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20554:3863",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/QLR/ywG/FKdXRLlYPJzPKNJF/component_thumbnail_143.png?Expires=1655683200&Signature=PFuiIDsmUqjbZrkItZj1HUl9AA63xYUL4s~ybgJXLg1xGTGmYCYzzSEiHf53MWAIXnlQuAt6rEevu12vdgfYzmq7PrLYa7soDl-i~miQARSLIlLw~QpHmlztyOiAZkfgHyMv4IDLiyU0mfxxDAQx3z2DY7aKNinyjNN~Gy9CEg6Kse0ted33gIC8eCarwEGGelx0ZvMjkN-ByrOp7ht8k6B2YH5FK3Iu1Ob3n9c4EoRKvK7gw4GKg-Yx8xuUs11nRldjxzbdivJIqHkwONUeSTGDw74mdTB39Hok-wR5yMguuarj2hnU~LyQDyS0sUhSEz337EwKLCGarOWQ3lx4CA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Disabled, Input=Filled, Error type=No Error, Left icon=Off, Right icon=Off",
+                    "description": "form-field:disabled/filled/no-error",
+                    "created_at": "2022-05-09T18:35:47.083Z",
+                    "updated_at": "2022-05-09T18:35:47.083Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3e0ef0ec5551334b869736a070c111b9d1a74db0",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20547:4190",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Id1/lK5/MZswO0tbT9ck29Ng/component_thumbnail_142.png?Expires=1655683200&Signature=FnXSo-VGwUnlHNbhFMGQ7mBbpS17tCWPHyNAa47sl6Nq6EunGrjOcVowu8IkkxKrAloMyHLvWpVee8U0AArNGvuHmzgVKIyezhSNIGPyIsbMzZbhMkdlIfDv11SDza7QPnf5UEPKVfkR28hcF4bl2rOC8-GP~gzU5zyUM-14um4esyLD6T9wEcLlzf-dYVhukI7NlL0DB9w6-vY83zRd9HOL6qG564p7cB3133TDFxc87vhr4FssfgjjkcaRUXoWHgDh5NPq3BjuvYuC3dtrP7W2qIA2gSEUshoJ74n7LwwHYku5NRcGLNNv2SZdR~aI5Pp9idet3gIcNkwRdFy-3Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Filled, Error type=No Error, Left icon=Off, Right icon=On",
+                    "description": "form-field:default/filled/no-error\n(#form-field)",
+                    "created_at": "2022-05-09T18:35:47.078Z",
+                    "updated_at": "2022-05-09T18:35:47.078Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "03efcf2521536ae855c680c107ca4de6d5ec9efa",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20554:3850",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/2WL/EXg/43AZxSjdRXJxxbS6/component_thumbnail_141.png?Expires=1655683200&Signature=Dpr0-JWmkpSFp2hyvdCX2SbbK6xZXwKQwCN2nQCLvXe3O8BR-6FDpIvpVfsg3u6rgbQk2gX91cz7V6odapvACV3jE4PYm6Ft0o1dg88NacwHbAnGHR-g9Ppq0AXvH7kzlWHlhW~-IncSbiXo6DwvcOfIpZjcJ6kmY2dy8znnfXeT4Vv0qvF5iuDQ0zQPOl7fopR8vcmKtRotD21GKXQx4Trz8CSBRE4lOUQEyK77SuRwWEkJd2aWXrxybj53-oM5BVeLs-bIvMntwESt2S90FilXHKDESyx8ExDaD8d~nK2rgeu9zVZAq3CXzdqankCGH4eZsPZC0ATV46wqTgQlLQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Disabled, Input=Filled, Error type=No Error, Left icon=Off, Right icon=On",
+                    "description": "form-field:disabled/filled/no-error",
+                    "created_at": "2022-05-09T18:35:47.072Z",
+                    "updated_at": "2022-05-09T18:35:47.072Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "63c8febf95f04eae6606fdd212a0b01f9ac9a207",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20520:3681",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/h3f/c9x/EPL9OcXf8Oy0wYEm/component_thumbnail_140.png?Expires=1655683200&Signature=QlKzMJrCBPOUtb2B3M8m4Ny~2b-sOyrx0dczt29uNkzkxK11EWx8HNI~bgvShcf7QM2LmeuNuAiI7uQkrjQ1wsPFuXpTZBNuMCkYhKVZlwAjSeAceSR7irGI76Ue8kwcrdq2bvB7DBpfvGmcOCAAEyNMG~Gecj-BhreJlx2nkngOElppwJampiWNdB3PS7LKmC-4NneT37Y4Nd7X9~ooIvlPKL1YIUUut-~fpHWTvNsgtykUg043aXEInpjDa4HoSF6QgEsWrxy1giN1pqA-DLQTxAmCOyxGllb~x4O22YIYdRwsGGkAenCfcajrJSB20sj1uGQx~zIB12fHD~pngg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Disabled, Input=Unfilled, Error type=No Error, Left icon=On, Right icon=On",
+                    "description": "form-field:disabled/unfilled/no-error",
+                    "created_at": "2022-05-09T18:35:47.067Z",
+                    "updated_at": "2022-05-09T18:35:47.067Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6680b0a03a7f87443cc9007224dbead637a3f2d3",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20556:4046",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/mhP/yO9/lrxpkLs4Kgzgz6cf/component_thumbnail_139.png?Expires=1655683200&Signature=PY7Sdxo3KjwmuqYFHBcYQ9U2ExTNmVZhuOXn2iS0Bf-XkKUBVNDd8Kw5uaI4VHOd1qmJv5fWAYKNeTFtoOMGZ0lJkIjbGlErlqIeiFxnGC55hKT6RobubUY6RoIfAcUB4EtZ2GaAZsW9zpr7Ab0f1OM7GxT54Dsd0BWrYUQ6k0iiAhCkRlB1SOZJlqDYqvI4p0Dtjor2tE9cBouHHYyz~XNx~j4s-iC1GDflY2wZo66MMhPzOKg0ABGhAcm6QTDSTHFp96H1hFcmJe0RYLeDgA9~uRRe-vEzxPzi0OI5l5b0BtZZpNs4h-JxdBcAle2e56HSXe~ZqAFSc7Bu4bBG2A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Unfilled, Error type=Error, Left icon=Off, Right icon=On",
+                    "description": "form-field:default/unfilled/error",
+                    "created_at": "2022-05-09T18:35:47.062Z",
+                    "updated_at": "2022-05-09T18:35:47.062Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c8d6dac5a745d25bf61b10ca19a1315a79d92644",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20516:4359",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/c8T/SRs/My3Nwu6XGGNHUaLf/component_thumbnail_138.png?Expires=1655683200&Signature=KU8HiNKDuDGVdpxrXmymQGsNZ~Qgc6HwMNZRpamKJ6XtIcZ5SG8F9j2tnW~JWsc2cerHhjbbgy11Pp37FuUC3Zr3Yxv8t76CaATxRMZ53h2xFQkWfY7DUQnxrnY8gQw0NbjWmTWszQPvpXCB7WpJ6RYSPZrCO9Pz0bSuuoKdBjo4XHjREL5VaNzJ5mljFaTkNYQOTk3myeorJrO3JI2HDLoXlW7V1cX6Hq2VFF4PXH6RDVD63ayLjcRowB5ZMlnbihV1JfCTJTq2aEk57xyKiD2mDdjEnO09uOrPmJ3kBuvH-FlMbgbxAvP37G132Yoa3IHEtARPORL4IU-jBxm1ZQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Disabled, Input=Filled, Error type=No Error, Left icon=On, Right icon=On",
+                    "description": "form-field:disabled/filled/no-error",
+                    "created_at": "2022-05-09T18:35:47.056Z",
+                    "updated_at": "2022-05-09T18:35:47.056Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c227c5058d9588cd7ff2fbe886ad7785a95b5ab3",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20554:3892",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Xzz/8Ld/XMjJQrjg5oBCsx9V/component_thumbnail_137.png?Expires=1655683200&Signature=MEnHAZlHz4bEgbAH6YGzNb~0iFLvJlmjmwsAnGDCtujHumRhKxlsA0-wjXtJMK2vYuUYu5X9iYpkDs3KU3kBILioAsg8Ur7~urEzcZkXz-914vtVhKSYbZNXCA6YISTOIObDoIlrfqQ2okASN8aiQb7An5APGB19L02n~16s-AA9bCDRJyOxakOUvR1pDVWoznGwSfc7VvsunV6qwrTOizCKrxSm2nZsNjqtxEuA8eRsGHJwvewb7gqzChMW0Ivp4D-b53oJE8r1oZG8Z6sUtFV2VYVhStD2efD-oYRdLmrQs919KUhxQMVXe3Ks~Efib4EloPLmgZYgebF-CFkifQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Unfilled, Error type=No Error, Left icon=Off, Right icon=On",
+                    "description": "form-field:default/unfilled/no-error",
+                    "created_at": "2022-05-09T18:35:47.051Z",
+                    "updated_at": "2022-05-09T18:35:47.051Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "23ef83378d8346c0844f98e1d2695406b342312e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20522:3725",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/IBN/qyP/gq7GB74ynC0iWfnO/component_thumbnail_136.png?Expires=1655683200&Signature=SkX~BMd6kEo5bkR8qvUosPePlHJhDac8x5yQu8Z2q9lpmBDF4W71L7lBMcwkWuRq~1qXzQgMdCCnud7p-wYS1uC5-jWOsBzL9TBikbINrh2SvtWucU3IH2ONRZqFEy1CGNwFM0~Dtfx0WFBkYz5fKR1WXOqPBja2jekMSnWjs1SpiuZlyp47xaoI-flPItPUcc8Kqts37cGnUMh0teratlu4cSGm3fHdUxfBbNbHAW3ka1-BowzPidyD5HajyJZL0xd~7iRCNPn7~UpAGfZ2nuynq4DA9IW6zwit7bkx85n2cf-8ehENOb-od8BWWa9xvnPpxxHbRJV0-0DQIsB3EQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Unfilled, Error type=Error, Left icon=On, Right icon=On",
+                    "description": "form-field:default/unfilled/error",
+                    "created_at": "2022-05-09T18:35:47.046Z",
+                    "updated_at": "2022-05-09T18:35:47.046Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b645c0af57309e580c543689794a79344c865568",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20520:3639",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/nKg/MwP/3JtlOJIafuWP2PcF/component_thumbnail_135.png?Expires=1655683200&Signature=GFe2AHpHZ1rnbxecoGXs~Ueuo8--W4tPnTLJi~pQpPnVTPyGKKmjIgaUitnp2rkSlVkzta0Np8fZRSIiJZYiOYt52YddsBsSQrzpVwMu8wL5NZH8rP88B4DHKD2MjsSqMSl84Fq2H81Xrt8JmfJIhITAUZTL5gdz~7~XeCsPvao7bTx-jfJbueDpvD1lL7SCxa5~gdJe9q4710mWdManUTeglcmt5OGTsRD9XNE51kmdKrL~rXgQTqyMlBPlFN6RkgM0VuGMT0jMDkxHPV-45ouyCQyetnj0o4UhdS7pBl24YuUYgv3wnx~MN75R~3XRQ~w2ELoOnnxjEq8pBlyA7g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Form field type=Default, Input=Unfilled, Error type=No Error, Left icon=On, Right icon=On",
+                    "description": "form-field:default/unfilled/no-error",
+                    "created_at": "2022-05-09T18:35:47.040Z",
+                    "updated_at": "2022-05-09T18:35:47.040Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form Fields",
+                            "nodeId": "20516:4328"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d7035230ebb90532b6d0b058f6dd37b8799f086d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20840:6790",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/D1E/4FN/QRe3sXkMhfMufbtc/component_thumbnail_134.png?Expires=1655683200&Signature=B5lTv83DjRqw2c9yUZzAwD~lMKlBRMeRe7f88N7MNMwFpJDUKn3aQYfHq4id8yWubm9cTY-vdYYkdtzSzw9vl-7uBsHtgAYom0-tZCkKkzqBNsL8AtC9LaGqNlcfoMnu8Ekad2Oodf3OnK6REoAy2n~izCoeazBadqbpybjiONHqXG5N17Qz-hjsd79iNEKIegk7TvDe~ynrsGV3pwScGGWERwz9pjIF3QRiltNftsfnuNuhQKd0rtO7TfAwvzBMnZlGrszr2fznhP9EFjGP5MsedqAhJNenxxy-07vDCwC~Y1xGvGsuZbbLhbgpWui6wruaB1Ki4WaRDRmGZeosMQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=hover, Mode=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.034Z",
+                    "updated_at": "2022-05-09T18:35:47.034Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs",
+                            "nodeId": "20840:6800"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b3aed0c2fe4d9783f607cec9a6b046f2837de219",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21294:7480",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Vwv/uL7/VD5rbY4YM73dwFZM/component_thumbnail_133.png?Expires=1655683200&Signature=I0Yj8WvN8oPKf1iAKNjS0b2OTQTw22~KcS4ZtGCzAU7y7g6s-AySIkbwcRcUMfT5rRUsa~yvJoY8UvMH05a1jHpjSKenaPzm9KvUWPCzA0PNAm7VjhiVa32LKgSE5vBFTkofPbzIXCA52rHBGkPrAbN3gJw~nQ3LIOokvICeIV7QaWFgRjN~Ty3Jv0OcAU6YDCZsBrltXXKpTWREUJFHmUldTr5jTlrlUGtp5k9XxORYfHvhWzk5clbWl1F~8P6EMEmIdykAhKBKISc5oaKNDW8TQZ08R-k~N6wAvEpzBJ7EeminB6lK6k0JIqg3tCE3DQOHARtoVeIyDa8~XVeu0g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=States5, Mode=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.029Z",
+                    "updated_at": "2022-05-09T18:35:47.029Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs",
+                            "nodeId": "20840:6800"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "81313c451d4e0485bc2d9091dcb70fe56bbf1c26",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21294:7478",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/egl/0R8/WFiRoiqQ8dow2Xfb/component_thumbnail_132.png?Expires=1655683200&Signature=CwvwaHreYu~WcQZCeEVVl4S11h7HMOAygn-LYCkTtasdvIgxZfHJ36L6zxmz-Tj5-LmCaEeyx1PUwh-3pKVjNIbt3hT77ZISeTeMgeFh1ChsH-O-bIyZiw3V7lJv4q5B4wM7uBoapeZhsNwwnA-0BiBPg3a3WV20y3ahBy5PBo140j1xoiCSNetSe~iFh9ut-ffzGdOlfscmzjdpGpmV~GF9FYlXZrLNSt0M8OSB7uuGunux-QaGfqw72fasivKNrg~XBeWSTYwg9w2-hK0c9fElyA3u74Biu-5VQAJ8zgcNFrXupPD1rk73yviCih~JPYwQM7NP8ewZ2eGxYz6bhw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=States4, Mode=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.023Z",
+                    "updated_at": "2022-05-09T18:35:47.023Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs",
+                            "nodeId": "20840:6800"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "07d79f7fc837a48746066a25cbcfcc8350ff2132",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21294:7482",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/obg/p0T/lSYtDzYrK2adYUqq/component_thumbnail_131.png?Expires=1655683200&Signature=HZ91pRc4Y~qyQu6SeUaDC67EciI1AGxUpN-eg-9FQncNL9IpYYlN0nw3n-oebw5i9TFjpugcaWqQNo9eeJ93ZYrYqy6KCzTr~PyvZXdW2oGMBEyBCc~xfGqV3hJcqEGm2yGBfnuRc5zN3nsHmHVfJ5fuJvFjcFASeZ93Msw77Xgcyr68WHt2mIC4GljfhEaIDADCIcLtdU5rV-HOHkIheMiGEZTQ3Uon2iGUxtM5jdfrrz-Xik8xCkJBvjTxTvWpjlLKLtA4zOHMNMNs~bNdofkmXgR92WdCrw2aYuvuEueJm~KVkZ3K2o7~g1x1IujEgibwYNfyq0PWxHm5j0nOag__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=States6, Mode=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.017Z",
+                    "updated_at": "2022-05-09T18:35:47.017Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs",
+                            "nodeId": "20840:6800"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "99fc4ba2ece6da2604887b60a6972bb46884125e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20840:6791",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/lmM/NXw/YercCfrbbAWVfmH9/component_thumbnail_130.png?Expires=1655683200&Signature=BYdjyiQdhNvuf-hFoeOK1hVJANdF4~tchYq3aJ2wXlekLuaZ8AHK6iACe5DCrJNiGW13~fujib52qB4nvSjRNRrhYmJvW3J0f1BzDflfY3~WXYF4cu4~FPv-tGivViI08mKpL7HYGL1gmChqEe7rKvLFRXOrdhI0QkdnhmWk3SvVkIhfZpyVgJh2FXgOGAkCPGKCqAjp6~Tfx7Xi9bvOhaEZ8U2QwzDM11eAME69qyh8P1e5~ehfc3~BVxmk2AE~oiYoKgdajDrub~~ob7iuxhUG~bfjy-DSciDzwZd7Ftcz7txvznAdX5V1cROBLWjlDZT3C~B6Cn9jj9Hrz0ZPYg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=active, Mode=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.012Z",
+                    "updated_at": "2022-05-09T18:35:47.012Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs",
+                            "nodeId": "20840:6800"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f475b90957cf9f4720a5a7df956733167729e815",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20840:6773",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/erv/MRn/F4DX5YQ2l2Oru9Zp/component_thumbnail_129.png?Expires=1655683200&Signature=Cmi5VLzTl7mRfiELJk9gJjNC2zHCrUH2lIXdjqSHhXl0AhHQnOy17a6dBcPF1SGS0F3OZJ3pP3ByNLOgyOvuXP4XOVCVQPTDThJtR7XThkpmfWIwjR6NTlx706qoAZVNo8ZBGCexYaseYeDBYroQNL6Q4x-b8i5n2ApO4hA1Ydp2ThPTK3JW28YeC4723H8PohqSMjtqfni-QeVlke0ngsVRu-crGZuYf~3LjH~NtuDdxoPlkSpil9giLfcsjkiBqOv0KiuBusqhGTe1sb4s6gKRuVVwT~YCcgiCbLQzciQGcsw4bFRbjQtLZXJ5goGsWILF0YldCIMGYcU3jjG-Tg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=default, Mode=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.006Z",
+                    "updated_at": "2022-05-09T18:35:47.006Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs",
+                            "nodeId": "20840:6800"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ab7989ccd20349524264eddbc962560d126aca96",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14312",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/H3a/AZs/JOuqPmFIx8rysLcU/component_thumbnail_128.png?Expires=1655683200&Signature=SZSSHfzliYA5ebSyEyvZymQco5hDdIRdB9ou9JKi8V9b21EbWU3vAgXtAo4arQ4WlUmx-qjUeTeuOE4np5FJvgTR6JJ1XyfqTl~ctAox55tnxd1P78HWmqeO-hiyYX0kuEBTU2jgSOu1adNvCeRaWxOXFJtQOSYJY4DeRC4Z00OWjGFEvnBlfHBsEmX006bnVMeh3KMFsDaH6hz8ZOVFSoTMYoosEvfR6I4VFwPSf-yGzbIz7D-WWg0RSOkjjk3lpcZxocPHsch9nifCWExCCaUYjh1JbkqSk8hOC9QIaCXCJX3YOpe6ydDQm5BFpN1a4nRY1WPs22b3oeCNoucfkw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Tablet=Open, Color=Color",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.001Z",
+                    "updated_at": "2022-05-09T18:35:47.001Z",
+                    "containing_frame": {
+                        "name": "Tablet",
+                        "nodeId": "21526:13618",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tablet",
+                            "nodeId": "21526:14105"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c3a4d60db956525422932620b48f36701c474ed9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14153",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9A4/QJ3/3Wvla2DyY4uqjkXW/component_thumbnail_127.png?Expires=1655683200&Signature=BIQut530hooRL1gi1oF3DryJE0wWzagZXgChSzhAA7FtPa~RoWlNa5Ire7adVk6OpiIp7WnNt5nc7lLx3b4uibhMrPKLBfDOenkZR2Qny4Gaxk4LPN-rZAU2nNjTyXhoePtp8ikfoRB6el01qNXHUOIDfakC3N8sBxuodpsxtUjHRryCAjA~csF42LEXbJJTXwosx0CmMner2~KmLxJb0EnDNybkk6SpqUbsiybRsmO2eriL~2imjtkiA7f5~PF9SMQu~KFAGZSJ3gFmu2dvysEwdFIOZz4P56GdDiiMvY44SDvWqcU8dqsf47-zDB02QCvFjQtvhOU3lucWI~aDSg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Tablet=Open, Color=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.995Z",
+                    "updated_at": "2022-05-09T18:35:46.995Z",
+                    "containing_frame": {
+                        "name": "Tablet",
+                        "nodeId": "21526:13618",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tablet",
+                            "nodeId": "21526:14105"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "85321ba9bb901b552e9474ce6239f1a206c6222f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14106",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/G31/ms2/zXwDiTKGrnqQ6fEb/component_thumbnail_126.png?Expires=1655683200&Signature=S7YWLwQk7r7DkrV4zVazBgVZ9wlsFqZ6OtU1E~QyWpdkWjhI-1HbUZZJ~Xmd1klwoljVrTBRkNtAIBvVULAyZ-7G-fjQxzgqdbS3BW0LeubL-PHRUwC0NULjOaLmaGLlTgF9eSZtGUziOwBScEEYGXrYiXacOXZCIx7qkMVSpSkfhNLRDwj2cyEZNBJzMG9fUgiE68S8lzJUdjo7rkJLW1YIpv08IVowrpqiXH3kyqLOlzEnkfM30xW1sSPkfUZtR1qlxz6slEFUNZGbQ4OCFBWKyVAse4zSQOpeIn7uPq2qRzx8-LSGkSjcidkouDEutW5tJxz5vgIgKYIBE2r0EQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Tablet=Open, Color=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.990Z",
+                    "updated_at": "2022-05-09T18:35:46.990Z",
+                    "containing_frame": {
+                        "name": "Tablet",
+                        "nodeId": "21526:13618",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tablet",
+                            "nodeId": "21526:14105"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "456f0f475f25ea4dc93aa4d0b1ec35c304dcd52c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14314",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/hul/SVs/eNDhNMjkNpS19XdP/component_thumbnail_125.png?Expires=1655683200&Signature=Y01klqLKnmdfSThpyi4G1b3dNw31JS4kNayu6gOFkF9RcfivBqhNs40urRNqRRvs5dXbS9YDkkwjGGnPsUI6tCBvgYmvY47n7R6GfppFa2E4MdKFwZcvfuKs7LyflHG1V0cCDkomLPCVAY6eXLF-qygEbbQnw7F~SPVngu7zv7Y56Kc95zHuW5SKfthijEM8jSCR7TBVKq9v7jc-N2oFHRF~2FnclufmN6LgGgJYVJ8oIIs~iBiQz7UI1seSQftaXCNR8C2RLBkRMIbcoAjKCwpYgvt4c-iMZpxcbllx1d4Eqw339XL8FuvKU~ylsU~6LFumyuROdbWR902m9d76gA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Tablet=closed, Color=Color",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.985Z",
+                    "updated_at": "2022-05-09T18:35:46.985Z",
+                    "containing_frame": {
+                        "name": "Tablet",
+                        "nodeId": "21526:13618",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tablet",
+                            "nodeId": "21526:14105"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8e294b79980c0246eea5bd9bf144b1ef6d76eb59",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14151",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/mkZ/6qt/Eb9DBq0npijfBJAb/component_thumbnail_124.png?Expires=1655683200&Signature=eclus7u30zkdp4oOpPMvR2Foq5gh6PFGb8dGPGyZ7t9h-8FKf1j4nOKCocYoP1P94pnpMAmr8ryNnmzNC~eruCVMqw~xVmdsbToeG0OSJGB-RP7LikbZN1ANVVMPOdNmfVyMVQtAcj24e6mwyg1N~lj8KCyVrMK7axSnUrLp9182fQpUZHHCmlDm4j3HsS93NbkAHKmkKeDOdM4rTsd~JhccvGoFYdv2iH6yTce0YjLDGYRTAAVN3geFB4~x0xq0aFfnjOvNevateLAZ0SQccEx6ZP6fU4VsC2GMWzPRcXrdEq9vFsESR81sjUCxbB7JkjZLPVUXIVGgFiT-sxg9hw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Tablet=closed, Color=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.980Z",
+                    "updated_at": "2022-05-09T18:35:46.980Z",
+                    "containing_frame": {
+                        "name": "Tablet",
+                        "nodeId": "21526:13618",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tablet",
+                            "nodeId": "21526:14105"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8bb4bd75a537c508670d52ab42e75eb9af52617d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14104",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/bJO/IkO/o5QvuIMfVJkqyYH6/component_thumbnail_123.png?Expires=1655683200&Signature=CIbDusOeYjvZutmxCMGh-WgMksPXhfYH7WmZNl1wXsKlvf8VuCUu8FmbfyRLf~DYDUtwFhCpId9uBMUJgsZkfg1wzJ2Z7md3Z~V353Xe~DSGNeujtdpAAxHpTUxq7eG9Qz86noUTC9Qq1yJvZQTR9D4Ge-1QrERM2wlW6NbTqUPlkWVjJiXIp86AFyPV5qGs5~RHwv5s6D7-gRlH4YAjeUMeF51SKlTSaraknI48i05Ns7LZOd86YKx5rHUmmQwnaDRpcho1NWVZE6~HCkirkOe3wlpr8S3xGNo9G~-Ps5Hs5LJ4xvzmzPBVrhvdaxu-pIrNyu7BWXr6xPNRZSxPpg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Tablet=closed, Color=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.975Z",
+                    "updated_at": "2022-05-09T18:35:46.975Z",
+                    "containing_frame": {
+                        "name": "Tablet",
+                        "nodeId": "21526:13618",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tablet",
+                            "nodeId": "21526:14105"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4dbd02481c5c92661480811b06f8429618541e7b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20014:12926",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/4m5/Vg4/pqlzTJdq83CEoH3F/component_thumbnail_122.png?Expires=1655683200&Signature=Lll~92pKCo2fO1LctMDfx1iRQf~iWJwEBXJXQigWZZlBRZHgBsvrpzOYMBWJGlRJPwqQpLubJEy-4Cbd52u4h41fPIq9O5fqgzr5s2PQrPT2E-hZeRBJFjs5~NIC0lx~xcgbIOnY0vfNQHelbOlnLjGmxf8gV~z63D1Ya7MwASwT28Hklan6SyYj~zwSrOKHWTUaO4oWncIUQrqFlv6dxs-GInhwKSdWMXvSLWSwtUZC8~GQk2j9cYsxNO0cy05cDdIadoIWinxG~QTyvAyd1EF3qxresTdvKQ1IUbxS1kf~lqpChjHiemSUSs8zirtO80rvZ~Zdqs6HSeeMPeB6pA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=default, Icon=On, Responsive=True",
+                    "description": "button: primary/large/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.969Z",
+                    "updated_at": "2022-05-09T18:35:46.969Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "15f78dff7247cb21ac07b3da3a84f1548af9a09a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20058:11422",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/YsS/Tqa/u6srR9G9xaYycROR/component_thumbnail_121.png?Expires=1655683200&Signature=XOo0DVuSeyrNguZpE2-39E4NQusaxBbMpydD-2Lc5YkzmP7A77XQPd-RljpKPA2vxciJwmTJcTMqi0NDWwqNuyTUSbypiSHDSE48BT8eT8JxMyG8Yoag4HFtrD-vr~yBudT6HMI~SCcv~0POEyeBcqXRTzfO108OKGgmns72LhYPi8IVGf4XaLfLAYc0tMvaO7z1s7WvEH1gI~msXhUr7cKCkH2EKfGu-gl1qDEaE~P-6QMpuj-uv6c6pj6dxcGOlN~O6fQdkn7u6OTNLRPBptE~DPB~YcaVQ9vjgAXXLsp3Z2WlX5Dr0JFQKH2rXh35HvkjcJjqp-Fop8PSB4hecA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=hover, Icon=On, Responsive=False",
+                    "description": "button: primary/large/hover/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.963Z",
+                    "updated_at": "2022-05-09T18:35:46.963Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b30bb2fee795d7cb195b78b04d9228c01f7ec849",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3236",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Yf8/glw/6Q6Q3bCCKI831pMP/component_thumbnail_120.png?Expires=1655683200&Signature=Qjpvknh0AWv432wR4Rs1zD~ANa0plJ18fAaV9Ccbx8NFjHgR9OiYv3u5Za0yM5KAsfvmms3lYgIJb4rMQ6Zmugttutm4pwsKTiBc7a~GkE0KD7XGaHrRe9~UxAwdj9QI3qETYPMjuydtRQexIbCblz~ZqMCNqQl6isljf6kr2W2onXXZ6zuYHioWdkf59YoKgZqjGStXgquAtUdd~X1syVRt9kdUpGkPDKXTrLoM5rpLcu5WyCWtKcesoR0ciAhk1cuXwg7QMYSebpeFNpsV3MiewtrFjccw5~lUzvsjUEwl5v7eGWqXQQ9b7iWyaRDF-aQahUWZn5-ebSQw-zQl0w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=hover, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.958Z",
+                    "updated_at": "2022-05-09T18:35:46.958Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1ff0d43e39641d08095a94023d1a181159be3e95",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3232",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/QdN/BSm/md0t3S5FAR6gLSli/component_thumbnail_119.png?Expires=1655683200&Signature=c2EONLAIalpaxD74ew0WonFw56bZe~RT0VlWFwwGiqF-~bxej~GNeTtuDoxFuWY6PW2GyDGKTzaxojq9Ip0iaMBCWgRGcg4qF4iF3mTSLpo7cXDs4ZF35g7UPUEM24Ux8yNI0jH7QerIwlgkM~kUhDDOp4amlvqBpJlJ1foUesODvTZ6a37vnkBJEV1NbN3Ium0TvDuZePgQ6HTghTWPtUYBf2wsnx-ljMGucyta~OmnOcSqTybCnFVSKO0x4qyTkMZZS-Hdw060e9yRBT4~LpDAan0g3Yq36KPF744F1eVG6GtSglIBtjWLnI~ZDKdyvTaU78onkMI5MLhCb3loZA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=hover, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.953Z",
+                    "updated_at": "2022-05-09T18:35:46.953Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0a08f42a95bdc59dec337bb1abf59dcfa6e0907c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3234",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/IFj/Efp/2yJEXLrOs3iPBtOg/component_thumbnail_118.png?Expires=1655683200&Signature=dSs2OPJSeJUFVzVolAVltbPtexj4pNCz~UGZC50vIgWFM8LEA1zvD4G5CO842XFPR~sqJ-lwxNyAqbFuGEtJ-eR-0Qn~F68jAhUH7zDY9Neo92r-3~GCJLAOSW7RkLhncOhu0gdQd5cw7hWIs~Z33moIb6wxA-toB0enqpzlKch7fr5adrfz9l0smTEFzUaqiNYMccP0WwjlgVl3n0QkTQ7Na-qhcljwgQ7VGLe3w~7ofrekZmOHn8HXFH~po5-6~LLB0Q1WRVKNVu3mMVu1eZW-W~7StGSASvmA~XFXrLCfBNYaGX63lUyEXCpfGssWfQgjvRd3D6CJLm9lxQFttQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=hover, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.947Z",
+                    "updated_at": "2022-05-09T18:35:46.947Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "54e5ce0be560c22d875e9e0d3a7e71a69ce773ec",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:11196",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Prj/Z0A/oYBwU74dp8XGMaNE/component_thumbnail_117.png?Expires=1655683200&Signature=gxUDVnJrsQUfzZd32oanjViZgneAfHAgt3mV552xqbruVoWrEeUS0RA8GkmiXYr8~7PeeB-4O9wa0mY-vgJqezP6iOUkQVbEjkwU5ZensIrHzae6lQ9X6cTYUjPgblJcF0bh8CDaagQak9MP~uHojLscr3a8U4i3RhoEmi-l~rTSK2VjPiFU1SdL6woYm0aCV3JJo-CSB5NwqFQofKSJTJeYoUB2dq-CMuvB7zN0CoajAUlxXn-d8VSpMbBaSw5Fyo~VgEhv~q~NTOQB6ExhS7Wl4~QT1~oqGuhWgLdN4Ai66cWA7eu0jab9kEC6XZOsxEyisY~8osRal-Tgu2holg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=hover, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/hover/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.941Z",
+                    "updated_at": "2022-05-09T18:35:46.941Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9fbbff08484a069b41f86fbd7574e931bc0eb84c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:11192",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/4GU/Zn3/YmFxJfyVdJERZERP/component_thumbnail_116.png?Expires=1655683200&Signature=IhLzkOYWy57C5q1L72bVYhRKjkBc6z5JrwKUdatKY0xlX98kR~bKUmRwd0Wfwgwk~UIFxYgy5N6X1p0NeBXEs2VY8IvrG4Q6NvI8uxzcx3bcIu7oBmXNJY7kl91R~i5tXYFlDmOr-FMT9ihwhXlzpQClLpJ2oMa2Z1gsJZ1SE-efrLZ5kwxbHNfxQ5jBWwzYkHuygb-awhziVqBxXdBit9Z5mZfr1~kSJOyGyAhpfUf9uFsP2G3t8SvKSbgwVhLG96bdUcbUCSJz2Kir1jYkkSWPoAok43Z4oEBLFqbPZ487xXDjhjd~XvsdbKSTMOnPC~mAXf6yqetnEPsc~b0zkA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=default, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/default/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.936Z",
+                    "updated_at": "2022-05-09T18:35:46.936Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6dc442e482b90c2f36e808e84e30f85fcba9cde8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9616",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/jmc/IBb/U9dZfP6OxuNMth3g/component_thumbnail_115.png?Expires=1655683200&Signature=VOcKYepPF9MPUZUA9p~nR006ynveNINqHnizoEyVc7-ytAxslBnDUGFy3MlscfbWfvA6oFNffESYUmVKmVmunhBlWi1hspR~MrWcYQ3DF2whBcu7IfgNQUFzSelo5JcVVoFZqKC6lTOnyTZtfFKdt4VTpSNw5RzoakX1pZI9sN-f27FMzaPZPti8cNds5b7elioapmHwsxxiTLTTKUx331w3ucMvSPzFgG7dI4p8lPc40JsjHZgMAX1tMoOMu6gNEoBF7-hkTQc5UfrxsbWJZt0Hys23naOUz7QXxkWQf4Rg-iWfTdLKxHFbY1KiHLoLw361lYPRPydjlbzKPORcbw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=default, Icon=Off, Responsive=False",
+                    "description": "button: primary/small/default/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.930Z",
+                    "updated_at": "2022-05-09T18:35:46.930Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f5cc1651c8ebcb9f6cdd16a7f466aeee2858583d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9602",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/TqP/FHw/OP3WmLDjQr6eiKbj/component_thumbnail_114.png?Expires=1655683200&Signature=HQO9O26rBTBhc-Aah8bEHCQnYwZeEKkY77zIg7HyIBVcUQtL558p3rT84YBWABh6lE~F9zkxgwEMbKTtWI~RexaJZsMsiMrsSWPxcTejFFCU3pv9qa-NidOo~VXFiiFPPuUB5i4vHW7u7HMxuYUOz7yjMtfPmvHvGKd7qNLTusKoiwz4FPJJi3~OVOL9RHUyCyo3Uz0qjem7jFms4l5pQMAnQdswFLf1ljkrQT~PcGSfmwIvLgiYZSn~GdQSI-NzsiOdDt~QkDjJQIlgJ-XlvxB-kOa2ZC3-3BIokzaFqxtcRWUyGVvrym7Z55X4OToveK44wIa0D6hSytiHeoIKEA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=disabled, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.925Z",
+                    "updated_at": "2022-05-09T18:35:46.925Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "25412465163fa2bacf7c8030d2f7271abd2ec961",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9590",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UMe/Rcr/3zc0LbvCh9Y4QQxu/component_thumbnail_113.png?Expires=1655683200&Signature=d28cRpyB9nMOD6TdQCBHBxsIcuNnsHJMWp1aL-la9bQBHsX7WwfjuBYNAIAF4em1k9kz0UTtU4xvThQ32JEmDCccQsCgD7PmpG~2hKCgnR9MsrB22Aar8Ni4IXaLRHnUg-oikqi1T3tM342gMP-QIJE9PUe8A6sHOg1rbq72nGAG~5MrkUWwVm7s2~PAnpcxwd1K0Wc2LpG5wtYVpgVsJCStl80u7y3QywuovSlqe7TaXjNjms5J1sKifi4SqF-b2bMeF~YKLs5ppvPCnC6JYEKpumJqZd87OFlGZjq3vErPqxzqkqKR6ErxOXnPEOxqkCRnzBUQ72-tOYJ-OGfOdQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=active, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.919Z",
+                    "updated_at": "2022-05-09T18:35:46.919Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ebadd7ac7619654c7d44eaad08dcf3ca172748bc",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9610",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/084/NVW/J7WHp9MxC3yh1hSr/component_thumbnail_112.png?Expires=1655683200&Signature=YuG0uLdnbAVzaCU8QVWJ0NQWUE82pUCjz1ojJa6KU4b~CjHHYnm3Ti55spaVUWl~mubycvnivnr6A1vpT5ZnFRFXrPIvTYlKTcTvT2aEbwhgVmBTswyuDpUZIzWb0~hci1k-sw2TEBCew0WXwFAodxrrJYvtnMG2Yw6cV3rOS0VIERK7pmVUnvRXAXiDF0QHcvLWpE3~rIU7dxIdmoWaTvZw4tPZYSrMKS1fJ5hROIAK7LekjOF5GXpoc~lJ0SwsXxvuqcF05FEX--0TWTBtAkxg-UjqH0T0VksivoXVuICGuv6o9kxVua50wEiHCEHMqD0PUu8m39CsENz2cUC4rg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=hover, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.913Z",
+                    "updated_at": "2022-05-09T18:35:46.913Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "cc8ae8fc6a41cd8fa56edec970845474675105b4",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9596",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/rpV/Xgi/YgHrf7OewiiJ2ifm/component_thumbnail_111.png?Expires=1655683200&Signature=egtg7OaZzLdOZUGZjXYpR4w4vc3kR83CK7KHj~gxnGR0roK02XNocE8elmRZpv8unTMEfagpEYlPAWluU9v2xai-6Qr0v5wr0xuwZOw5qEmpdbjiKdHku2s8s3KMLESYcJKAXENlFKPZ80xeCpl6PJ6GisgqZeP1oSP61dWjm0u2WMgJ2sYeojpmyLiSVi8bSEyCloH9axf7tPIDhUW3q3TppZLw-8vnBzEy7D2woKltejjx4JQcmRnjiiPpq3HLp8sXYoMmy4rCbufJsu~YtPmJdIqCbKvhuLkYFfnrSRgTTZImm1RXgWMh1gIHw4ymSjTBPqoGc12h35UdWafTPQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=hover, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.907Z",
+                    "updated_at": "2022-05-09T18:35:46.907Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e8427a12ff213b37d0a75c960d213103ebad2794",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9600",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/DKG/LkV/I4zCqMcwn3nl35Wc/component_thumbnail_110.png?Expires=1655683200&Signature=bbdTPP7cPTh9JdBzVLSawXNY3zYkfVyFv~t1ldWb98Nc0YYHi0zm01JzS-9cD3Ze2ZCdyvvkIckAWlQcT8ilSXvE5P9XfCNkNRAEL98O4QT11wCP43z0VXfFiEBCg2IqRL-Octoe8bny4eHwtGiF~mmXK6XR76DrnmQD7ZPfz2DOydkO-yozEAS9npV5NEVPOpSVMV8Hi32ldnkvT~~romw9M4nhesn283WhjOUi0bWF6B7bIDf6kjE5pTCL2q1XAyV0-q~os1QgqNycEAmhI5GbxOOcgHsR2w2oG8QmK2wLoAlQNY9QVe68qh5otlEDAqkpn1r8m8dFnp497nXlPQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=default, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.901Z",
+                    "updated_at": "2022-05-09T18:35:46.901Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e2a2f7b453838ee6e6ed310ef91e9f2565846536",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9640",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ad6/67b/5mYMdiOa2yikJFC8/component_thumbnail_109.png?Expires=1655683200&Signature=AmUk5krOcuZxUVyt0YT9SWKB-S1iEkV5WJn8OALqljMxxgjaDM0UbMqwrQ7NgQy2WRTE8J~y9bYgiB7jxQQZ3ndRhHcog7wDMleVZlbclkcXHrAcFvnEsb4IZJSRonhrlsaDZ3FXXaUGjpXOaw4pYghtm2~7SpKikV3SzsEYQswykFpd9QCDzOqPITgNZva~pTlijS8-z6L0eZc1z3Tv2US5PxZr~UzoakLuGbcUgOKPYUwbWieCFTDD8Ur7geVfu8FGCMb-65iBCOUBjmGxttd7j0glp-bdFYLLcaY5lGD6bQP2wB1hqBP~tMkJ-b8OLOL7GMrl7Ona-8DhevoUOQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=default, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/default/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.896Z",
+                    "updated_at": "2022-05-09T18:35:46.896Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d2a47cf2262c9b3936ba78709422c78dc50b6a93",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9638",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Mzd/BwH/19pHAjUwMsGAbw2l/component_thumbnail_108.png?Expires=1655683200&Signature=fzv1P70kTqqP6T1gQkyj9S4wCqj0NUEsrdwV0A2C1NGjBEB2n7CZ1xIY~KNKeGEXgef7WEFoQ5QM~aahRHT8Xit2Us1U3I23kTU8UL808bc2P4aTiFhePFdH0L1Blk8JufVTZ55tNnAe~aJ-1GnxgFLyxcxzcl54~AR9ZN7xQcXbMbVbHLno5PBHoCAKtRkIf1zabzLinxiw6lSGwks4BTc3IwxHw3AlUAuzuWYaF1dL5OGppVhGEG5Ffkxr8NfGiNTefefu7m6aW-2h0gv9mh4u4xm3Jmg3Tz5lCTEiefYLV00zHXxVmd19Tfghb61ycSLfSu4QbfCx0AGWo9aLfQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=hover, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.890Z",
+                    "updated_at": "2022-05-09T18:35:46.890Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "bfbeafcd0ab8410c4d8cb5503fb49ecd1d14fd25",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9624",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/3AE/JXV/MhOuMMGc95419WFQ/component_thumbnail_107.png?Expires=1655683200&Signature=CAoCgqsErSsKXQV-Tt-ZtAuFLg6TYZXe4ESsaDbN2N9PKmcFgn-tDAOm9enE1Sh7Tp00JZz~FxSSN2mf2NDiS3ylM-jSyQjGoi-uUo2gn5hDxnhnAtRsHSTroySc5nTwC3hB2mHyb686tuR5RvmywZLDYn8x-EnJ6IMDAS3a95DEHMiaelL1lMGJ6I1QxHCcFGhUDgOQdVUcBsNvOZwwjwKbuCq87DdYP0TU8pWVw2VtATMuC1vDZ8Mamr45NtA~Cz-WDXeV~RGv3KZ0faCaqTTVCoWFN~0mLCtfAQ8e8vEG99KrhPVOBw3uqDANqSVkrGAh9ffMKQcJYVGpQeHS7A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=active, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.885Z",
+                    "updated_at": "2022-05-09T18:35:46.885Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "182700d8faed7ebd7b08c305e9c19c1b7eb2ac68",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9632",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/V4D/eu1/7iNuKQ22V81kb5YL/component_thumbnail_106.png?Expires=1655683200&Signature=YmBP2xdfXFVczdWFur3LlRXExtkQLtZ0FCVU8mjgPumm2N2kIKN76XbQJGkh8tfQeJ5jfnuy9NK9Prl9aAOeEtG9FuMgnNmduhPOweASh~0nnUfgqcqVkDX0jSdX~ujOYKOtLnIztDCv5kIB1USr-o7bU4A6pHHkG6Ri2zvrA34GLn7tAIkhpPLrSDWKypgcfxFlHRIVPo1xjAkGPrBR8vlly3b5gK8b0VsCgQePEcDYecNPUHXXOPgXs42UklFNCq3zieGZd-a1VaQFK-MQjD0DpeNeqZMiRJnEejg1hG6EcipU7K~rEHrwa5k-IKlS3MqKHixuEpNB76vTpvVyYA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=default, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/default/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.878Z",
+                    "updated_at": "2022-05-09T18:35:46.878Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "11573c8b462e54c9e6aa9cf0b65120a7d59fbeba",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:12568",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/NdG/bmw/xMWBAFZY0ET4axLJ/component_thumbnail_105.png?Expires=1655683200&Signature=UmYLuhXwXsgNkQxbvZPGQF~IFbRolQKnvtuVMFqWo~2Iw~WWy-ZDcpmLNJk0E1Jkylz3AvHkehO9fuLjd4H4vTqbz~4Rx~VQ5rbvIocCEvVxO2H6~tFImT6T9zG5Gk49~2~ABT8ZqFhArRkAwn4EDT9eAnxq8SeMXzYGdPf7zC4ZLjvVFLx-DFo2BKlyijIApxWvEmiSMLjQDe8UXkG5yZb7Rj5mjXQ~9DHRt54nY0gWymBsaHz-MilsY99nsZn2NlIEyiwLMqic5T~R1rQVdhX~cnIapjJfo-6iOEdV0kUwe3MWHCDPKwESQmiEzM6KD4XlDvmBp1Ug4Zg~O~kynQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=default, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/default/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.872Z",
+                    "updated_at": "2022-05-09T18:35:46.872Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1342c9dd671b7c1aafda72227ab14f93f7e10d91",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:12564",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/L9q/aon/BqxWEQnXf4oYmkXl/component_thumbnail_104.png?Expires=1655683200&Signature=c5nTAn1QmQrzK4ugoVbKfg6RsE8qOeJVNYfFhethQ~3ct9lH1V2ecjtN9ZXDhO9Fj~9FIHAmnTvfJ6JX1T8roBdqlkMJEyWflNyJj-71sFx1WuFMko7RFV~ahf5vXehP~KJgJSoPZV-iS0Jc7LWrtuc5aaAL4UdULrT6~ug~uMOAlLApoS1mUsT80J6iQmiZHgMBsLKuif9lJrdLEqA1s4U0hVXQRs2Z0Nojlr7KetkGGMCEvGRG6uPtnxGAlOdciNlZrqz1PKVhuW4pBhEKVuOtyCSTbz566uxCIo~jzq6pa1Rq4DrHGrVIYILzSnY-RxLIf7l5dvv3uYolM00p4A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=default, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/default/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.867Z",
+                    "updated_at": "2022-05-09T18:35:46.867Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3ed68d75afbfaf89c0a1cabc107c127df307aa11",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:11913",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/54n/Yxw/0DcWVP2VOtARCgXZ/component_thumbnail_103.png?Expires=1655683200&Signature=W8GaW7T3gNGc9rjbuf8IFtsUvpKPV4NI1AYIKUFU-pFs5aU-0bvftrtEZNaevvZ52SVNXgfxgFpl50chVzLPuy2Fd7TRELUWZnbNurtgZmNMjYd9ik-402xOD09BfPNhaSXXGyonxGeS1pA7EFg2rkVt2jqYOm8t1L0Rd9IUAxT0huhmQuyhy8ZFVOajJFXZ3teYcozLsF~XMB7dSyB-fRctDFG05xwxKf-NVK9eIcnmHbVVQg44kmRZnrVtCabzy39Hjb0aeVal5snGX6Ca8tDtYzjszl18iP8pzIwyeUD2~Gj-ZKQf0GmWmjrMTZH35iV4RiL4qcV-PuIL~cN04g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=active, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/active/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.861Z",
+                    "updated_at": "2022-05-09T18:35:46.861Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b96acd1f85aad486efb356fea957ce924d158e5c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20014:12978",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/cRH/3PE/pZ950uPkDS3ObAfI/component_thumbnail_102.png?Expires=1655683200&Signature=eSelu1sYSIkvfMI1O8x~FXKFDZsOuNLo~bdJTIbNPCdZLzCDjZhIXT4Rt8vaeITxR7E6PLYoaaoBUBd3vnUhGfZbMCsAO8~6WH3nyjdATfg31E9eGqpKDQ18hvP4tVWm4CUQDHHSL6pkoW~Q3in-DwcnWD6QG-Jc6Wn94UeYTw~hE0v7e4EEfVrMlf2RaN8zA79TxRTfCe5MbyLvLGPKv-ZAoddJJy6fpGmjnujgUuR2m6SH2gXt76ugti3gJr-fJ4AIUU9XByyicMmf0jKbsemFm2Ohg1YYV6Z-8iXLC6HW9PTcySzbwDtN2P0cXErmVRIAqZPxq7F5epKeuDpk9g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=disabled, Icon=On, Responsive=True",
+                    "description": "button: primary/large/disabled/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.855Z",
+                    "updated_at": "2022-05-09T18:35:46.855Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6082ba457bf42d9c8866b103780a4030313fd90f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20058:11428",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9aC/79R/uy68mGYoD5fDIO7V/component_thumbnail_101.png?Expires=1655683200&Signature=EFiuq-dpvgEPVi-RthegPcD84gLeeoEcxTkhWc5uWsLsOwC5XdQ8HK3ntqQLDD~EIeswJUnEx7jVi2yFSaQVqTNKSOHdWyztXlVXf3Ob6iR1T-fWoGYfl7NzeQdBvncV3LKzh~zBcQYo6EVnT2YDLRuFkdu48UVHoq0-CT0KCj5QUtldyBp12t6QnbMtpu8E5--tSp5lyrUAV3STl7ui~2rdYrq0ydyF10ac0-4roUz-Fn9rocQfHo0qmTPemOVgyTAhl~oVViryUctd6ryR6s3oiuF3vQiKbIhWU-n19xLc~HIUIjrDvBP1Hsv9a6C8Wr1ZFwpkc7eOkONYNjv-sQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=active, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/active/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.849Z",
+                    "updated_at": "2022-05-09T18:35:46.849Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f222fa9817ca02ce97c987cd396af5b659e474fe",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9592",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/3Jf/rMI/gYkVpFMJbHATSfI0/component_thumbnail_100.png?Expires=1655683200&Signature=dQZ71HKpsuV0WfIKAxFQPrZXgtqyPPkZNrwZz95h-1fcRCrXUF9syVQ6RG8v9Uk2F2eZ-blNDKryOEzWRloNwM03dOg8lhPqPIU--VH2GC9OFIEjrvPHDWlrGIDN2Up8IXeo1~KuYKMmdfvXfvVoLLV-k4fyxfV1aWvqDi~xaboEO9baxEt-jljt6EFYz7eYKBwfU3tyIlYAYoOpFtoQxpfsBdUKrNj1MFvAUlPAbRYo54Rmg4iOwiwu~ZduuCtQ98LbdH8asHzrNN5OmOeb2PuucgtsO8HQxljozolaylhhU23wYK5s8sCFxsDGZdMWIfhp2qp4XJ~iGHL1CdgFuw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=active, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.843Z",
+                    "updated_at": "2022-05-09T18:35:46.843Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "380e94da7127769348ea6028d03892f144399ef4",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9606",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/DXp/upH/ZpoZ6A93NB7HCECT/component_thumbnail_99.png?Expires=1655683200&Signature=QUiDr8dEk5u~h40SUZEzAn-EjtFtldsOt5ehG8l12w3JLwznG0gtVQvFZ465znNMm4hcijdZe77FIJbob3WbOuf97xXwV2x17uvXDAnNwsRlBM146Uvuz2IJREoWaoCP4rzcRSSePym4pWPYyzXAQFFpVrrfslGQ6rnbxeeBJ4iQP7~fN19joCNUJ1DFDiRwRq8JAYVJED8-0kCGrtCLVTCyI1QwRow9jG87uhT0Hx39mIh34BmWEZmUeOWGATq2F-5D0cv39p2q-oIvyhhd3wU~XmOvduEcbWpwnrP-IB2DGjQqzctnVT0WPW1yeMguMZEnQmvZBXMSvi~-cTMkoQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=active, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.838Z",
+                    "updated_at": "2022-05-09T18:35:46.838Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0524d9167fc7abcae0ef6e205a17a455c0314b3c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9604",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/FwM/RC5/WADiyqShWdKAtAuv/component_thumbnail_98.png?Expires=1655683200&Signature=Xk~NvlFFZnrxo44fgRSby76Hwo~v22tSWuqgZJl9siFLDjn1q3QSXcuqwKC7osH7F68mn6udFcPryPG8iCS2wXf1-JEqma9WTJ1DkHCxpUbn0SanSVHf7SlPNvVfTRuKa177Z~rDzNn94y9A~x7oxKY2CyBuScFoSQjLuVhaWurW1DVYeIYaPqxltHB4XUVEHPo~f~o9lD1oVR~BykoRNzlwMrVEk7o6TE-qE3~85n03Kqy0scCseQy5zeL2RU75MupIWCadpqzePuFVNd~PxTTT6vbMtaN03POByDL-XkaZk8NNZoBJUgZvDUeL10cRzhoOUvVmJ~a3TxJAoQIi7w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=disabled, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.833Z",
+                    "updated_at": "2022-05-09T18:35:46.833Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "bc34092723d4f0c800333c55e644bf11b8998916",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9612",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/TsK/p4C/u3VJgiaPjVPc0JeT/component_thumbnail_97.png?Expires=1655683200&Signature=NTq6Zb9lqYBpZL443TPkFpkF87HYEDY9SVl4Z76mLibWpEQATWDjFeTtdbl20alIi3jGgNWp~wvZPDE5VaY7yna-21FHsfxHscHJcUrKrtgA0ZoUs8Yp~k0L0d36rWhLDs8H-gfybreVdu86diVFmNbLLh9fyvTJSwTdHQ3mYiXPK~LFiB7lZcchgZrQDQ5sjcU2eE31auC9xP2-Tm707yZ9ER8~G7fLE5f9ENjPbsRv6cY5qNJEpg9JOurHLCyMwaAMm1YP9vbSOpNbXk0uJEL6ZgqvynS2w55376V9KT-Tyda5mb4J42yvJ7QmcIhBaO9TBG7YWOmXzL3EyYTA0Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=hover, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.827Z",
+                    "updated_at": "2022-05-09T18:35:46.827Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a8cbc24ec1519fe1acf12543f5f222e0cd60fdc8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:12558",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/bCi/Bpl/NmEKdp18rCIu8Obb/component_thumbnail_96.png?Expires=1655683200&Signature=Z7Xlqns8nVBwwOaeOmpGhIwQY8j1j98PeDajFI2zGYUJk~cKasN~sFwWu-s6GRet79VN0Y~e8KOOdxLfoMVrNE0q~G1jyTtayGxyUtGyAzDI83gObRIJIppqMHMGXXk3dxRXXpnIeU2RCA8EER3XsxTbxQjXEt-99r73x~FpL9KlIVBrgz8okxLBEW7xbQ6XyqSdCqAhVOzE9wipgLtiH9Tjy9k39Q0GsCjPuUU7mNuRMZTucaO5NzmLqrf8cf5YkF40zZnFLIUdpKd61uRuHeHkxcr3~WRUbTqKv2rEIEsfpFynsWziAdPx3dlzgp0BfIgZ1hNC4bzO2CvxrlvKFA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=default, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.821Z",
+                    "updated_at": "2022-05-09T18:35:46.821Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "83ad358f4b96b9cc6901ff7d5b7a5fb85111932a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3372",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UYS/Vvl/0Xyn2MDaOKQWH9VX/component_thumbnail_95.png?Expires=1655683200&Signature=QSOSPssx2ca~YR3MR9F8GlnaPGRMRL3LY357oWhlqqkpGSpb9qF3jRgAnAnuY8S0TXw4BsWyjCyc-ZBltDaYMy1tj79f0CincWBdcQUye6XW~QNa1JY7V8xnd68u236o8QmHxuaA44ppelm~dbcnFY~wrwqZuF5rmaYZC8jN5reRBJxiMPKVCo9ZQA-RVAkTOubHccRy-a7r4Zx1jX-lPhYRznal7Sl6UMu9O8nbx8i9xszGcfDRKJ58y8c59lmVNp4n6zeDwAWzpAhp9giMycc5dd8dAImf9exYsf4aryGALl-Y7wIXSUJMVdi~vy9SjGrfMvXTwfi7GUbgMSOXbQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=disabled, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.816Z",
+                    "updated_at": "2022-05-09T18:35:46.816Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "04ca13b6708174877faf587ba4d40c8c13e5a912",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9704",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Kwd/OHO/HQynGdc25TUZQhwU/component_thumbnail_94.png?Expires=1655683200&Signature=KTFXgXOIBSZliQElNZ0zS6WphCd0qAz12ftlImIz507mhZu3XsRfewLp-92syoVYsdJgk3WoZ~Qf-tBcWlM-N0MyoikEOqG3nh0Ynq3J7UTxmPorDeg81gEUM89Etlaj~lvLTmqwK~qe76KNDc7saiQATz6Ykiy~oKDgYmTfoIsC5fTpzgM6ZppM-YT0E1785fKF43dV9nj0FbSdIiNSj9zaWyZqryKmdSOsBq4Q1kPzjlRGVHNN2bwuJwrd8bYEJYndrRgWwR2LHaM6~jhhk1UClmTMWl1fJPO9tbGcGTWC9C~QxFuKIVjOtxiO6vxfBaZVhmbd~9B6rjoNy~Wo-w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=active, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.810Z",
+                    "updated_at": "2022-05-09T18:35:46.810Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "aa654ccb09788121c4b808ac6158248c1398e396",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9712",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Ypb/99v/F0OQRtZP6OtuTvkh/component_thumbnail_93.png?Expires=1655683200&Signature=UxlYbriCZhO9-Cwq0ebEsgfJSi-E4LLx1UjlPPnCx4J2TyZmMo33iaK5fNZzDIWPi9B-tfg3pev6O-osLnOkYMC8ethWsrfAMuuexsZvdxK5JK7GVPKpXbCnJ1Y64UIo9lk3rkcj4hOiDl2fmI6DROjS7uyhwRzgaYGMvOsxx0iNCU-PpfbJ3fvr~lkTWjPjDm0udV7Pa8wDRoy7kBf4mDMFTnXqQX7b120TmgSTdJxGAgi6IDKNcc7tk845n2kZrjzolxOeAEQ6EyHo2wiV-tFoTiLp11JQ0Zh9H5TBxzXvKuOVkap9-0mHbEZL0q8S3~HSSNUAYAIKWpVLoIgPog__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=disabled, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/disabled/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.804Z",
+                    "updated_at": "2022-05-09T18:35:46.804Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "58b201e25a0484a3db25c68fd91f7c95ee0dfac8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9674",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/MDq/FQR/Tov6K9vNirEcMYuT/component_thumbnail_92.png?Expires=1655683200&Signature=RhZyUcdq74SPa~owkmMp1loS~HHj5TjFD2u-ot7eYQPbrPUD10r9Fcg0pM397sim7~DbEcDQPHLFVDkoi8enaTY68K8kMQR7Vy4Ctlx9kvOYxNRSMcnPFBYF-1U8PM8VP6Ey5jh~TivkfeVxCHqkZXn7OlSGPzesRRwjpNDG4i66ZEJznWQBraA2zww66Jvt3bTKEuCQfYVxLbF4rXTcUZUzDNUC3gOdeq22Fr1ztOY0xED0pUmhuhfkSKZ3ZExtPcaf7SqGrynUD5Anu-Fzv~MmeOHhNondaAUz4kji2mZyVyshuYOYmToZoiXvlMuiY2-qb3PUmV29wRvD5boiTQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=hover, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/hover/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.799Z",
+                    "updated_at": "2022-05-09T18:35:46.799Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "cb87ce89da4b197d70f52f2135ff299ccdcf3345",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9668",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ljB/PBy/YMorBZkGb0mRijMr/component_thumbnail_91.png?Expires=1655683200&Signature=Xkj8FSiuK5flFTl9xaCTcZsrY-aZqHGk9vxAURK1If5JwFBapvGgsC824zanaJyi9ojpyfdvuVaogD2SYguZ1eCXGbF6iaucpUwovXLwPXmRdbGS0xTQDDVXlam1~BNW0CEA0QAceZrmxHLChH5OKCpgHqZd1dpXd7tZCX3wz3Ah4xravxk7xfBoBvgrToRk5xX8PlPL1Mz1UJHeAYBRogAardFhBf5hfAFkV32rQbjaC7ap0b0ILI3XFkpMSuvfbFAVJYhAPs7juN25OfJ0~cY91Vos5ztKTF~aITSnAdGfNIx9J0EOlN37pGOfjE5ZfrO8bmXfUQ5vipqZk6d9zw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=hover, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/hover/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.793Z",
+                    "updated_at": "2022-05-09T18:35:46.793Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7be3fdd75cd38c1bab7b10cbd28c12eab692877a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3187",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/piW/lpb/PRt52r56SypWr3BD/component_thumbnail_90.png?Expires=1655683200&Signature=BAwfMyVYvbLKpbXNOhjBdvv0Ix0360HGtq9~cT4kwt1nUrldatzihQdR7PGqdJub7OcSvehNMKW4K9Pkrw9Bua8yCRO3FZkr2pYjAJvzO3r28vRcJYt-6oOrEfFEiBUtZ3xD-PjBQ-9BhpyW84qDEfZMKHtBN-qVmsq2xuKdWf3~PYncP2XdEs8GwLbeKkJwC-WJ5kcNonNjVLL4zN4GyPAz3UprGaNqz7GRkWImUibku5zYC9UBmId-CozTqbU~76fCsOjrMj-J17nAw9cIIjYVZ5Yb38ncujruOewxu~EVBzH3inxQlXHXPmvB5CwmqlTxoXlj4J4yFwCANmxwlA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=default, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.788Z",
+                    "updated_at": "2022-05-09T18:35:46.788Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "11808f2372cf7b7f7f4153a80231401ceb0664ad",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9666",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/h0Y/lex/NMdCElQ2veTjPP7p/component_thumbnail_89.png?Expires=1655683200&Signature=TMCncgqTt-XOdPQUI~eiIiEKNHgJx~q-4Y5tAzyGNmQycDPpUFvY2QUKXQSGbG2ZvHvcKI~bcmi4Ryo-ar6Bqh-PWmb1TGBRv14HpQtiddCfcSCyHAzDOcaFf3RiAyMgvzXLlzj-fpTx6OdCHlrMLeqAS6eRk-t1hc51pI09q8urCoMYgxHmeTQ55T4Kr27K2vE1DbOyW9wHwlTRrmxoq3OxeAfkI4sqloDQz2UULzUCL~ukC8co8W6gOadaxr3OM0Gxpfvac3qYTwqJzOaaJ3EpIYwmzAbKYWhnh6UwZD-GtPPIZX0q8XzCkVAAMoOuCfgF~iyREKKO2VrmYyTkKg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=hover, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.782Z",
+                    "updated_at": "2022-05-09T18:35:46.782Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1947e48b3721ea53370d5859cd864faa0f890d28",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8674",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/xUU/1fY/1YGkjLfgJgT7XHOo/component_thumbnail_88.png?Expires=1655683200&Signature=a6PO9CQnS4gE9nz6~MYwurSy~G-guICDFpcNhjAD0RxdgvJyZvcni80KZW36pYSsXix02pGE8YofMBuoFSOkU57nXHaqxmjognh2Lz5OUSyP1wBmTCNY-yDfrFp1kjI1dVdW4HkTawu04wlwwqMs4iL1yfHTgqD0KOgfXcnplFz1bEKK1eeCzwo475NG~us66CtQmluI40g1xkIYBNiGS55CZWLKtaB6L2FEXllibLrxeAYkrkD97y~m47vORd5IvQlNaUi5Kg9RNSfXAyK16QHhI6tkecxXte4c8k5Vw05TlkB4JB9aZFebzy~mpObgtMMH~iuS95wjAllbBEDU4A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=active, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.777Z",
+                    "updated_at": "2022-05-09T18:35:46.777Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "cc60fba135fcc7689666f210bdca663182add47f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:12554",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/m6B/n7f/vUiq1hA67M0nvpNa/component_thumbnail_87.png?Expires=1655683200&Signature=OO6RRss7q5L~JmOJeYLMX~5VxyygMkkWhci6i2ZoT7zg4EVrPuQVWCHPD5GppOT3pshbjGWO44qZMbYiaPnrH0V5sLwP~yHvBzL5vOpTfqSgZ6ciFR4wfGq5hPHLjI69~B5d7oHkw-~IfNcdaU1qYjSVRpMj58U0F-2kXqBOqoTkbQMdu59j8GnAJWZ3wUslXErcG2EX2nbGkpnieSwk72YhfgAJWOwfxpH0SsThb5Sdx~uIE94fbugMBLBHB1esHJAaO6dB2TGeYDgB0SSrq2v9ajiRLKQh2WtpKgCwI1iYNtgsKo13lKCpt2JBlPW2nII8IHjKiN2H4yKBQRwBNA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=default, Icon=Off, Responsive=False",
+                    "description": "button: primary/small/default/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.771Z",
+                    "updated_at": "2022-05-09T18:35:46.771Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a009f062fd2fcba6235b4b2d32f7354e236b2ae0",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8624",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Q1q/w2q/kBnDWwuXqyY2yw36/component_thumbnail_86.png?Expires=1655683200&Signature=cKDwX-QVycF1RWDAekJXec-LZr04YPT9dixvPfaNBYhxSeUiH2amjC4DogIwwqM~liX0SZneKCoIsBbbgLPYDBDZjoCTkndu3nJjfuu9clpwcKDAi-mAJVqL4kKrE28pwM~EvyliEZwKWuOC3f6ClDZpNCpzjonbaKzfkwPFYk8NnKMScOz7NK74twJbscFGBCsA0LoMSGnmdHpDSdIsieAfMwzwDakINQnpmquLPRb5tSJIJMnhud4vBohYgn09K-brefGH~UzsJVYS2Ep7dlT7WYs8WHNBHc0YXWd-h1DOV8iHS5eyMl7yAMqmoPpaNLvd6ibz2UBB5ZLoBczWPg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=default, Icon=Off, Responsive=False",
+                    "description": "button: primary/small/default/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.766Z",
+                    "updated_at": "2022-05-09T18:35:46.766Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "876a52b45742a0d5c94f4b7f66b9c75ed81693ae",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20058:11420",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/cl5/MEg/LkBHer5Q4irAgzbb/component_thumbnail_85.png?Expires=1655683200&Signature=bxah7JMkfcswbeKAKbyLf-o9ebWbeSlLtStJfAHvx0GbvYIfFnsTO1pF~tUee64cz-nmP1lm4oRd3~o1hQvXmTQnrz68Kv0zaiW5xP~G-B8AkhP0Lk89t6F1JrSLB9dZaAezI-L~dKlMJRQAbPcYb0O0sqMPXW6axtjFM~MBOUWraXUqDZLAMiz4GezkCVLbPLZPVMcPCJ1q8Cwr6xlc0l4pp7X1xKyAQ3Il6RoZk51ehVa-iGpevdkpUEbxF77yQk8RcfX6ljpPOSJjt9qJvYTPSMbo4HEnON-X0luXTfCWLUFKAd1N1ygoDap5Jg-KrDa8iyNXE9H91vbreNkfWQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=active, Icon=On, Responsive=False",
+                    "description": "button: primary/large/active/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.760Z",
+                    "updated_at": "2022-05-09T18:35:46.760Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5ea7146de3520a7d00c3b18f8d799921d51282a7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20014:12925",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Xng/c1F/CBWJ4VLqhY9jAujf/component_thumbnail_84.png?Expires=1655683200&Signature=hCtF3zurQm5nuhfYYfYFzw2KTE7GkWd2-MYjmHSLLSWUMKO5nPA7JzV2Pknhle9~FBSTqc265ARLU0iaJPmU3ehpLjgo7NFEk0UeEI7JK1jlgMZe7xjOqzVkuam-vuN8zERA7iaY6LC-LQ8gNqNMOGu9V11ky5jmpiQGajTSyRCatVslUgmoSXZgMC5BEd~eI8hB5vEQ3SQrB~D81PSZmrMrCFAjeDeLIjcQDEJFMfVVyfw83my7nPggkThpp~yccd3gaExycrQ-wowWRljk9p9-TKkoIlPyOzzogaYfPZ2XM3Tb71GKIM~39-zmPeoI3aTvy5vaZ10S-fG~Qo6m5w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=hover, Icon=On, Responsive=True",
+                    "description": "button: primary/large/hover/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.755Z",
+                    "updated_at": "2022-05-09T18:35:46.755Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "37f8758520f7e329e70c78caae2cc92a41cb4ae7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:12566",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Md2/ux9/VN3AgfAiP9ng8ijx/component_thumbnail_83.png?Expires=1655683200&Signature=gH9OIZhyYRD4lbkx~L-o5oNQa3lxe2hYH2kn-YDhQTA-dy0-reoPqYvzpa8ydVVS-LtxYmHCRw6L-2r~~xXtCn1EM3Hdo3C-ZUKXS0KD7tI6KD6q2W7DHmuinCBCGZUbbmHFvivgLod-Cl0LITeVmb1scVB2YPr5S-UKbR~KYXlPps5Z6TSnq7iqWlYt9kHvf~QB13DBaxgpuKVSckOJip6TZHH4MVydr7zrVAI~kvDrCRyxaZXCisk2YCR8nJjB3-HE-90leNw1lszR5c6R2iKrJok~Hp1rfbeLBMG46UPI~5CttRmNuFtHu~H~OXpzmN0CFtFmTnbX5~IdfW1suw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=default, Icon=On, Responsive=False",
+                    "description": "button: primary/large/default/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.750Z",
+                    "updated_at": "2022-05-09T18:35:46.750Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0d67f55fc4709d0f38aaace6e4a36d96139499d5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:12556",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/LdP/Rgd/w2hBomu2mwKE6yZO/component_thumbnail_82.png?Expires=1655683200&Signature=Q7IsTiRRx8Na~26~qnhObVmR2-rj08MvBwNNDRqFGCA1o5~jvtW4UizuwTr6Cm7H4tlPvhiJmZB3dVyjC~ncyRAPcUbC9MYTMP1KajQDfBfGoPZZWX7oc23fdvu4oxjhVX2N2cjvHga3v35Tq0-X7Mu2ybbp88U-ZE5xZN-M0dcAZduL2NMewy4AhlTh0H2ng0KK9aBTA15kfSsPFFtPNUTK5DXEip990R5BQRrkurbSUBXwVUIdddgIw0~8kV1BEQ-c8CLa8Save75O6aDFsy6QcIfTOoNWG2SA46PGGjk4apTjXppTZGp-IX71rQv6yTBwL~nf3exzF0h0mcW0TQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=default, Icon=On, Responsive=True",
+                    "description": "button: primary/small/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.744Z",
+                    "updated_at": "2022-05-09T18:35:46.744Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "987ede1714a29a9b63f1dbd87b462767caa1b2a5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9644",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/BTM/okd/ON7VLRrHMyJCmjQn/component_thumbnail_81.png?Expires=1655683200&Signature=hdz5Bmx5gWMutdU7uE20NPX8PJ9j4Dj-6hz4AJfDVZoJwmAUb6qLTPYtxStz4uAR8vulsUCaVqyy8TPmN7NjvltKxe9cBOH2aqBAWJOh0Xl3WiZ-bhFE~iVKz70DH5Yu5swBZM33rj0gnTjfUcccr-emYz9pwtlQc2~iJHrPzoMHa~GTX8jAwFUvK7JSjdi1aDWflHK3x0d6Ub8wgBcj7nDEnefICztQUjF-Sj9tLA6yf-r6oRtnSuXEGKJf9DlBdW8CH5BDFq0l~NmKcTaqk2ZOS1aQgIFARDzkGr6UltbZdiw73DQCjcZLFzqjaMFRjhZ2KO13rChUKkB3E2gu5w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=hover, Icon=On, Responsive=False",
+                    "description": "button: primary/large/hover/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.739Z",
+                    "updated_at": "2022-05-09T18:35:46.739Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3f03cb8243c045e602ec5354e77467a14b10c633",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9680",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/FKt/1zj/7TyRHWWVL6e3a7oI/component_thumbnail_80.png?Expires=1655683200&Signature=DM0M~tskOnZdsFLrKetK7EZgTSyBqF83GWGOO47a3kVJUIS2jwgjMVAxRz2lRuNz~pgLqSN3t9ncMyhRabTkIpToXKIiph3BlOc3hj9-P6KrVsoCUwZbz77nBy7~KRaXX~BFbQdbeRbY8kgW5aVVPm6nAZ7ZUk9YbiCpcQqeZ7BmmXnwywGswJZHpY3GpIwzjQapB7lGYPcaD14A626nll~ya5f0O8tJCCwkjj4iMX~XD37bE0kLISb~i-PeWdFSXBHG7MmUoO4twARa0OFGVU~tsq4tn1DPtGHYDOkq7mcIJG7h02hDv7GIuAQlTl40yLDKDgPC5O1F6kT2oXASyA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=disabled, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.733Z",
+                    "updated_at": "2022-05-09T18:35:46.733Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7fe8a2a0111e643d66caae89613aea467a2cfa5b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:12562",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Ltm/9ZT/HtUsKr9A2czplPSx/component_thumbnail_79.png?Expires=1655683200&Signature=Bydw9M7qB~stuCQ47-12bC-cIcPwKMcYchIjJjd3dkmF0gr5QYAmhhWtmcst0fTGQ7U2r5s6K2mpY0YBZw7Ftq3FKM8ueoDElMxUFiZ9lIBOHLGJUEbuzlw7O3jfKyrj0Pe8klLgWSmvvmeB2ebV73xMwilkkf~0R-UfYxOGCY1scmQCxrMmjYK93xb8rrcMF1q89jrVwiEWp-DkO8M0Kn-4AFSImOQE6Z8PzA0Sbc8IVtAd4QzaXBxfBozqNhAu9TR6iE3CDqoxqkgziTpEjAAlIGYvMIkSU7ShOcc9r3bRIYN4EJepy9R5BvyWLkFJV9gEx0PdVoKkz3VCk5g7-w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=default, Icon=On, Responsive=True",
+                    "description": "button: primary/large/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.727Z",
+                    "updated_at": "2022-05-09T18:35:46.727Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "df204f48b6e446a85d5bb3da3be4ef3cdc82e119",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8636",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/JJZ/7kr/9btrlcgRat8gQwY7/component_thumbnail_78.png?Expires=1655683200&Signature=ClxS0035VYACA0tzmR19j21TZ1t0HQWuwR3zB22XKE0CtFqg62DHbM~HLDSsYkpQHpEgkZWk9nZ1GiI1Z0InzxaEF0WMQJXlMOdJlA8LYzNP9hkpBHPnM62z34REf5byWBwdcVSbvMUgIk08n8ihyLLV-5If1LlJxnhrXfU7l~fH-5W~ShMRDQjYnP7kQ81ClQTzSbsMpcE~7MGcWKFzROShv3Mp7XJ6Qrm1HqRsJBsMqMyLZqP62w6K6636KfVppJTbLSXKP-ubUTu4IbYsB--IVUyo54uYPjbC3JW40dB1IRa4EXzlnr9GtqIsPAv2k8lcQGEXxs5-pNkIf2ctpg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=default, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/default/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.721Z",
+                    "updated_at": "2022-05-09T18:35:46.721Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "53740de698aa5aefcd63c55fa2d95a6b5dcb9352",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8654",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/FMz/LSE/kYAYXUyeAssxuJjE/component_thumbnail_77.png?Expires=1655683200&Signature=ZqF5SSH0k8t5cVu7VLXrkoK9aJo7o58sxJc7QbUPidEQDOxT8Mry-s0u~5bkmXk5dDmpyW0OVib3cIpBq3LA~UjLsDpl3e0oe3l3BKXrbX7aY7Bzw6lyyjnJHN9eLX23Cg-MZse4u4pdjEYs-4H20nfwvvyjC8NhiLjdHhYjPg0YpBBi~g~ga82JaiymT7DYNv1OArkToFsVyU~gKC1J4UlTtGLuwJ6-CZpVksoEiOmFimA6mkmjBU8jDH4Yk-rrz9GETwkFOwPzd-7Moz9m40tRGCs-ZPcgEsRMwbzZFxQHlcb0v53Hw61HYT-QFi9KvSnMHg2o-wpFwncLCscU8A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=disabled, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/disabled/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.716Z",
+                    "updated_at": "2022-05-09T18:35:46.716Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c7d1399955bdc752573df12028d7aea94cf18d66",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9660",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/H9p/qgZ/VGprKP2q7NHPjlWD/component_thumbnail_76.png?Expires=1655683200&Signature=GUiNoLwPJ1o0xIKpOJjCru-~iTo4EdTxDJy74rKDPtAf3RvwBni0X-QYt4imI9DxcxTGgrF~6gxNL0IQzW41adwjNHtzwE-45bWLwqrZVbJal2hQOKSDsdx3T0VJxrTJ0QWFN1ugWlkCPJJK5tvaarwrv8FZpjbAN8AolGSmnqJjkH6yWR-U2nyi8YSDgsR98tU8NqwFa8HhIX0HLB9dBNXXTmKQNwWtZzxlhT8Ct9M4nLsGEv2-qulMnQPxjuFTs0X67bRJP1ZJQIIhFNGSFnGhiOFOgIvXjn0sCSxn3qG3g08SeCSUh8Az-SPp3avhVtVdECB1WGT-wfPODiDQCQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=hover, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.709Z",
+                    "updated_at": "2022-05-09T18:35:46.709Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4c493f19feceb897dcfa5c16e2dbf3ca8a0506e5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:12560",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/pWR/XQ5/4exDRmu8y586Kot9/component_thumbnail_75.png?Expires=1655683200&Signature=epE5BrBY7ZkKQpoHihrnuppMgxjSM2oy~juQgeqXb21Z2u3adZQmc0vSFGRxy0ZMG14Zxe6rSKpi7YInxni80TOQReiMReSCgGuAAVXcQ-Pndx~Li1RpqeMbOz42KKABG~zMVtT6WAd5flZwPIKSeaSkwuHAt9MivUXKLkCzLETQQyQeos8PFf4Pz7OMulHSTak4LawhdPGsn-Mrvza3-wm0tb0A7kho1VKmV5MNj7rRkq~g31kK3VekOdsNd55EJDpF0Sc3vh99ipxBQLQfkgdDRM7U7-jQlDVm7nGkRd7UoNBhaZOFZmONZn5uGa-wtvN6fUKl~lknxNoa2LSo8w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=default, Icon=Off, Responsive=True",
+                    "description": "button: primary/small/default/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.704Z",
+                    "updated_at": "2022-05-09T18:35:46.704Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "53a399c6ae96b4a6f97722e141546d2ea08934ae",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3374",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/6j8/x8j/lwPuPY8xC5YOYUtF/component_thumbnail_74.png?Expires=1655683200&Signature=QqilJHQysT3ku6dvMIFJqCu3-jE-~7fBAM3H3jdKDrhrIl9jyh7NWQ2bEEzD4BN1vABzrGBLizQZxTe7r-bMvHDhVXCd-CqRTwC8VUdfVqZhkIN1NpnoBJQIFHjBqd1LZbWsndaynDyru-Rj4TVLwCqtHZ7wVtqRl3pXFvZy7L9kBE5HxkMOzsxX1GhdCZfCa~NQXDgq0U87V5OsFdHzZOyp~-rPxSrq43RqBv35KH50~tu-Ze6elJfStWmNAc8jVGp6LmKYsvOl904zOKl6r~qBsKFmPsgjbxIUEXDjL6nbYOUEtnFjnGK-9vqnart5lcALkGfZY8OXcAYBNk0mwQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=disabled, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.699Z",
+                    "updated_at": "2022-05-09T18:35:46.699Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3bb7f37de5ee751b0b10d9d674f963cc90f7feaf",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9626",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/2qz/Z4o/veQDh2WadIbWV12Z/component_thumbnail_73.png?Expires=1655683200&Signature=O~mjDS~3mtReXkb9NVkiApnXd0uuwTK7kh5G-TXr0Nl~n4JV7sgrE47bZU8Vdj0Heg56S3lC9Qk~pVJJrxMZIZPSJJZ0NWq4QEN90CB0p7HGptfUGRhIJcq54p0dkktndHnsZpSpcY3s338QOI45N1d8334Pr9MP0QE2bVgljZiaBHXw-E-Ga0c7FGj1Vj-Hi5b51-m1KAMfk5PoaKnk4~8RWb59vl5qworKw9zbR~COVheotoYAFItEYr7yLh7c~WzHe5QiXtREtYbdhxot9vFPFVQ-sCeR87ozZZgIsIJDAs~rTtpkcYshxyFi6jKZd1zWZMTj6igZBfYFjQOE1Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=hover, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.693Z",
+                    "updated_at": "2022-05-09T18:35:46.693Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ff0e0d530bf2e385e24d5ba2da29591e0421da81",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8648",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/nmm/FYB/RvAmppXfj3yjf8MF/component_thumbnail_72.png?Expires=1655683200&Signature=dE-0H5zJIJ8S8liTo~aevntL0nDWd-DgrKxrIKtHwZ~tSNo71Z0zicUFZKHtKaYFeIezzzPLUldM4yPSI1Ijz9dEPxUe4d61SSVVkZud3uPeH2-DxnchRjRPuWNuUJoXqHQ9nJpCdDsJdRe250Kdg2th-NfsOvAatOFa1YPfEEyeeHp6Tj-OWATJmZ5~pw0vEfcH6wjp4oODbJ7APpYS~7pN9HbqAF3KpuJNiIbGta3ClFdQC1Rnl~FgxSyuf2w4v9XLZuew8aOSTu5BDXBWIM7-u0bftYK-77UYxTAcomV9qHI9r0G-2Ra4dKoEVlXFRfjMFsQSFoIC4~O~kW0nWQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=active, Icon=On, Responsive=False",
+                    "description": "button: primary/large/active/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.688Z",
+                    "updated_at": "2022-05-09T18:35:46.688Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f0fb5e9b988202b19565c19fa280418f21b69a6a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9716",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/tFC/x7S/yoYgiWGIjAf0aw4m/component_thumbnail_71.png?Expires=1655683200&Signature=N1D-KTkdKdE8A4PZ1~Z3yoXMgxNGz9a8wnfZzumTiD5of3wzZUziBQuMILcuMvTP9KsymtigVgS3h9CpeHwbfXq-MBOSV6kG3lIJ8Y1G5f5LD9hbmgHEU39VZTRC7tJyr1G2Hrxy~Y9bzwVpHqpq22p-yyPzGaz~xrHqqCalBX8koXdSqBeLF~kh6Zw8KLH7sA6nxG8Ju24KbVT0aa~RuGM1Mhh32mZwyw8xlJMtP9Gc3qcMbKwfcynKt5qHthsql7PDLuynHxrlLWMpxIc2dedyTmelk3dTQKEQCHYFfVtCRear1w4VWT-5oQVhQ2QFBtO7RMeC8r2~iVeKV9RC3g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=active, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/active/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.683Z",
+                    "updated_at": "2022-05-09T18:35:46.683Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "db79ae7c2a996e5c33f3f4f85ae27c3eb810d447",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20058:11402",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Eit/C5I/aXU6I9aUJ6mHC3CL/component_thumbnail_70.png?Expires=1655683200&Signature=JnwjKtwLPOeLelxhnRCg5hRDhaHQpgtPnmChVLkk3W5lu-mrTPuYqKWv6BOLv-vt~DJ84vJ05U1zNm8uaa0OwOwJeXaIoqGenUc8mzVwUrNI-FObkjDma1BMGgQs8eXGyBg1y5vat~qQ0Bm~3DI7XlyQb5TOczkIL7SmiyeldUYxfbWeqXl27yB7QtGMJ6l8rhfq9ToOzB6L7WCvVKWgyFMNs5~IWHHAiffhgT1oxlSeK5MVzunOPjE7GwzLIadslkqNcsRO0XdrGB8QjXnFrKEKpMQi1jFsZJeZi95ynltg5FkEqtKTodXR61Fc0YF3zHpLVnKetlneymFzlyFPwQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=disabled, Icon=On, Responsive=False",
+                    "description": "button: primary/large/disabled/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.677Z",
+                    "updated_at": "2022-05-09T18:35:46.677Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5b26696626e2485defa63ad3fb8aca0854c26ddd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20058:11414",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/d1h/RoP/TFukDywIvVcx1Xjz/component_thumbnail_69.png?Expires=1655683200&Signature=KWZnOqk7L4wR8bXA3RaYsj2fzhlikUU0wFNOflZfCUY-cseRgabwFfE3uZNByss4S1IJYk9rAkfTL2CojkSU4WLDFkZVoBq9EHuiYczviIwKjeHYXoIfzhXoCqtqFHNVupv3t87yWZmMA8umUISxx3352HMupowDsoiNKn6fkBqZJMfBCR3O6MUZ4380WDRdK8RYvsB8mENtn2I7UpyO7Da2RgoIsSQGfUs9hQQ1K7uS~3UhzCAbpmj44Om5rqfqmvD7HBY45cWODcfsxxah3BVsXmaHv4zyvYfk-fmHolbE2zTwY622tfbWr0tFQ-Y~gefPdDHpf30hULw0lUTMrw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=default, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/default/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.672Z",
+                    "updated_at": "2022-05-09T18:35:46.672Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "acef103f8da18e46b68beb1d7748e811cae4ead7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3230",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/EF4/Mh5/Hl2UT6szIpzNjHd2/component_thumbnail_68.png?Expires=1655683200&Signature=PXN3oNq9~txzWr2z73UpnhKJMLU63qA1~DhODlTy-0bT1sUDHFQTi8gX6fc9n8zhaa6J73RXQVN8tLoesvt-NACE~ARXnjQZ3vLectQoy70Tm4tU2MKOmugZAs5DZJduIMCf184aSTo59LrrIddQ8-UYksgbkssgt21rzBwvE2mVDfPBbjloh1NHuQp0u1H~sC~d8qeBOzWVLQ-O1pd1clqWR-6PYQ-Vmlw44t~T0I6eJsHe3PAp5DaTIPTMJdjwxaH-iMOW9DQTil7qbA8mFLp0lVob9YC06XrK9S4OUYk3m2Q93Gwh3m9m0yfKizWAUQRYByCG8RqxGWHiGSm75Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=hover, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.666Z",
+                    "updated_at": "2022-05-09T18:35:46.666Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ba7935f73601d05f0cc726ea307bf49793baa975",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20058:11398",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/TZH/8dw/ajlD14EkRHTq0nLv/component_thumbnail_67.png?Expires=1655683200&Signature=M~rOLeUWpE0HErB2Wj2Svp3wVZsxg0FmrDbgoNPOfnQe5i-MOLNY6jk~4BAr2yKUmC-e9Cn891W-joTM3C6s1YB0HZcWhMIcmqL1B1M4-99hM6uKhp79OWo40afaIkZs-~FS0nyJq068LJ2RKhti7eh52O6ReBac0xpewfPwOr~AyulRB3K-WfX-5k1zwP8hDvPnzS5zqi~dNJungWnZ525pnIUBYYdnJHJcDG1XnOT27yVkc9rixhm61XdEgyboeeIkPpACnj63kFqRjXWN5aPKqvmXFX0zlVxXbLrjiVXTjkVgAKRkcwfAn1bhaIqGmuL1f9LTxQnIIcZiEL6ADA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=default, Icon=On, Responsive=False",
+                    "description": "button: primary/large/default/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.660Z",
+                    "updated_at": "2022-05-09T18:35:46.660Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f93f97ffbaff38ce102d7d079a72b861e69846a6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3376",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/VsC/GBv/mvih0YuapGPFg0ca/component_thumbnail_66.png?Expires=1655683200&Signature=Yycy~Ad9YKw5L-m6gWPPqyX~R6tarLehT08TP8zOJapVp9Mkr9aWp-yPbQEPmJ6I~3eX~pVzUlcj6nMNq4MjJ3l7aK2ZyjuYtadPcvZFH5zCZKlcD~feuzYAbc~OHUSUN2Pfe-12bVihDQHGIwsrhcyDBdJqwZ0Z8HsRfVGWC~~waaEKHMnzBjanr6X9~VtSyWIO66zY6W-5PLKKXRLmsescEMi4rhfP4CaXixHRt2WygOTvGcLsCWsxhJuBrV7p967c1RschmvIFQG54z8wk8eEyAYi~iB81gS0DvQAlT~N2Vuegha-KRLya7aLhcvrOTP9laNcNaFTZH~SwDfk6Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=disabled, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.654Z",
+                    "updated_at": "2022-05-09T18:35:46.654Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ecd14c3aa5bdb92064cea9bbdb29bf40c9768e4b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8634",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/OLc/zVR/1mFXyA6Mf1hi9bKz/component_thumbnail_65.png?Expires=1655683200&Signature=ItR5QVIaJkf8TwoBe1wQ8s04JEfVo99IriVkn25xTspqgr3VfSO5RzWFdilx3VzoYE029vN9qt~QObDFW3nVc7tRhsvQY6oQ6pgsiN10nScJ71hcUWZ4TWp4MKvD51ebbsf5T-zqE6sqkS3Nx5rZy9P8XQ86vfeMaHRbluua92ZLfyGKKjYtpYA~m1U5Xce9UEuG~xkEVyKz39ozukEf1JYINARmLwUr7CVJ5Z63kenlz8pEg3RFTv5RAx0Gep9M3HYsRgCU0mbWOugnU2lAR0Tg~5PR6EjgXCiNIiHs52Ow53wuk91lZuxViDt6dctTBn5RNbyYeeQxYRL3jMu7ww__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=default, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/default/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.646Z",
+                    "updated_at": "2022-05-09T18:35:46.646Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "33d8a7809b7e81df5287de699c9572ba2828cdb5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9618",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/HS7/52C/PJOYkq9PYaWa0LZm/component_thumbnail_64.png?Expires=1655683200&Signature=gk~wnpVfFPuOkmh~P~CxcnREZGNCO4m-LTtbSIjDHh4gVLugi8oqtL2dLD6DxIwK9waP9qxrsAes1pk5xgrjmDVrYFhXxr93u27b-nDVEXg9fXhuxI~ct7EkpCOvG3cuOnZFSF416evTJr9jKvVaB~SHxGK0kgyWwYmFN1DvSJ8OWfD8UArAJNAvtnn2NARrmLxawJGGhZp-NOwJbIEAKmffyfLMvLInsOouMGWLiPMSlsmlSsmO6rW5g5OoosGwcePLmghglKmjCOsTE7TOkwwFwhojOZWj3iv3-J88VOQUmtYCg0H9CCuCeIkhjnca-igUhArfkkOpZq7Uxe2aMQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=disabled, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.641Z",
+                    "updated_at": "2022-05-09T18:35:46.641Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "78789304e0d606cd0a26717a28ae70c41386c3ad",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9620",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/GnM/VAp/QV7brCiFdmZtZp1p/component_thumbnail_63.png?Expires=1655683200&Signature=YoRieF-P3Vu7pjN5ka4LWOWo0JhWTF2OMM2Fcisp~Dj8o7mVYMDYfoVacThKW8ack71mtDtCC1iMbLtjkVZCML8h3w-XbcU1QaCZxC-bPJT4rzc8kPS4UwYsCsOMM1RWRF2A4lzZ~e1936lZEVe~BtNtMTQHfIyBNpOCzzOLE4F9ggMQT0UGKDrbUIhlfA8CMuacHcWxBdE0VEASYwtKkTEL4cFJUCpEWI0s3w3jqmNpuFc1ROXR9XvHFjOifaOfbCtNPRiP5fRy4Lu-VwR81d3QJ2fshJL9yd85jDPU0JuooH7ksKnzvRXyQNsZ2IMcHoe4FpkWDQALLK8XPp-rJw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=disabled, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.635Z",
+                    "updated_at": "2022-05-09T18:35:46.635Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0ab1bdde1dbb459ec484eb8199a07a608395eac7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9622",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Yzb/Wl8/rWLwaZvMhw5Jwhfk/component_thumbnail_62.png?Expires=1655683200&Signature=ca7oWwbtRRYzomYyIgB-Ar7TSL5cp~o71Dk5cNRgoK0AVkHBEg8CZ3fpNyiBGAvyZ1-veKaA35sztjdcRUWy-cBz3Uns4KpGpcD5dZtPUI5~4PaC5NJH9jpIn9EVkK9YG5gJRjbrSDZ5E2RW96OQxUHyQYtHW2Qci4EP~cHeXOcdXi7MAFwRqHB3X~l1BhT0DVIIurORw6nrBJ9vaL30yzpolAO6nIQ9rdgVA3Qv70W1llIxvc0fQfk2f2cAaIGrAdRm36zpXbdfmTYEtF1~vF-pJsSdh8qpoZL1lQujxKuM4ukdneulH1SUDka0dgLtoAr-V5dH2cDOm1n4QY-hlQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=active, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.629Z",
+                    "updated_at": "2022-05-09T18:35:46.629Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b6ec4da07aa225ea8ecdf56c06cf424ac895d02e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9648",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/3jp/ytn/qzTEkhIH0cIzPl1h/component_thumbnail_61.png?Expires=1655683200&Signature=QNgm12rJ4QmJNuu5N61YWs3bUas2ptO-XXjlQemcPGDCqLIDK1cA0vnNdxV-pzC2srUNbi9aCg75PuDlxwn94KGHOG~CmK1gS-AHlu3xf5tNpLLxMBUpYO-u3Z0rvHaK-PPAGmApFb4JuOo2jNAK7eIcHRO2Dj3pSPIpJBZpky0JEndco4Clfmm8vtGV0Mh3FL6afb7lzXgnUrc2wRlqaQJNXDiOOmpvOdp-12ScheKu5JeKWbj9sQwhtCsZZVQe-d0L~6hG~w5SQIyMoyU2eAycSflN5jiXyOgCpNXUrXSWxOChRYtT3lMTGVOZda69KMxBrYuffhtPnaqD~vinDg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=hover, Icon=On, Responsive=False",
+                    "description": "button: primary/large/hover/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.623Z",
+                    "updated_at": "2022-05-09T18:35:46.623Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2c0ed7e59d33bad09d6a89613d2645ea93cf33a1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9634",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/TbQ/EbP/eQ3VASUH1xHApNTB/component_thumbnail_60.png?Expires=1655683200&Signature=I0~Q0L3UJTSRn4UsCJxk5-obbUKNQ9X9sF7t2D7j4KP~gtJ7Zt63Y0bgbymgQN05a3MXiuDfUEagv22vPwet~Bz-DDph-Q6XkkH1LkfYmKY8vI8bVNbMme73kz98zs8FgBGc-jPi6Qgc8VeQuEEUkZPVN6T27YSgGzIeyYfmxnoByLalsg0qqWeop46u0IScP~H~CzyHlo0B7Rf6H7HyLB0iUtpAKFMmG3aAOUKIRB0JFouOCvuX9bM0C9ybQXI0N24l3Zl~o-U8~~pxESUMvN9lh7TYClO9eyDIDmILThU2SrCu95JaJZISPLjI7yN83NGeSa6VB6BB9DOr0JRyRQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=default, Icon=On, Responsive=True",
+                    "description": "button: primary/small/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.617Z",
+                    "updated_at": "2022-05-09T18:35:46.617Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6f57a1ea39765bdc81e80b7aa29a073643279bf2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9642",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/DZq/RRN/mKtXRnXHwci3rqWX/component_thumbnail_59.png?Expires=1655683200&Signature=QfvxmdSVfxO8haxjvBP5Z8wp-bz0Ws6Q6La60u-1gkgtaB0LgvBDKQ~mJXt-SxcwjPMgeEtdDu68-IkeX0MYo3whOVcvxiBj74ta4yM9X73IhBW2xzVgZ2ItubVBk2InFddnP16KtkW0PoABG34-9i3aVzmgmq7W-QKI4uZjcvor6yACaYCx5m10UcBN5KGu7CKlN3VOAf84Q0xBpGXgIL64z0kyM6ya5XFkHgvTGxowJ8UXHRTOm12vFtsQE1aD1tmdczABdN~7xGnwxtjmge2IFQ8cW3d80ELRv5sCneprCeRU4OkpE50VA0LcCqxUVQoBaCXUctBpc0NVcRdNAg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=disabled, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.611Z",
+                    "updated_at": "2022-05-09T18:35:46.611Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3c68196a1fb3df625dac0656b01529aeddf715b3",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9682",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/JvL/jiG/dkdfdeocdb6o1a8O/component_thumbnail_58.png?Expires=1655683200&Signature=ghwKri9kkdlVIoXDv0kJlTLpPSOh8xKEXnN9cApoyh2G-KRBnSC0e05WPeGlYsCLfW2HywBMON~WUC~mGiyZ~LN7dzIE1rfXQDGZxdKtvIEF2x1BMgNpSc3u9w52N88KiexzZEPiBUBJqdseHDlKd9bZKiuttOGxgsXnHyeEr7k4ZIth8faU3Vv~1BLESDa0pKSYARSTDmDit6gNc9jpzCDCBcbwPOH3ifmMl8KNDh0YWPcSGuCXzZL9nhxGhXrtR~4XkNNSmfR-g43TeuhDC-f2GJjWK7LNxQ9qX90rsLPNu6KTy-HvtSSw8jcAK5DXZvMhEMnsdkk716Q5dVzTzA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=active, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/active/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.605Z",
+                    "updated_at": "2022-05-09T18:35:46.605Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a4b3f8fa2b24948c8cc1daf923d7b4601773f851",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8644",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/baU/0HL/efIOJsr2BPqrzHCB/component_thumbnail_57.png?Expires=1655683200&Signature=ZrLh5RpxsowSt0XNQULLZetDOKGZK~WzYmI1UNNekva6vvWNWGM8-eD8tX56~sq7W8JVtF6HKdpZ5bgT1nQE5KuYpJxpLGFwJQPFWrltL4KY3x3VwDuj7etvih3zfaAEI4VVBoDS-rjKs8tXTYiyvLVKzXRXime8KyWqPVpyihE86tCCT2U4iwn-fqa3~bZ4Ai5gcdxYiXxsDyNkr7HjUGXJi0dQJu0GEKAZqqO~aP4jC0rx-hmxB3NAe8fOQagFlCPsAHbBBJSFY0Mt3Prt0mgmPBNNMuXwogtFHRLa2OTT26inHmZsWrvZXamw9V7DyWu4T3W0IbekjO1oKEjWqA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=hover, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.598Z",
+                    "updated_at": "2022-05-09T18:35:46.598Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e7a5131293334a8b5e889eeb140e7b74607e307c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3108",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/oqz/US7/gZmZ1UfHu5hLCjNr/component_thumbnail_56.png?Expires=1655683200&Signature=SkNNEQ1kZqCR9SNdv5U48-WyMguMBehGrm1KP3J1luBODQn77FBeXDMPtpriBJMMS86nL436qheVQjlm7eT~nRPCElXSKQ30yC0WWUrRwc4ukiIQMQa~jrordO2VAL7ZsR4jv8i96X0cp7GODH9qiKZaZA139tSSJ2wa2AfhNl0vZptdtQvSqsdLhfA2nZy81bu4kLjHb5X5IBAI3WjWy1zkDIk8hfw1y1JPNG3zjlXdR8jhsiESw9gmV825A6mRg0zh5SLCq1kROCZ3xIJ1H4GFb2TzGoEV9SiNOkXX7yOp8lBABbAcxwm8KsisNAg1oA3etzt~B8uqpCOV4hFhSQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=default, Icon=Off, Responsive=True",
+                    "description": "button: primary/small/default/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.593Z",
+                    "updated_at": "2022-05-09T18:35:46.593Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "adfd7688cd0da17bedc65e565b3ca2f0013c8aef",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3135",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/quk/dgR/SzqzvaXFktJLeNqe/component_thumbnail_55.png?Expires=1655683200&Signature=Ho7zbxAw6rVfgBTCxC9qQN~kDhKxLRwYa7fhGVQ0TX39N6B5Y6qJHNL59FSNFhKbBm5fG5zwxnmNu0CJ9samGyZ7fMq2AsQnY~ouElQy2qQKHRlh27QAa8sOJjLkTl76yEEdTkscKSH-IlKUuEeKCJsq0653hlscxciNugoliK4fkzvqXijOd2Y6vrCH3Y1atN5SPwzXW4DtLQrhF79JaQfe5G0J6pUC0sNU99gL7ZT7OZ4xw1P2HBnwrpdD8e--6i4HgfKSF~6GhXPSNFCLxeYWWLzEL0Zel1Ieup3e~~HKHRAaWj16UnlTccPtmhoJWFyHEE~LrMQzapBsSULyNg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=default, Icon=Off, Responsive=False",
+                    "description": "button: primary/small/default/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.586Z",
+                    "updated_at": "2022-05-09T18:35:46.586Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2ee1c714678adf526a91d8d8605ea98c36403c77",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3370",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/cDW/ry3/rF3Vespm0eznSDNE/component_thumbnail_54.png?Expires=1655683200&Signature=AWkEy36L7LP7nhS36400WRhjz7j443coezSuWKDfhC0CY77Iioc0M6ELwcMmQwZzp1uZcEX6zdQeW8vd6kgK5DUYXo2Tqn5bsrpLDsSkIhz~eUDxLIdLD3Xf3h~TqnzTp9BnmaWDKmHhUxCdWuSTAZZ~8xYm9HXg-UFQEoy5~-GXuD~Cr8x3tqzx~T~I42uzJ-SnsGcupxAsB1lOWWK1jVp-UVEB~DS~nkCwKD-ELhty41FChn1YZ8CfvyAeCXTMCbWcCL9tT09fIsg4TfIq6kSqUfVnWT6m1HodTcUoiPwvnITxxUJEqtjQKF2V3LcGdtoCTlOWbA6A1IbMWMt8CQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=disabled, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.580Z",
+                    "updated_at": "2022-05-09T18:35:46.580Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7fd2176a8371516ea7af64f173c8a777b2a701fa",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9696",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/jL2/KTR/jklmPq0Ds9Bfyp27/component_thumbnail_53.png?Expires=1655683200&Signature=EpQCWy4pep5hmeTNT57r6wbzN5rbVSuoy7rcnUyFlaCq7IXgTl1vJLfO8lRpfULDHaXSLplDcqUqAtxueBM7IeZXsXnFA1SEEn5ufgTfvREmU491RcTdmxqdhDnHYPSjdJR9x1KDJ~Gmzo7icsCMTgR~bWb-MbrupNTcxsTXODFHhwm1TVq~iPmCD6bMYbItxK9j~yBloJNNaqwzkiL0Qq2YVkFXHO6jTNKvXaJANXiSqKNKz4ph5I9Lna91IAC1tbwb2vpHAP8XD4nr2wxBU8oHYIqkfGsFBjv6FCfTsXQFSzFowSZYO0-YCPA50yBiDfZNl2BsYSY-tzvq-eW5ZQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=disabled, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/disabled/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.574Z",
+                    "updated_at": "2022-05-09T18:35:46.574Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e7271f93cd273da42ba69c4a407ad89813636249",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8660",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/1Lh/GoB/hyqg2Z2v0fGaAOUF/component_thumbnail_52.png?Expires=1655683200&Signature=Jatlcyg8RludWgYPBMFHTYDm6GMFa0mn0tknFozTCRQ2fy~nh0nUH4hOxFKpVUzf57JjXDkRlZXs0mJb478Ng1Xt7b5hbzryTpBNU2GAcJMOlJChyrB7Pks1YjBsyNcdFjYzskOY-o4d7lY1F4Umrd6YnVu1tG-sZ~15HRkP~BuVznQ0iUyXItunc59Dh9RpmhFguqvNKcA-v2SlWWdOJnqFetr3F8PZ6qEqBVCQZ5xR6oQG~y4F8yq6X0h8~pc0srL~j-IcIk0OXBUKWtdyYMrENRb2Y2ZoC1WOIcq6uFThDsK1P3GhNFXEUq99wtP6ygSxD5CEp9JryzE5xWFdrw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=active, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.568Z",
+                    "updated_at": "2022-05-09T18:35:46.568Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0e32b7eb1542f013dcbe0bbb1f245b76fd0bbac7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8662",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/1qR/Gim/ccR0vtyJCxFlF7rl/component_thumbnail_51.png?Expires=1655683200&Signature=XgSEI3HuvU8i9t8tzTvA91NR9LyFXgH1G6omb6Z7~wgnqa8DwuGiJRblVTzURxYcJP33PopuO5NPGDeRE63df207FBpaFqoJG2ZWXb0EyiOZm3Ai307RKX3pnpduN9rN~OVlhJQWOFu9UE~dj29UVxQqA5Xic2MeStYA3ZNXZp-Ja8t1fF~N1sjkuN~LkSZlHTCUuO1HOgsrvXMQdQHouTgdhAX9~uJBNamnYerJkImxss6ATQ5FevrTMZLGYSRyrEecdjFW0WLB8X2bZ4W7z-mHLxlKIzO6-ScHm~1Dq~fia~E2rvdCAmbmvXmjh5fb27oR23zyQaFFnCX2hVp4Kg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=disabled, Icon=On, Responsive=True",
+                    "description": "button: primary/large/disabled/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.562Z",
+                    "updated_at": "2022-05-09T18:35:46.562Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "afda8a5c1f0ae17357165b58a32c264338b536e6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9650",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/F6y/Hlg/Z7R4eHEpDBo3La0y/component_thumbnail_50.png?Expires=1655683200&Signature=V6kc0LQGlWsjQ5KjT5bUGJ0k1YtcG1WmgYF99F1eL67SDHi2CslzuG~xUpwFQid1GxS1EIQhYu-mJ20Q75CO3lXdjnbCvYWQlaxkVxuS3T~sq4khzgcTb6qau7rJy8jICg76nPYjY338L8Jnd4866V9v5fjrXbhJxGjiCDQ23WenKwJLOstEvk19F1A~t3umU0W-wmsM2dd4ZCor3xEZPf1vb0BAq8bEENKPRPa61Tn9L51zAJvIWF3KaCisK~x3RiskbguNSwpruZ0g9xGkWSECLv7XPHShRqQrx5BBo1CYOXjb3O0wGkWtVJljJ9BSUoo3jHYxknqBGuLJkgl68w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=active, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.556Z",
+                    "updated_at": "2022-05-09T18:35:46.556Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e1ea77d627874b06f350f9b5cc69396fb46f2729",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9714",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/f9L/jHQ/BipRluuLejlhot6B/component_thumbnail_49.png?Expires=1655683200&Signature=Uo0bbiUFbXVeOsgLkdYvE9OinMoAvB-yhg0U0e0oR1Ih64qA17~K9TVtLq1zjh4q9fbsB4pZ6PyCajZRNeYa-tnxzr86oSW3ldZD6apBaiQA5Q8TTzceT-od7zpPaPFjY6TZuVtNmawYBylxBGqydcFPHpBUdQfchO3-YFR4JtsOpMfTiXUhEis9p3DQdku58EbKv1JSXxTDInvh5a9mKl9Je2wndyzGZf9OIWCgb2kTD6Az9p0QGOZGYHlPDDya67-rDjclgLpIxEQ0D1Ozxe2fDH6Wi0EqgOoVqSeNF2T5jHbogSd8Nk6pbPJXR4UYTgE5fEtlWYXurrVxiw4fyA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=disabled, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.550Z",
+                    "updated_at": "2022-05-09T18:35:46.550Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d31677fee4e8e598f480db573794be2560816f0a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20058:11400",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UcJ/nuS/APjAZD4YDzxDk9No/component_thumbnail_48.png?Expires=1655683200&Signature=KFxbfUBjc76e9BB12NJjypn18TFiZxM5z-OHlqE9GAVe3GH-HJi-imwvgirxDVfS56u7QZkDdMmGZdWniEOoBAv4SWX5hZ3UxzKtmrdIu2w3BuMwLxieG4q2aU5bjTtwCmKbkC-P1dZUn6TJRW3O-SZZF0s44W1R4Zuq-R3Q8ivKUhjVX4N6GoGb-pDQlhr-5OdxJjXZkJsLN07~7pIN9HUx5FlrxhKYOdbGiOEtdS1b4h5wEXCUcuYJj4ksA0K6yDv2qmG6XdvNss~YAJdYJ7UUP3GhFyV3gJOWAMHeeid0rehLKE8vRHoHwWI6xanXEB0IvyormhMfmRwBLHJe-Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=hover, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/hover/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.544Z",
+                    "updated_at": "2022-05-09T18:35:46.544Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c524d3fa4fbb7ee8fd73c2ed8c1f0594a920b0d6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9694",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Mv6/CeT/UvwzDlHHPvphtFVf/component_thumbnail_47.png?Expires=1655683200&Signature=cpq4eelnfGeAYXuSjvecMfsRw2tZiff5gOOsoFd2s~zc0xeMhW7eUZcFgXIiI35YLFFR2sHOyGseoaQvSHF-N4FRxRRMVwzNvSF-FUOAJ1~1cC7-UOEXYiuTz-LhcQIU7uUpEG7UoivpmA~6UmI1tc~1~ul5ioq2Xz1nacm21MhHOE0PTYlUtzfMM9KOuKHe4aAol-KAaY7umyhs-mBTyS8qe3H79O9PjbkAWUtp1Bfk9AjzDhFuusNXJSByCf-nJPdXb9pFm32piIg3qWOidyRkhuKYi5egeaHw1BYckIx-TVrHmpbQ6pPJPEGZWCyCtWT~kGs5ZX6TH-Q9mGpP4g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=disabled, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/disabled/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.539Z",
+                    "updated_at": "2022-05-09T18:35:46.539Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "479c698071f32244a6e72f81a15b8553068142e2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9608",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Lfo/I5E/g4I0ODv902iDUXi7/component_thumbnail_46.png?Expires=1655683200&Signature=FMIo8Q70PyOgloaoGHNIM4IWRKLssLfVVZDvEgG2SDJGCoIWP8TeL9XiRNGQAO2l8FeM3ZqGXvgUHZ3lvRdsiIbvpfvxrKjdNof~wDVzK47Zq97EQGzJWr5n3k~82etePxX-w1IDOzSR8MdR6RSUoUtYc4qY2tLfzRPbYwuJyl9QLGQp6P9JXuMZU3qLX1Nw8twYzkExwXSVLDAN~l6Aa1eQIJR5omB1zTgT9jBGSFRHIN1Egwn7nULcbwzYdt9vQtEsYoTed68hSuFRmA6Z3uuAtuHWRDQjtcT9442U-9KzUXrGnyw4i8PgKBSAisrqdgSCMC1ohcQDU6ffZL1CYQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=active, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.534Z",
+                    "updated_at": "2022-05-09T18:35:46.534Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "949ab26842db46c92a09bc2d72466cc11efda832",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9678",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9wN/IJk/vpS4T9HF9UO4T5JW/component_thumbnail_45.png?Expires=1655683200&Signature=RMrfOYqZwU9M-cLmadGYH5wWIPwDYrrNIlvn8Mk894-JySZB-Qpu1dGhAaV9MV7xa0V8ufoWSYKDehtZSIqasBodmwM-JYVnbChTmePEwVBjkASQSYGnXCqD7zhOZ70oLtLNCYw2mjPHQstkTZPPqEE9fQ2IUDvwCqAfvwIvI5KXpMYFs0JuvVRMEWI-v2~Ua1U9plhhUAX5UWxwBgraD3By~Aw5MrmrajvVJBCr6FTjRozBeJ4dJ8n7lb7FNGRU5gUFWG4p0xVTxgLizFsV6kj8COEiZB4e~Di84-wCOct3SdO4ffo-epUNFO2GkWZtHNBLMLSDrH2pYkDjxGMC~Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=active, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/active/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.528Z",
+                    "updated_at": "2022-05-09T18:35:46.528Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "023f8a4383c3a937550e022e3aa489705c222329",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9664",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9ve/LBi/hfziMfoCVJx13qnJ/component_thumbnail_44.png?Expires=1655683200&Signature=EodS3zMggaB1gLuNsQ9qyjRdY1-buxTl5pb1XWkhTHrGlVbYdc0E7~JWekvlvuUOzF-x5oHisGLm8Mgo2NXAXX3tv878aSpAigChndvzZz3efDHzPzn7q8ZzVIULIeLfyKepAbgOd4LbD-WVZ5vJYzpFEMBD172q~g~WcXeRonqJ6Udp5Uvlr4aA9sPnje8u97OOan3ltLetX1LLbXwg636LzPRW28kCVZGkWDKfmhNs6QhoHtTmnQ~gGDE-cTIFq~gEGYGfqlOjEBjs2RxCa6F5fiXo7tAnxfIwOdHdvXsYkLmUFVqjICAuCVg8Rd~n4sXTLtE2aQS0IA~Uli4hEw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=active, Icon=On, Responsive=False",
+                    "description": "button: primary/large/active/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.523Z",
+                    "updated_at": "2022-05-09T18:35:46.523Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "bb9fd426d2bc39e35e779d7ed1882300e2f20da3",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9658",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/vT8/jlK/IMUxve3kAQTzz8GZ/component_thumbnail_43.png?Expires=1655683200&Signature=HOA~jW3-JW6MuEGneUzink-xxsEqGsuFIWwNToK5gipw7Sdh-3cqGinPAiLhHKnPULHswQm3lRJTqIMj4Kvt9dtU8gf9btMNGxbvfm-I3GCL03S2SHzxe4Mm0R2nkMXwzuJYYs1PB4h9c3m5x-nsBMzQMHH2yc6OFzsvggPDKG1g9vyKZwAAh3su1fYz1wtD47baC2FW8VqMc4r1qL83-zI9HKeHuw1kbz~zXKFN9HL-wu6z4V0Frfz59U8bveln~mwMLZBqHExTxV8cQ4rulRZt3JmZXER2qaWRMXWVJ9KIo8M7fB2fPxD6c~pb3TWKbaYY-feU6SkH7KpgR0edHw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=hover, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/hover/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.517Z",
+                    "updated_at": "2022-05-09T18:35:46.517Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "cb4f1c80d57bcf70d503dff54db2ea8eb7b070fa",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9656",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/bh1/UHX/s4iQr0W8kVKCOpiS/component_thumbnail_42.png?Expires=1655683200&Signature=Agl3U9B56ghGtXs3jK-7q0PJHXbjTiwhWp8mq9pZF4aNLMHebrwqf6ChhldvmOLAeOuAXT~qh-JEUSNnEftIKveXTY~vXw~Qsaqc5vriS4-mIrBCT1pw3a5eySE21qoiCls18hUNs3X3U3G3Zoh0PwEpHSwZYTWfJmT88UOgValaTMsbOXKCiQOSbONvW7gc4vcEFeHPlI8nE7BJ4EaDzVRwDW~O9U1-Aws-ka0b8UQ5JSWmwSokxqpMjJT70AsczjVcTahqcDG680cl7Q5Mge7eMwXhKxUt1T0tgJ-A6g3MexPT7bRlfmsvoHyJv0YbUdErw8BaZ9qGhaKLcCGicg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=hover, Icon=On, Responsive=True",
+                    "description": "button: primary/large/hover/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.511Z",
+                    "updated_at": "2022-05-09T18:35:46.511Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9cdefccdd02d0b7b6c817fd2ddd6b216fdbf4f1b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8632",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/6Zs/Hxb/QNSZAi1cDSPT3wU3/component_thumbnail_41.png?Expires=1655683200&Signature=aGzSf36WykDrOrHo73dvYbZVETwfFiMEJjRFUvHEstHDfggGSY8jXSZN8Uj-MuKaKgf7Ko43WStm6betBCTom-ODHjgEI4QteCAx4-pt53eWTRhqjYqh~GTeS~jcJw-M1zFRRFrzvOa1LcRkMipdJpRA2KqJfWqE8tuNlOeU8yEuR4X0~bcBQyfMGFBAvhFr8qlDk06bGjYEUg6efWtpj3sxF8fthE8m~UF~4YYQoPiXArreZ6Hk-YKa2gXo1QTHwPgbC9j1Hd713nEwAbIVIFYmqAVah1CK2lljqZ0yqHgraaYcWnpen4X9Q-DScnDClLY0yF2yaOYVb9qG7qxExA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=default, Icon=On, Responsive=True",
+                    "description": "button: primary/large/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.506Z",
+                    "updated_at": "2022-05-09T18:35:46.506Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6e5b9439e3fd39152fa5b1f1e6ed273410bbf707",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8646",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/zja/ITf/0xb6jbanQhql3nzs/component_thumbnail_40.png?Expires=1655683200&Signature=GVkAvm8ZvdSjo5qhZw~Ck8c6DMyjbGvN1k774d8ePKRlW46ApjGkRgPFuajQJQn7aWv1tnccCsWM2gHK2e8I2dt1XkrLjkMMEVtHzLYtkUVLKQ7FJjn0oTXN1qyxqKMi0tj5lK~qazReMKrIUttWbuhbsEu~yoW19HqBGY9d58oO~~Yu0D2Uwj70Xe3-89Zqlb8zvhlAZ6rs5ECTidGv2MAtu5gu-q~CVHeWgCHi1LBAMDIxTZGexdNaITmlobaJak1s1wFr~8uUTFypCOxLU7SN5DyHjWt8N60fF~dxV0X3P27n5ki30qGw8V2pkds~VvYU7QpK9zgrx4dTQUC7hQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=disabled, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.500Z",
+                    "updated_at": "2022-05-09T18:35:46.500Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c93bb0f2584b2ade95f8a6449c29b4f2a1064dc2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9594",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/QW8/YGy/LeGy5yBbsHg1j8Qe/component_thumbnail_39.png?Expires=1655683200&Signature=Tb1DN3RbZauHtMuHnhEN3oDh-r89JjNXFCJZdJ0YLRmSn1liEGiP7SrLn0aHLmrL~Sa2ReTABunZqIExOs-05gYjD62eDvFOeGX6sqIMbg~uo6-3vuSUA3RMsPvXzdtYsbJDyLf3GGXOKDTmyioc78KXgj4qIpJzIrG3ToTiikZYC31UOvH8pRrei1pTO-ouo3kqEUygJeRmWv3xulIM4WXzPnmpols-xSTaWBSaXQz4g8lxm7hCp2GYLvX9Xz56bVALieANQO3FkBwn0ZYVof7toGirCd7QSrxOOrCGCsi6EatT84vzjcLfcI0y4CQGBY~utJfdWFhto0-7FloTxQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=hover, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.495Z",
+                    "updated_at": "2022-05-09T18:35:46.495Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "df0122b1b8d2c521b2a9fba6fd52d0aaac84696b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8666",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/6og/IWe/6cleZp59n0Q9CiXv/component_thumbnail_38.png?Expires=1655683200&Signature=LJtWu8TQywsX25RBqSAoOSqLyNWGF42lgRH-h3Sws8BGAYooia1zrlbph7y8G2Zr3Tgcb5gg4sgtVPsQGkLpJcrQU-eSlBcGi~-KRI1nSlTX5-6C-JqpJADB01An89IYpztvCYYga7I9Vh9Eiu1ZalFIiZmDtKHzxAPPwPL8PLnsJ9BJHoU4F8xu1MmS0j1Dkgax4T-RzSgAUPuv30Y1RtCdNq5e05iSZg-jrUNqzkB0mF10LhOISE1OW-MzARQ9vGt-nRCcGQiWI3A66oA2ewYbeyoflycLtUiCkwhHpetiZ6fVezsJ7CjbmS9VKNFX6H6McRB3fohzLCuLczkPvA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=disabled, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/disabled/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.490Z",
+                    "updated_at": "2022-05-09T18:35:46.490Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "843b95c3be4928529e7c8485426c7aab2f989a3b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9654",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/dZm/bhJ/9oIJMTNRAcbwGNau/component_thumbnail_37.png?Expires=1655683200&Signature=Mb-2N5VwV9tyyeNp2SNpejSkUM~7BSgidENVHT2Il8BGrPMz4IdzCQbMYL6Cb~ldB~UsfUYRGOvexbCvyCxGneUpBwU1hi9FDF7EGMzyZjSO9w4ZQvg7wo8-KIWKOlfTqHPU6Zc2PHlTEBOhpA9t18Vlxw8zLTTwU8MeBWamWSlnVtiWAZWZdPSEZ3gY9BjmoswYLt~6ZSdhhitmizLo6rgtqyJRlBNI3QF3y9XmrtdzMkEEdqbpNPBUSTaXPYkrvoQhZqggLVR~cKa6pF7tCGQN8R2ZtSLEscVqQnr40Z94XQ~BGYfT3cTBiOFKZFnTkYa7NWrJZWH5iblScjXTpQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=small, State=disabled, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.485Z",
+                    "updated_at": "2022-05-09T18:35:46.485Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c7fda865042206302daa7e68c436779ad458ae67",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9690",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UYu/xUW/ZxB3FLa8KN7QSjUh/component_thumbnail_36.png?Expires=1655683200&Signature=B0yia4Mw-Ltn9XvImkM8m-ShhUtJAkrppHAzA0IR6akpCIZUdOK-XstEsTNJqIsXbmX84rcVBRhzhIZrXbfvbfAOB0g6MLZk24MMF4wBigWhRu5CVwsbR3BYzwl2leau5lYXOESXcGwCxDwLkLhurJvq0IN6q~oRfJiwPA6eLKnN5WPC3vibRhXETGZEYsHiINIocVoNh1FH6NtcHtJcEhQ72GLpMc2C68YK2AyE0K8b62MyraU2uKTSuJ9-an8XPOe5YQ8aQJRVNddGofKrD-0GK-dY6GDXcnM1awYjZvTUSwNTr-11V6Wqa6xpp5mao2YuZVIp2XpOdyhIzXBhxQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=default, Icon=On, Responsive=False",
+                    "description": "button: primary/large/default/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.478Z",
+                    "updated_at": "2022-05-09T18:35:46.478Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7a6d1b96b8c9255ca7e0f4c46b8b368b3afb05bb",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21437:12524",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/7mx/vRp/vd9iRe0f33XioC53/component_thumbnail_55.png?Expires=1655683200&Signature=CXvqzSs0Vl~UhKG2vPB39Rn7TnMdTiHesFSrjy1-c6NFjr6Q0kb4pYHkQxr9pPgPeNoehtnmo2iN4m9-Z0MiqZmOKDSepRjyOAh7K~XijGLEvq9SC6Zj3MiY4GQ2IZrtRf6pms~MLoz6HSMRwe-cNTHQJ1dxR~cTU4bRcVEx92hmKp1x4j9xUMbbk0nHOIuTYOX7tSN7o7O2AkZYqK6zNW5DhOoO8SJeXkVBbrfZdBirC2BpT3e0LX8cvZvxvv2fMqYx6Un0I1Bval-j6pOdQ~K80PonK4FOL8S1CO-19SB6p4XRknoaJBrmGuwFBJWXiiFJFZKhLmt2DXoOu5vsZA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Organism",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.302Z",
+                    "updated_at": "2022-05-09T18:35:39.302Z",
+                    "containing_frame": {
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8147588103a437c2d3a65a6cea5611dc232da080",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21465:16642",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/sbG/iag/Idfr83P0fAWYl19E/component_thumbnail_29.png?Expires=1655683200&Signature=coRJaLXhEc9K2XViwW205gguDmWLHIZ7IWtgCfVNmXKyECyx6FTNgmoYWUZ8IH2wEJUwnW5YA4VqL0R-Knk0i24rK62ae016llB25gz~IvoRXhoHBY-sq-bMW4xfO3eqQRfVCYl1pEV5LfztS7oXEA04cUHS-QtRL6eH2BuQfnmlIBDKjANRe6r-4t8ZoOYGeMwRHqb6jcuu2SSvO4ZTjAChuAp3Z9UX7xItK-nn2O9QaKEfBl5GjAYDuVAdE6~vJeRdkx-4iBr8wwTY4FgbXxLttnJFPB-nv7H7CCvSXakzVvjmdhbEnPmUBCLFHYn9Qmt6jkjUp~~fUXdChULlQg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "structure/fieldset/checkbox",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.157Z",
+                    "updated_at": "2022-05-09T18:35:39.157Z",
+                    "containing_frame": {
+                        "name": "Fieldset",
+                        "nodeId": "21465:14096",
+                        "pageId": "21465:14093",
+                        "pageName": "✏️ Fieldset (WIP)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7101f1df9b64356a5d92c2ba0acf548e85ab8f5f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21465:16639",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/DeI/Jf5/FR9ttTiMJXFEuUwZ/component_thumbnail_27.png?Expires=1655683200&Signature=dZ1K9QI3iJrQHQ48LbgUx4Lh4herqsuRJ0GP0bxEU1mCpZliSPUabl0OGpWTqRkZPrjQXIhw3-eIFz~lwbv-rAQQ0NB3A6ewExq95GTiRY8Rv~kpqC-NBPnsxiMkgzXovHu2lGFGBMo9T8Df9xzxvClTYL~0LthmlnsXNLZVKcVMIdoxOrbqPHLtvviqBjz8lW57fnufxD62RsJ4Y0d6LgA~0phhN4bkpJSCo3bgMrr8ahYX9D6QXnYZVUyjUyUZ9fTi4DsU-0Wbocmpza68T1HWm0CM6T8DhFgC6-6We4UNGDFITewM634lPksaNHw2a-7CcyFCH3nKs-ekvSb4BA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "structure/fieldset/radio-button",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.146Z",
+                    "updated_at": "2022-05-09T18:35:39.146Z",
+                    "containing_frame": {
+                        "name": "Fieldset",
+                        "nodeId": "21465:14096",
+                        "pageId": "21465:14093",
+                        "pageName": "✏️ Fieldset (WIP)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7bcb75e9e1332c3fdd645b77093d5278d4907534",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21498:9692",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/X2M/Osp/707sfm1VmEOTwWmx/component_thumbnail_60.png?Expires=1655683200&Signature=ZvV9A9BXzMXNzAG-4fTh7RmipErtg2pAp0USjsEtoqmOv9jqRjoE0u6PKugMC2H4z6wPFNJkDPP9ZwKB4ciYkwuishgeczXyxFg6ht~smGUMgTdl6DL7cMTyz8wuX~cwDiKBdzK1D0ti3uriXIBz6KtLoo5e4Jy6Co8q3qQCxdi0YqVSUlVv8CZ9PQ4h-Vf2nF0bBuu2f8nSQ9kqtqL5iGYavLfL7nHy1aG1KVhvew0FgzJ1Nk-opvVWweobfU6Bk5~JUcC1c25xEoU~nTGAL5MOwjPHBVSeRIgl352N~xfVMdUDv-hQInJaxV8ef7Pzr2oFyanj1AeNtJkH0xD1EQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=2",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.803Z",
+                    "updated_at": "2022-05-09T18:36:02.803Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21498:9691"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "830a2e9c3b745c087c319b78e1e852057513de0e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:17507",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/uwj/lAK/CsEsIAb5P0eVpeOD/component_thumbnail_59.png?Expires=1655683200&Signature=DpkUQaOQZd8urTog7Mo1hZmDDDF6Yelbp0FeSx~q-gHDLRxVgVNt-GWm75quez2u5iZX0ZnIzlQrMPz1uCXZhU29vqOKHkPB76dqRs1TvfM3fbWqeGCdr~EHCE34OalLFzd~YhwryHbxqOOYP6xRf38V53StgCn6cu8Qj5OwkbdVNmD5SWV8BJK8dwjSca~4nt7ouC~VA06uLl0KY3KhQM6KTUXhoN3tkUeiuzNsTz5v1zTjecbyhKmqM-p85r0dIDCdFBsVr6FknnMFjZ-cFcKy3TJ5qTR-zhafNAOOOLPOxemCbWENChZrG0vmRKbGFGXi-Lq1-7ak9QngpSl2aQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Black/White=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.797Z",
+                    "updated_at": "2022-05-09T18:36:02.797Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "Tagline-2",
+                            "nodeId": "21409:17508"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "62f92e6263d7d920e5e27ff32a429f482855acb4",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:17509",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/RvB/9tV/IGKYGTsIZfVDnnlX/component_thumbnail_58.png?Expires=1655683200&Signature=e2ydyzMQYhi-k~4A6cez8jlSfSUUU2ztDB-j8NNuNhp5VMVHDKkc0M451GqrE9gT7onrIRiAqJx7VevOCeba-l33EwNzFKAHF9LxMC2cKgY~UjxUDRAtB-vGplGNNB1QAh6zl0HqkiZoodwfBMtGalzAAd0hwFTtPuWkYyLckn~YmzP5Qxn5evyq4dVG7iKthwZ3XtQkMGMUaR2DkohIIuhE4g~s1YzwVMFNgvREpI3ZolZi2wJ9BxG33uee31~JhwHiO0t3WYZaYOn4Aklf~9BCPK8p379emOnkp2xgVJCQWjpbqSkIyRXnP-VdnJj0OwsY~3w5F3fQBmzvLv3-VQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Black/White=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.792Z",
+                    "updated_at": "2022-05-09T18:36:02.792Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "Tagline-2",
+                            "nodeId": "21409:17508"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b4b62ad3d2aa56957781f9786292f94cd07bac0a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15281",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/hYh/PJz/NRdT49BOVriirt4P/component_thumbnail_57.png?Expires=1655683200&Signature=KEAToL2gYmRVx9qQgKsvd3FeVMi7DlnvsK2AxJRmHHd9ewz1cjHQPJFtbLYJLwRJuhqy-kMQcDVn6F1WAkfRVN4GVVe-kCyC1frItSE4Xh0iQ3gl5z19p93nh~QrWt0flvwNouaggHU-gLPjOB60mab403yibM3tH7bzJpkSs9wm-IHadhAaR1khJbhVBYIl3yMcVZzZ6S8t16d8TO5lT9aQD8I~axsWqUr1sXfZq8Kr1muBDamJC417XxFZUX45vfisbkHiYn2YzPyyRlxcMR-~k~hixQSo4S28UrteHBldwVdlyCl-JbI-~r~tWCv5TNeIRW1WTOItwyq5oJJW9w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=100%",
+                    "description": "#100%",
+                    "created_at": "2022-05-09T18:36:02.786Z",
+                    "updated_at": "2022-05-09T18:36:02.786Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Line height ",
+                            "nodeId": "23067:15295"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "14ae93052c23dfbea4c1016e7af15ff8aaca7566",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15282",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Nkr/bgB/wfOB1ZpBStimcSag/component_thumbnail_56.png?Expires=1655683200&Signature=HqOs2NO1MtpFRsQLEnl9-w5zBgkN4pSKz77ci2XhSMEOBT29igtH4cDypI0WReID1adtMbQX05gO2oEut0kkzJ7djkwPV-MD4DxnVBkHhzN5c86nGXNIkZJSWjE1J65hxhhrotCjf6ZwLPgNXTB5ritoDWpQv0CFXe7LviJxN3CFistouNcnNiDm37aO9kbyugGkXoly89C-WHmr2psJRcwJn5zB2Lsr7lnCYnBwy9dDSr2D-I-SmPry3Jbq4tfH-EkXpWNK4ESI-BddOmJtiB9ZQZXPOxvF~HpRES~rBZ6ngeDD6w2XIzTCB8DQGMpcO3b6NQHicqvEDT8T7U-7Zg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=125%",
+                    "description": "#125%",
+                    "created_at": "2022-05-09T18:36:02.781Z",
+                    "updated_at": "2022-05-09T18:36:02.781Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Line height ",
+                            "nodeId": "23067:15295"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7e3c064dd0e4de78f95dfcbbca20a4ff00fffc26",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15283",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/4mg/oR0/CLTNcowVH6OK9v8x/component_thumbnail_55.png?Expires=1655683200&Signature=e0E6kyV93hfJBRnDSAgWaJdI0rBWfB0nctikUKNb3-vBZvhOPNIbXDzRy6tnZT3S8AINWncuzXl2BaVbOPADyY0bge5xl3lTuhb2zc-7KdoT4HORQa4ETAbtI7ppvXqQv4Xifx1WcupPh58WOXwiVhddyafMd9eOVH0aGRyVLAUG9PEKMO2LndMfcslqnqRwsXgpbbK5M1MthFdu8F~mRpIowqK8qqgfZH5H0NjMJGtxZfjLeNW04zhewyqw5V~LKO5wsVjI-NH5qd-fq2Ndq3C1O6UKJyRc37eJV3RMRyBBG7wBEdgPH-BhosXer5dbXe7PMkel55037so6IedLPg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=150%",
+                    "description": "#150%",
+                    "created_at": "2022-05-09T18:36:02.775Z",
+                    "updated_at": "2022-05-09T18:36:02.775Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Line height ",
+                            "nodeId": "23067:15295"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "be99614e8a165d00bd8a3419601111084846c66b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20629:5320",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/7oL/tgs/D6ZhwQvHvisNi57K/component_thumbnail_54.png?Expires=1655683200&Signature=FmMREHUUWWWvAIQpLjUp5jAGNYt5R93kcIoCbxzO8ctlCXsRsA9JYFhNnzQexPnjh9zJs9fDvzDDRAMt-Z0C8FqVJCBaRcwQz1w6xU24iPWp0Za-7RQRRn5mFIvfC2q687t7Za3aGO1g8mEpZG8P0XKJnR7~0pHbyZtzeKaeqi3imtgXYrja5ib1EV9tBVpLCsrgpblAbvW~n7DUlhFa4abj35IxySeCIUDcGhiSVHVAIejb9SW0GXJY0oxo~A9a5L-suq7ZYDJaNF9Q4hY3iSIn-Wqui~1~rXTIBTKtHt5r9iSmYSLTcf86s2yh~mj97dN3lQcKYA8oMjzPVSef-Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Popup type=ImageContentbottom",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.769Z",
+                    "updated_at": "2022-05-09T18:36:02.769Z",
+                    "containing_frame": {
+                        "name": "Popup",
+                        "nodeId": "20629:5282",
+                        "pageId": "19945:7461",
+                        "pageName": "✏️  Modals",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Popup",
+                            "nodeId": "20629:5282"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e734ebcd0b4ecdcccb446b35f8f551570c07df41",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20629:5291",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/8yA/loy/FcRFNNUT3c737XF7/component_thumbnail_53.png?Expires=1655683200&Signature=UVCO3ZDrjnjqmo5vCssc96qn-hQqGnojifPxb8MG3l~gM93KQ2~aUO7gSl0vkU63GuDJ1jLhbEWeWgKOFUfTRH-shyr5J9Zx0HhgtmVwiO39CByIcy~~q9se2dr5-4GE2WbXA1CllsElxWd~dxvtp-l9Iug5jOr8EOAy-ILEEIOXA814Yl0XC205u9SYMB-mMp-eHaQg4y-faSOhj09O5UDWWe-ZMwfvlKD4rGKXxbf3JNuo1UViGY~fktG15BbTKXQlWPL-DMeDsmSHty2tLkXe6R8NqMqpFVq1T7mL7lytovH1UNyQI6p57CfpcZWQO9gdLxDr9SrG-niGVczykw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Popup type=Content",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.763Z",
+                    "updated_at": "2022-05-09T18:36:02.763Z",
+                    "containing_frame": {
+                        "name": "Popup",
+                        "nodeId": "20629:5282",
+                        "pageId": "19945:7461",
+                        "pageName": "✏️  Modals",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Popup",
+                            "nodeId": "20629:5282"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c4333c02722e2f420c334539357fa26ed62eba42",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20629:5283",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/bgX/KMn/XK1Wrpy79tnaDAYx/component_thumbnail_52.png?Expires=1655683200&Signature=FUmGYmW4LaBRygh82kloA1I2ALCENXhjzGBQJSb5obj8u3pfm9qw7b7ITffk-P-~BW2PMmIcyUFYHoOfXfD9fJsjZpZFN-XGavNWHKRTAytPaA1ndpuDlpk5NC6jeCw8z-b2kHECwkvmPF5qy2Zn8wPQZ-zc3I9ZmLBcnFCqad7fUGJY7CCJ4ccypBWjM2~NOpdZGDDFG3JepzzDHqf0HGOM2lOe6G87Fz-02BjHA~6Ukq6H4O-wnqBWBRuUB6fShRUXTxJb1F1Ooju~DUdtB0s7fxj9mGQ5Gcv5cRx-jWq~NsZja22LM7fvg82F0BxxutnwjdJHExWYOmWlpVeafA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Popup type=Confirmational",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.757Z",
+                    "updated_at": "2022-05-09T18:36:02.757Z",
+                    "containing_frame": {
+                        "name": "Popup",
+                        "nodeId": "20629:5282",
+                        "pageId": "19945:7461",
+                        "pageName": "✏️  Modals",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Popup",
+                            "nodeId": "20629:5282"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8b835d106aba02800f3965c0b07bb9f1889ac56e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20629:5300",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/JnL/SYr/kppKKmszk2wQ7CIZ/component_thumbnail_51.png?Expires=1655683200&Signature=AEDY~~-TLz3pe29DGwN~aXHAo2IN9e-5a9xnqSPUmfn8NytCMVAVf6joK7riYk1PJRgG4CG9owSY~dRlq9XKWgHK1CJYMN2EmehaJtif85ORhEcCF99sP5Q-6zlCo3MKqVOEo-JLQBKfHCRosvOzz6GtOgr5dXSpGJUBKgLZi9dZ1fbUdfIT7Xm4BCNMAeyq~Iyp~VgWg-XkOg9sZN2Nnb77dNLOEYxLi9B3efWvLzOwdAxYm9503xBt91istG0cVlSi2cNIMI3bXv-H2k9hxXEGaj9ooLcDEC66GFucp4vibkT9g1or-2A9089cy~pYAXogwQSOerdZTih5dXT4Gw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Popup type=ImageContent",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.751Z",
+                    "updated_at": "2022-05-09T18:36:02.751Z",
+                    "containing_frame": {
+                        "name": "Popup",
+                        "nodeId": "20629:5282",
+                        "pageId": "19945:7461",
+                        "pageName": "✏️  Modals",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Popup",
+                            "nodeId": "20629:5282"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "bf2c58d63cb31e53d471e1a7f49231d91b59b9d5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20613:4608",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Ive/SUv/DOCjPcaGe2KJ2Mmm/component_thumbnail_50.png?Expires=1655683200&Signature=hb1vKN97ucZ4N6uajQQ3l-7zdFwVg39uiUHlj6m3WmPnQdLX1vxzG5d9rXbZuTVUZUwQruGy70aEdk-E~q1pfB-1szc~FB1ok0k0K53A4MKbAd5q20qDDx4d724MV9brly~RC2ZNBPjgxZ05zmZi~pwwxkziTDN7VsYar6pehG0kXIhnM2ecT5Bqoycm9LRxqwhF5elWV6SGzbHkasdHyB7Z5WfArnnIr2sX-IccISrDCezSZB1zxUw88o37xCX4CRz6W-KSGUz~iNrKum2VFe~wekn-R5JhU1RSBclCwPAU5~-dzUgXywIxHIUilYlQ5yzNHaaGepgLQECxGfJA0g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=link, State=hover",
+                    "description": "crumb: link",
+                    "created_at": "2022-05-09T18:36:02.746Z",
+                    "updated_at": "2022-05-09T18:36:02.746Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumb-item",
+                            "nodeId": "20781:7075"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5782360c0e61fee2aaae7e496350e7677e3b7815",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20613:4617",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/2Wo/PMy/dmZPLV2l7JmK6ope/component_thumbnail_49.png?Expires=1655683200&Signature=cpxBXJ5Clwg1-jx~UdQDTz53pfDIkUFw5T~Pz~09h~evvrQoqNwEb4UkcjiLPQoWdtk033zFEeRcwdvHjlGhSX9CxLj2WtENd8X-ZEAFAkk3VBJvZJ9Qn5STorx0QW73TyxbFzFI6e2csCteUdCY12fwKea5fS4Ljm3bnfJyQapqDJVDgnmFbnIbO-YRyfpDs2Aa8Sj6~Gh5Y~gKMOpHfHJYg7V1jJ2m13JDzLlBx3qOeOKOJ1fYNZtxxj0DONr1eKVUXDJO0eYUpQvp4ii7nJsnmMe3ZhC5p~ioNTCbDgF2XAr2iKCCQpkeyVorXsc~MwzdjDzY~tMZ7z-9L~7C2Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=divider, State=default",
+                    "description": "crumb: divider, separator",
+                    "created_at": "2022-05-09T18:36:02.740Z",
+                    "updated_at": "2022-05-09T18:36:02.740Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumb-item",
+                            "nodeId": "20781:7075"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f9fc439efa354739359c5f4f58ddc53d6488ff0c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20613:4605",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/VM7/aZ3/iU4hIQVLlJGO1pNJ/component_thumbnail_48.png?Expires=1655683200&Signature=O9BuANSKjJsZ-4srCAbnEKp5pyTxIvv53rgmAPp7OaOoaIeHj-RBeNdAxPEttjXKXaVqb2KaHRzCfBFXJdmKD5zvMhQi-CjXsGS8apxvQpW73Z0zJxJd1-miNASRomUb1~5FO--E34tzWLO72AFcvMR2HVbvy~m16JilyrkZCLDywTZDKDqCD4eEholfb7HJcOEwJ2evVYYq30SAWIUUsbnwNiw-3A9jfpcolG2tegNcW-VFvFUzornw5FQaRcWFs2HDH0K16nRDPls6czsopO20RCj18rp-OAmqL7R0ks-LFsPVZFZAygRj7g0bgbHjXrVBMT3KM4B1wrpbQOCJ~A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=link, State=default",
+                    "description": "crumb: link",
+                    "created_at": "2022-05-09T18:36:02.734Z",
+                    "updated_at": "2022-05-09T18:36:02.734Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumb-item",
+                            "nodeId": "20781:7075"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "db5473141cffca9cc9b070e8da406e9dd96d1cf1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20613:4614",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UYY/ch4/2Ek3ajovez4nFzfH/component_thumbnail_47.png?Expires=1655683200&Signature=c06fwWVmC8Sq-wakP4Huzta1yansG7pZPXfrV4Fc2i76eA-oc2XKMVmAm4nDDfQZK2HOvZBV3gWSY9bqf67ogjl0hIdBQHb3zeDEAPI~xcFuipYmkmzZsqs~fHUcv6lEUgPN3yJWOD0frUCJh~4BKL2JBuDf3YXo3-QqqrFcm1tzx7cSjErVNkyoGpWOG5x5CpLBZD5JDHittWvtV3kF7L6WnVhEc9BAcPbTUNKMHZKjwunJ9SThW1gTAxqTLSZq5H2ILELIgXVvcfsy5jneYZdd30Ix3jMP66ylJbLIcwgRWb1rAPNLeizQE2ubnw9mcCAsiEVhYp4b76ECs11AMg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=current-page, State=default",
+                    "description": "crumb: current",
+                    "created_at": "2022-05-09T18:36:02.728Z",
+                    "updated_at": "2022-05-09T18:36:02.728Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumb-item",
+                            "nodeId": "20781:7075"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8907a66a636b3c96ec62efc2b18bd74e29c41c40",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21138:6859",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UnX/ei1/PYfmpdqV3hwk0NQW/component_thumbnail_46.png?Expires=1655683200&Signature=CxhMMUkW8FWda9tRi7W5MWHtHS4KBm1YZ4R6lBJwIvw4RftQwP4zfrCOGvDgb3SAVd27x7W17P20Q3QGqoBcIp5F6tHcp~5iO4xA5MZV7v2h-0xuFmwzybdcJXLGdOiMOuuUAXfFNJXUr4GZU2c2HGbcwyGyMvHQ2xKVybMJdJlROYTi92IXjUQB8UZxp3kzHwbZwX~MoQiU1mFDDDhyEWteE2-bVRoCxMQWKnhH2-8uh4iq168o2F0ThbVazc6VLQquM~SsRXYsJ0jPRkNBjKQiQ8dzbfTG1uMVvv6vEm2oktPoQ4T1s3-UbUCOl-nVGzTf2J0y9RnLu3KiPDvA2w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=collapsed, State=default",
+                    "description": "crumb: link",
+                    "created_at": "2022-05-09T18:36:02.722Z",
+                    "updated_at": "2022-05-09T18:36:02.722Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumb-item",
+                            "nodeId": "20781:7075"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9c0a656f2695c7fc390da75b9a450793100ce290",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21416:10807",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/YEM/mNb/iWrQnMdWs9iEYIIw/component_thumbnail_45.png?Expires=1655683200&Signature=LP7cpDtq3OvQc30mXOfoL-9LNYYpUfgn9FJsai6uNTpvvlqHYLV2BoyB5SYQXwkkEMoUL0GtLR4xu-OOOJvK5PZ5KtKRb00WSHdMmAsbFob6R1UziFfxyRLWnS2nq3g0oQMgOr~JJpKbtNV68hEnuQoYgLBTAFMBUvgADGWkNt20jxhjYWMIYLmY2-yNiNMNJ4lN24cjXvKjY7lVeeQwLlaHyYn6ku57sSvvnh5dy-ih3Yy7AAvPRO69dYRlRsgR9qJekjK~~L568AiHjyh4tAMZF9T6JyAABm22YD5e~bsZd8YDGoiW29MIAbKo7XOUztrKeJxXQAcdRdAoku~qIQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Black/Whi=On, Configuralion=Horizontal",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.717Z",
+                    "updated_at": "2022-05-09T18:36:02.717Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-2",
+                            "nodeId": "21416:10808"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fd5daf8d18a8a449fad60fa231476b5eafeff157",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21416:12962",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/rxw/4dc/7u8KE29iIORgWamE/component_thumbnail_44.png?Expires=1655683200&Signature=PzeoD99aBYToOiijUfbcWA9IfdKhwU7Kt7mNWteCdewqrPp4vVjUYKCPlM7Y49hZ9vd3~aspbov3Q7hjkto2-d94~aS4QAjnKvGZl2roF2m9B-8GJ8qyNE9ehHpgNGxq6a6Ecf9gJmagUELKux2xnGnOjsZc9vEO1mFSu6VmmKGGKdOpPOG0CFc-AedFDQhTQhate3d0rW8Ef-fppqdEo62~a9P59QgCfsP7mKN2~EfiQY2hg-KMXrUQIdfbhkgwKV0gmfTNUHDKZSAoqxX3MK093IV~qomuQq1dF8uFCRunh89r~CxK206su7Agoe5RzV1-yrD71z5a-bELQPWGgw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Black/Whi=Off, Configuralion=Vertical",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.712Z",
+                    "updated_at": "2022-05-09T18:36:02.712Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-2",
+                            "nodeId": "21416:10808"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0b27a6be981a87aff070611b4d0d029a6a247b7a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21416:10784",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/2rG/DJK/sfGIO9yWYjdqifsi/component_thumbnail_43.png?Expires=1655683200&Signature=DKOQGd3KD78IAd-a1l7aLFI5B4Ofq6MD65hyyDGseD0YjvE-4IXtTCuQUfw-0XNaM3OwzX9I-nKUaZSZNLau-9TC9XGorTFuKq5fgrNLnkw4-lQBffq6Obz4TYuBuBxWks3mBVIhJZbZR2Ji0R~TuKYKCslRpmi3hFktSsTdE9vl3JFb~nYryTLA07nmB1ijfbOLrLT4tYte~IE7f4x~opMkJfFz9238pAxmfAVeveKVUMl0FUAm5GVIv0cXW3UwHvdP-ItDxhnGfw1l~Te-XEBQzvm~-8~8xDyYyKjSma-YFd9w-o~jIEAKz8ySGSTkhwDOFUQKINJ0IXuzWJA6bw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Black/Whi=Off, Configuralion=Horizontal",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.706Z",
+                    "updated_at": "2022-05-09T18:36:02.706Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-2",
+                            "nodeId": "21416:10808"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3b1bd354ea17edbb45a9bd77266966eba3d2776a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21416:12978",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ehO/BKN/QIKMptyym1CGugbq/component_thumbnail_42.png?Expires=1655683200&Signature=hpKF~xqaCoMuTdOGETihzRA44ADPFFEp0SVh6utmKHWWgBVM7qXyRRS7n5ECP~Yq6tpBeNrrUbe3Wac~Cxerm1mCSqXV~dZb9MpWWhyVuORrhjzxc7CqqyB2ZygBnd161u8FisGcbWS8SNCcvJj2c0qpFhJK1PtmOPU7HQfi4xK6~kPfhD2UVZUxdxrK-fOgzoRgUJK9~K8-S98Nx77bAZGF5iFNEEL47q6yMrdYPFJ54RYoIowglIoqKWriyC52Jj7B9DFUx4yHwYG02kUteO-8SQ4bN5~y71sCoeRKu3I4Aja89LjNQXy1cULGzllcxGRZXZMWbBLouXoj65nj0g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Black/Whi=On, Configuralion=Vertical",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.701Z",
+                    "updated_at": "2022-05-09T18:36:02.701Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-lockups-2",
+                            "nodeId": "21416:10808"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0ea620dd7532135fd0db94a6d5c3fd53deff8a41",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21294:7579",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/409/l7l/wLd5gEB3DPZ9ejEE/component_thumbnail_41.png?Expires=1655683200&Signature=E8M8bzWsAyKFoHdsP00De7KxrPbA4SqJULxgItzqOT3e1QzaT7H50qc3ckJt2pvEPWqFdJXIpfUjkaC6~5FVfKtI7mEpotU8TGTAwkKVbLU-F7scyodwrL95o-bsYyQ5gh33nmEZVDZn7R0r6V9FaS9q9kKMFHeuWt6ha-EF1cmAymHaUUqgCWO3Pl2JsjhGxbeGcPe2RA4CT7xjvL-DXWGzcZDbFrKw7cx74cnAKRise8v25bab9f~B-ylmUDMlhk66TdPimQ1xyXwT8sliO5lkybAKDPIURGm-VwjSg2qC1XmelGVyEAwf48cTED7zkPN7xR8lo3QQyd-BZdCg8w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Number of tabs=Number of tabs6, Mode=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.695Z",
+                    "updated_at": "2022-05-09T18:36:02.695Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs-grouping",
+                            "nodeId": "20840:7205"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5b4ae162c40bd2187161943abb4d7e253833a16a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21294:7582",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/fz9/cDz/eJOxe1YRWV6x6VuW/component_thumbnail_40.png?Expires=1655683200&Signature=MPlIYdwOqq~cnGrKPAT0uGCO~wAdN6bAtaO17YmP1iA~tGHPVdafvrorMSdVh8KnOz96tVqFtYpypQAaTb9ePOeezaqxDdzEyRNXNU3~7PUkw9fulQX75Gxn2UWopbYbSDVRAQFcePi3GGrl0EuvMf7qOO~RPCAGTUtKRhVmPYCbCqts4KCxKAZdVn8CmVqvyNxRP-otMAXb8xWrgaQrNmDFCzknuz8E9IZZDr4NpoxPDzjxMIu3JQLS9L-ryeDkxKm9cLgVXLhQAEpWkmC~673jPZYaKhjWwjgkDEOXDLTtaUnLjSiUV7TGUfgE-RWkWeuH0Wb2w2RsmSYWXrzbDw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Number of tabs=Number of tabs7, Mode=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.690Z",
+                    "updated_at": "2022-05-09T18:36:02.690Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs-grouping",
+                            "nodeId": "20840:7205"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fd5d19d318158e4173b84194812fd46217b0be92",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21294:7586",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/63I/P7U/n5nH8vMZJIu6nldY/component_thumbnail_39.png?Expires=1655683200&Signature=h4B-7dW89~7EY0jSGKKMhOFREYU2dxoDviLXhUKLrpt9f2LlgSWPuHm01SIwK0fT369xMgFPVl5QS25yMYiwJUanaH99RN5Fli2geVRivzLysb6FiEG44O3VrZ2ms-PsEhJieKQr2dfoZkcGKun8vfDysEnTNuTiGfm3SWNg~ip6NXZEh0DM~K8RH5G~mMA2IQCREVuWu9BoNN82JV2ioGEup6CjIOhduBx2LCTApfFeieFMaqXHh0TGr5Aw5me0CP2jNvdQq~e9zYPGg6F-vBgnB0Mi~7SCOC19QZMnQqlGtN8Q345xtqBVdyUa1hMmVmA4-8U5CgPKkp19373row__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Number of tabs=Number of tabs8, Mode=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.684Z",
+                    "updated_at": "2022-05-09T18:36:02.684Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs-grouping",
+                            "nodeId": "20840:7205"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fe4cc7e1b7df579595568f78a8ef035d505f7dd6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21294:7597",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/J8k/61V/LXZcIW5Mb1Yna2ae/component_thumbnail_38.png?Expires=1655683200&Signature=afMt97LNDSm7Q8O4CF~BGlVn7VIPYZxGk3P2LGVTstlAYw0c~tih96dPZFQnn5tqiQgIK6Gx0AGrLAJnDi3cEYv5ZvUEnuvPQYIEzbjcmit0oz8uyNDulE7x-ynykX0js8Gkpuo6zoTCu~KDtLYa2C1urX5HILKPi7rjuXRFZzk9bzoJdr9ugQyemTKUGvJw8Kugi8NurTkuXV44y7MRKPKUX-DbSh6P6WhQU8ASSANdAtzcoC~HoJNG6yJpBV6g6ro5HOz43FaJno30i~xyWKr6zCj-3LHhzzB3Mm3rK3KTvG7CQO2LMA6Zh9wtIPvAIh~Ts4WH6PY~2joYLQM2mg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Number of tabs=Number of tabs10, Mode=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.679Z",
+                    "updated_at": "2022-05-09T18:36:02.679Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs-grouping",
+                            "nodeId": "20840:7205"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "01dfdc2ea4b414bf844b2ef1ac1710b38912e200",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20840:6835",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9yo/6Yv/DJUDaKREATGyiwuC/component_thumbnail_37.png?Expires=1655683200&Signature=a8-z~V4czGOeKYxSUUkYNjOM2veFNJ0WtGrE1lM3u6fByhhrJV~y23Mwp-O~GagT~yj8feyf1-Z9Es1HuD2TQNNrdo3uWdaP3ffaNUoVlE2FsRPvU06HjQu0DRy~sTWeTNP9doL5iSbWpQ1msaWkSDIzkGkwq~MpNP-XiOIXDywrEk9sMYMJfeNqL9q8Y9eJgLg5NaddCm9Mx~bt6pPHwI7DOM2ONQJ5R5SkNyyLKshNM3089Eo9AKgIboKxj~OUXRSFUpr2p-qSeg8vg3wco0xDzp5mmKQro-kQsuJvIrwe~BVvCv9k1KtEcKPRq~2ku3erHkpSr-XXZAY3Den9kg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Number of tabs=6, Mode=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.673Z",
+                    "updated_at": "2022-05-09T18:36:02.673Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs-grouping",
+                            "nodeId": "20840:7205"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3e16513f28425e3fa63986912c5ed17ed95a0b70",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20840:7202",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/nRJ/KfN/c8gbDmjIYki2J2La/component_thumbnail_36.png?Expires=1655683200&Signature=C55tj5otnKTnCJMIzMiC3sVrB4bi68QNAYYQNZHWRy2CzrZslfK77NeemJB6-O1X-CALMZ6UwMu6q7~uZ8HdGq3xUsfBAcDw9CGljSkuXP4rLHobzsE38CwN9sPmXWDN8vDg3rMN7G4KfgX9Z~3lvP946-HuS7YudZ~jjxWorgoqjevrkVS8SdMMkUo8FgN3SXG468iKSs55hfpuf66O1c7xPAWUYB7gF2rlChHAnFniDoCdgjNIhzVaDQdpzY-MbiptQAOb0tf6XTe9B7smcVCjVqAlDKwDDM4eB50yRbH9KNCJLHTIUmw3TJiVcKyjs8pg29GphEb8hr2fJvZYbg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Number of tabs=4, Mode=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.668Z",
+                    "updated_at": "2022-05-09T18:36:02.668Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs-grouping",
+                            "nodeId": "20840:7205"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "61fc14aed7879963c7805ef33d4732bac7960fb6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20840:7201",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/opn/nGw/UpzeLKQP4gM3Ayp8/component_thumbnail_35.png?Expires=1655683200&Signature=doZ7dGgy5mqB5GpRP4L1lB0f-MXsRxkd9buprNGIstdd9LcHnosOjZao6TPZ63rHzkajt7CUklkhj09HLFntE5qGMqyJNHeoR6pRUrzIoAYhPL4LihEwHN8JGIRVL5Kot25ZJfbcbeyw6l11ZDYVPBrD5eUMuQQnwVJSutEXzTOlyOcZSEzmLZF6dYfXImifo8D5mv95KlMaWFByYDdk-8XMCJenZjWhJZ4lMHUvvSVJJi23Y3c1rVuq8aZAj8fy7Qu1eXo86f7NxI2jc3jITXZoTxVXBN-nVNnODhXonfBnCEgJMct8vnMFskXyZ-BWKWBxp28lVJMwVWaKfPQDqg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Number of tabs=5, Mode=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.662Z",
+                    "updated_at": "2022-05-09T18:36:02.662Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs-grouping",
+                            "nodeId": "20840:7205"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e0f2eea2033c2ecc9444a2d94fd9a24a78eaa3df",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20840:7203",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/hzP/uLD/ZqsD7tzIITAm7z9b/component_thumbnail_34.png?Expires=1655683200&Signature=QFEfUcdh3MJX-qG-X7xmc~uy0N5Pt6UnjcU8ta~kAHtAJAatxD9ncbiNvZFq6Bk0M9vQdDs-F7Fzx~uaMUson8HGJPHwqKNp8UgaWAa4ohHrqIBOUst8smJTpcuyp7Bx3tkXpv5P84E~1dX2xKtEVrbZ1lOgSh-OKREDEjQ1wdGrX9O0fbZr11w4jCKg~cXJekwrFnvFD~b0c1p-Vo40h3Nj9G5IOTXI~UvT5a4Zs94ffhYnp1fWL4qR97s8orB9bSzX7gkyRPXdMljj7pgVe7DcaD8~o4IvRny2EQWKNk3I93fCJjT-5LG9MTSlHQuZQh16EcdM3X2lKzhdw9q~tg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Number of tabs=3, Mode=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.656Z",
+                    "updated_at": "2022-05-09T18:36:02.656Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs-grouping",
+                            "nodeId": "20840:7205"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a1b0b49cb16ae8940be8353953f5ae796719770d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21294:7591",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/4m6/rkF/TEpv3zaYeVA9dh7k/component_thumbnail_33.png?Expires=1655683200&Signature=VKx-t6PQjUtw9fyADpEooU-2EejvPaWDoqGSHmdr7moVvIxE0g0auqwFUBMygEimwRSdMf5LkAFv8ptCW~sgCsuIcQ-QYw0Ffv4-kQ1FTD-W4lMeQ6Tq4YadPzjQ6FG2WK4z57BeRSu50rIrmc70cSrZETPOxrtIhwm5xtAjhv3rOUZsq9NTTtZcTteSli5AfTNvaquU-FMU5Kd~90-O650HwbXpKmem~31ME01yXym89wJufV2dgH2ZJ1xbbV9v-O1su3vzPJoha4XNRtmgO8vlInkP5W7v2M-Hffrl8Rql3vTasRrdL6fVAJQ9krNe-aSMx~jVy3nUXsLVpIA7GA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Number of tabs=Number of tabs9, Mode=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.651Z",
+                    "updated_at": "2022-05-09T18:36:02.651Z",
+                    "containing_frame": {
+                        "name": "Tabs",
+                        "nodeId": "21440:24379",
+                        "pageId": "19967:7709",
+                        "pageName": "✏️ Tabs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tabs-grouping",
+                            "nodeId": "20840:7205"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8259a6a7868b2a50e39725635fb14d421dd6d561",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21139:6865",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/1nQ/8IB/f6edrpoEnV7SLNCB/component_thumbnail_32.png?Expires=1655683200&Signature=gMb8qi9Y2yBLFOAS7H~HwP2ZkJVaYn6VBGcQ0bwbYfa5cBoefZlRxnOoTEuEV241lPEWxfBIMn982s6nyyBTgHNJBt8TyZ4fuHdNPiPcqGIj5ziNM4zSNMmSx3M3yMWC3XZo5cv1lKd3Jzf9LWK~wmsnWPxbzH8T5z2wadgTic9-b7yo2ZXOP-5RHEkdZ7nTVjzjQzHMcby90M~nTCSGwmMtR8B1ZsXVAB3mmnVYOqoWsVq0LjM4DKYkZFJHzd2Hl5C9GsXsMKLzwPlJt3uUMrg3Y8fV71L9ST7mDEEgogrYNoe78kSFMRT8jRDtVr~Lvb1MJFSUpVdmigsfOsYb-A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=1",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.645Z",
+                    "updated_at": "2022-05-09T18:36:02.645Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumbs",
+                            "nodeId": "21139:6870"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "aa223430e38445cbd3b19b0968192efed2ffee03",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21139:6867",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/58u/FYV/s5KW02zR6C8eSOfM/component_thumbnail_31.png?Expires=1655683200&Signature=LrXvcYjNZ11QwQcbKxQ1bkvwhyd4NyubYbU3XW-A6nOzOTd-RsSLG-4CVEel1E9zSsR1xtZeY5Erjgai7i6k7YYrL-1n~Z~2Ko1wdyiNYXJczhsZUPbahDf8Es1BjFPckKpHO4Cb9h3obt-fx718uDX1DKTbuNsLrYDsijQrJDIfHQxyMDXTDbIp70I2SWmxg1zoi82UnmgZW5eLTI5oq7ni9z0rblG5HUHI-pDlPCejZsxhCdCDKnhVfO1UN-DnkjABr-nk~Glv3co3OtRJ5TN26xeMIzlbJf6QR4US-FkKCmSKf0MSYGCeGZJCwM994KNtmzheg0CMBECCevCS6g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=3",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.639Z",
+                    "updated_at": "2022-05-09T18:36:02.639Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumbs",
+                            "nodeId": "21139:6870"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1c99fbea57aaccdc4020f349b5c94e754482f967",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21139:6869",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/SZk/bhL/aCeQhxpWPFNRy1k6/component_thumbnail_30.png?Expires=1655683200&Signature=gai3FHIFvvUWB4VHnCb24l3~hIR4FhyRa90r~dTvNxumOM4OsLsXBaL2GBYQ~gGviZegkDrewn4oxvFpJT2SyFQ0~QBO2ITBMlIWpPXherjqVvGbFEnACiBtS5LAaK5249z5EaeMjONgPbNZY1szcp8RiOC3q7n4echD8HNHxeovRmkJgf46Hge~Vw2qa3AbKMbsO2G5XrQTbWR6pGNjIGXVZ6VkJOVvgkd~YCeoFOBaKvhFKJN1GHiUJF9DaZbowc3q8T6yy~FwXBo8vE-3PhEVePaUARQzNEsjtpvApJMI1kyfJkAFvjRYp2s-d8IyTg2C3vb~ZzOTsX2FwpwXog__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=4+",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.634Z",
+                    "updated_at": "2022-05-09T18:36:02.634Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumbs",
+                            "nodeId": "21139:6870"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c3e88be23d8290bb1a1c21798efe3c3c101f0ad1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21139:6868",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/zn1/z4T/UfNisyMm9dqhPMT7/component_thumbnail_29.png?Expires=1655683200&Signature=DiC652xGLppfVkynZOGSdB~kQ2ad8LC7g8C3obMclCphL9us~0z5PhdzEKeC2rRhIxQKmfSnViXkbMxIkJsuTuhKwPXizazI5rpsy0daSl6JKkzoYkBQu28q9hW0YkgfdCRJ-3n75Myurhl5f-lXaPdpyu0htdn7RycUIDNnexnU3WUl8-FZRXFgM6WMYzLJbyKHcaF-8UYKl6xx0kse2LCxwjmI0LNg9j0-g0cX3uD1Rqyr2V-Z--P--C~OT7MwYeapcd0tnoInsK3f7JdH66o6ADPAMchXr7SeLc0nQ3aVaZFQtd2doWJUhsp6JTHMpMRgh1Hx2QHKlBfB8Kn6gg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=4",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.629Z",
+                    "updated_at": "2022-05-09T18:36:02.629Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumbs",
+                            "nodeId": "21139:6870"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "267be9fd2b48f974d7c94f40f32e63a84c8e2f77",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21139:6866",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/nyt/94N/Tbc3ERXiip4whmio/component_thumbnail_28.png?Expires=1655683200&Signature=OoG3Ya5mNgcZ-L6-qpgcZfFR4hgfZFD9j8znmsZNXTsl0Lbz5rmaH~6j~03GRkjiR1MjoxU5xsOC0LRt74mGeSovR9tu7Va2WAwpHsqhQvE68nuoiOrg3jW31aPwGTD3Q5HDxfyuKEy970paekyNkNe3wxzZsdlBISn2J0iZCtuePPXOvWkXrFOyNCVD~7fuBW-uTwpOXRt0wgWrlB6mfUz5E~BTamwLezTyTgZaqQyc0iHIRB3~TTsA9lmIJbYOPhIczE7akvRGauSukGMIu11yekXMsb-ygkUlr~XdKu8N5WtRvQyIveH6cAFeoYbxjU1pVuugUsWZpv-ZHX94CQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=2",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.624Z",
+                    "updated_at": "2022-05-09T18:36:02.624Z",
+                    "containing_frame": {
+                        "name": "Breadcrumbs",
+                        "nodeId": "21477:9637",
+                        "pageId": "19945:7456",
+                        "pageName": "✏️  Breadcrumbs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "breadcrumbs",
+                            "nodeId": "21139:6870"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "954dd681006be9a3bbb45fd3c2cf65ca5cf71ede",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12258",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/aNB/BSK/vZMRQwloWsyM4ArF/component_thumbnail_27.png?Expires=1655683200&Signature=PqFjVLOBDaFU92eYO0KLuojRaPCPaO0q3qWGrFAQyZvEh~RTBqOzwoBhNYruEGtGkAuuLew6ygC99~3IBHjk3QGGXo2Fbp10j6q7oKJHqTFDwWKKsvFfsUr4D63VKEhEBJD~a9xAgf1LG1oLVK5GefxY3VcT99xhSk3Sd7B72TXshH0O8gFTj6Up7BrZwUyYlBmQiqNmgH56OEsRwfHevGcEAsQf3TzwISGrYKGVtg7VzKeZj09A3oo-lfZyQC5iDtZ01f7-R6gpkgdPgClAXB3ehJDIseGBEpraFe6-ntxA~hWo0lce3q-FYXGal9-zIDn324owl1wF0oQMdrh-BA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=1:1-400x400, Overlay=0%",
+                    "description": "Image+Overlay: image-ratios/1:1/0% \n(#Token, #1:1, #0%)",
+                    "created_at": "2022-05-09T18:36:02.617Z",
+                    "updated_at": "2022-05-09T18:36:02.617Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1adda0c6c7e608c9e12845e366e95853c927f40b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12263",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/gzB/FLM/wIrF4K0D9aAGrAEl/component_thumbnail_26.png?Expires=1655683200&Signature=Zms-hrr0fdG9-u1qeyGoLUXsY66uJgGPmO7xw-eouU8lVl9CtvJYPuWspcYty2-x5K1F8n-WfRLcofSNzBEVDTBVg9QXXyPQm6z9OD9eSof3IPU9n4iLlbiUYt7SLjIBecXrhib0Qp4-LDkIDBPazuHikjsLDJr~dULM3aVsY1IURjL3qL9CFi1GVg6d3S0fBHDIkgEHmxugCmnIsjbyFsGTxuiuOF9XErpisubo5NXtLLRLUbvxJJxrjIz~6DFD6CIqboMm-VJQmPpUe4FDiQQCHIyXQpY4lqYDgx6dpcrtfKnh9YGEEptmDtJHRv-195aVwnoXEuRCZfHhCr7TLA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=1:1-400x400, Overlay=25%",
+                    "description": "Image+Overlay: image-ratios/1:1/25% \n(#Token, #1:1, #25%)",
+                    "created_at": "2022-05-09T18:36:02.610Z",
+                    "updated_at": "2022-05-09T18:36:02.610Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d57b638567b073e52f41454834013220a499ff13",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12259",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/fzw/KzJ/LgoB23An076QvEaz/component_thumbnail_25.png?Expires=1655683200&Signature=ct74K6-r0C4FKtuMuI6ePusKRd~QQ-SE9Tf4Ujjp6md0IPxffDSoi2Iw-jzjGxT23UPVE0AbAQos4hhVuuMmNFBetfdgjxVBQHA8-40gqyoyxb302PWtJiERtPhiM8TAnJ-IXpquVYbI-q2U6l1dHIJVCaV3WXv4N8lmXSuhArTBLwVNzVeHwLJoMSRqNJWaZR8gyjDeJ216W64Fe-euBnFRb3g4c5ku-9lfMyQnjhUOD~WHzo6KRiYjaMaKTsQ4RbaNkisndmqi3~FwNVlZ9vXXzWGq1dyYLLBxe-~Hd40iSGY0Zdh3rT4V-c7Mq7pqTVIH1tc9qtXKQTGeYaqXjA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=4:5-400x500, Overlay=0%",
+                    "description": "Image+Overlay: image-ratios/4:5/0% \n(#Token, #4:5, #0%)",
+                    "created_at": "2022-05-09T18:36:02.604Z",
+                    "updated_at": "2022-05-09T18:36:02.604Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "04b716838664c3810415e7944afc2164c5496210",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12260",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/90L/wdh/0jNoijq3RgJPsO9a/component_thumbnail_24.png?Expires=1655683200&Signature=QtLZx0g5u34W-L7UJ06z5M0cQAKkS6kKfmWXh1pvulybUZ-aEcXVzkWknoFen57Ou5Gbrru5bF7RwpRTEbbiGjX4V6KzSavwvpg1x9zp5BXaG5gcHsWvjrp3Rqwt0X2FoU4ajT7k0YRkVbOD9t~33CoCPts4qyHRiLIsyl8tj0dcTOgE1nr5Lspv~4FaASqgrn0ajpcibTZKn--4qKPnD36QPicvBf8q5tJN1pQhAQdySXxX5MY3QJLzyGwNcTeGwvM8ROx5kyJnWluQxuO-mZOwglG2dZYocXM3N-fBSlXuVozlLg4t5BsuAzC~PTyIZkTMH8xjVOp2S05MwWMPNg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=5:4-500x400, Overlay=0%",
+                    "description": "Image+Overlay: image-ratios/5:4/0% \n(#Token, #5:4, #0%)",
+                    "created_at": "2022-05-09T18:36:02.598Z",
+                    "updated_at": "2022-05-09T18:36:02.598Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a5ec936777156c4ce3ae710642ab91bf0a9d5398",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12261",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/vPl/OWN/p68aZhmM8UQeh9i9/component_thumbnail_23.png?Expires=1655683200&Signature=Aew7tLXvli7hpYMrgkRCapqYI4MJMnreTcy8Y6Wbk8iYdifC1nywmzoKCuxihbOO6A8ksYp5vd6p-RI31lQuFz-fhPs2yDi2zF~HhDaXK-VYzQqWne-dhvmTvtDSnKjKQYcEVoIzd6HIUyw3jokETurZfO3InFWwoM1vjws~2V8-gtOerei1aQqTeFFitPWXcVX46jt3Nj~p6lRPLBhfp2dhi6DSQhy8i-vRdYTCbGaMP5u~FtVlzZjdcJTjb1vgETJ~vGcdXjiqQj7F9tN2prfQAQ6M-iGhyy8~bzDeRpmNeA1pxWw6eT8K~p8uWWoudYZ82iq5zY-jnYf1NJpyBw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=9:16-400x711, Overlay=0%",
+                    "description": "Image+Overlay: image-ratios/9:16/0% \n(#Token, #9:16, #0%)",
+                    "created_at": "2022-05-09T18:36:02.593Z",
+                    "updated_at": "2022-05-09T18:36:02.593Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e02b55ddd75da23905e0ff9a42ef8e71e37f508a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12303",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/MYY/Um5/1EKumobHNrflitKe/component_thumbnail_22.png?Expires=1655683200&Signature=HIm23Rl4bm3wZgWds23zvf2BgOzE~4QY8YUdbewE1HJZfJLPfaQDvDJj3XuyTgp5Q87iVISWzWGeammz7oUkHlP5kFhUwxtQjSRRsO1OSkU8xaDVVyKd2y2vZJEhOoeQyrzggmZ515pAYYLUI5vmIFli3C8hYRycOKPYx2KGpk6Gw0Ch4pb1Itx99aLf6yjI4~PP77o3xbfRgezoVE0lRIW56muqNxouz8-4mYAfSUXVnKYld1eQpHaBtorOeSbdjyqTsW2LyRavA-ReEQ~mPzJZuGJYp83m3gr2Pv9SPNIiQxUFPvL4LFeXi73iEnRNw9AE9GR7Q5q-Hjv4GLjutQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=9:16-400x711, Overlay=75%",
+                    "description": "Image+Overlay: image-ratios/9:16/75% \n(#Token, #9:16, #75%)",
+                    "created_at": "2022-05-09T18:36:02.588Z",
+                    "updated_at": "2022-05-09T18:36:02.588Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e9b9e938cdb0db4ff5e1e054faa9631b3e157eea",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12279",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/BNM/6ya/v70W3bACgMv80yUq/component_thumbnail_21.png?Expires=1655683200&Signature=gzldQgVzBwfdqHNxXKhSyVFmXkEZmrtrwUd9M45NN6KNUoxB4RgoLrSVpK6QHKYNcxMLa6m01UnArPwxj9y0I0o~3yqmxswTjUuLfuFoP8lXfnU0pIKD~ZDClZSKJq5LlJvtyCUEaxkFBu226k2zemubw2ieKIvBvYZPtQ~lKDpS3mJ8FU5d9Ze1sljbmgK-I~WTHSAdmvr0zfVHkHLN1Zp-5Dg1lCeNqqIe7bu85Jk944gnfTBx-daXvXoQV5EJVSCoW1ksEoA7EjX6Jp~fyIm~V11f9fHj5-lSn82~kHu2E~RDKU08qAwymERjtDmeJmvfTBeHm-4KGib2fDV1Hg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=16:9-711x400, Overlay=50%",
+                    "description": "Image+Overlay: image-ratios/16:9/50% \n(#Token, #16:9, #50%)",
+                    "created_at": "2022-05-09T18:36:02.583Z",
+                    "updated_at": "2022-05-09T18:36:02.583Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "55e46dc8dd2df2ccbde2c33cb82acb8a2e525359",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12285",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/vV5/dWU/IlKgfZ2dKUwVobYO/component_thumbnail_20.png?Expires=1655683200&Signature=hzajo2g5pWwVi~TdeAL4lz3C9DcDo72KVPx1JmNmT9tGflnTb~GoxPUDkh~M8XVtZQIc0KP8I0fnDIO7Oc7WGK~x-Bwoma76g4otLKj-YnO-xN8aq7pxoENBSumfS3CMlBd1TYdrILz07NY695yxlaAQUH5v5ZedZe0om-qIPqibNYnb0Nv6v~KJWQTqls8~SJQ9PK~dnBWEcdDVpUXZ9iBCU3X3mfAIFwWE7D330Tx~L6hXlVswOM2vMbHNTrIfe3BHiYG7S4ZPi9IM6aXSfKfg675Jxr~4zELjbKG-G9QULanrmuevw747HpjEqo1CX4XxTZwudxwvWyu~fHSXYQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=4:5-400x500, Overlay=50%",
+                    "description": "Image+Overlay: image-ratios/4:5/50% \n(#Token, #4:5, #50%)",
+                    "created_at": "2022-05-09T18:36:02.577Z",
+                    "updated_at": "2022-05-09T18:36:02.577Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "744fd2d440adcff1662c251cd4f02d5c0d1c95a3",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12309",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/t0h/vFJ/FA2qgqvjCMQLLheU/component_thumbnail_19.png?Expires=1655683200&Signature=WJo98LiUVvVc~PIOHChYmGpGl8~tSDopdSnIewt9oEWE44DkyTfpzdtNPo8Qp5geG-0gbZOlvm0pWo1m0GqC94oogYLuglggIwtj7W~6NnJcun0YzK1US4D8YgXtxcq4Vv1VCPxa~OBJQ7R8m-JoBzkdi4dT7-4a3ry2ZMFMir6E~WDu-HIyDY7h7tXaHXtp1cBIGU~6PwNw8YgVuAsL~rwn8u3OZJYFB7NzVsXYbhkPWR1qa9JiOrIMhCKFVAEqzm1aioWPLAhin9HVyukxSq1BUGVblP6Mgl5amX3kwtLkNOTH6yILZOT7dZ1qz~L-5ofdTWi2ugdXBB1AzTuCbw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=4:5-400x500, Overlay=75%",
+                    "description": "Image+Overlay: image-ratios/4:5/75% \n(#Token, #4:5, #75%)",
+                    "created_at": "2022-05-09T18:36:02.570Z",
+                    "updated_at": "2022-05-09T18:36:02.570Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "951c363007abf2495e2294f65db9b777f4416ca1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12305",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/N3n/nGh/xGJGVaFhWlEeJSxJ/component_thumbnail_18.png?Expires=1655683200&Signature=KiQz3FVl~zW3Lb8M3H0pSSGUVnLjeHYZhLEyYUtLcMLG5vF1Lzjg6oOZH3RxxW3m31N8HmeO7uOCesx6nL5WxcklIJ2DcHdnl2m0aWvmwP-ZJhYtRV3jiVwfUioD3~r~ODuSLJ9PoG~77EYPRK7DDyYKi3g6YvPRQmfpn2Mffy77OVAMFsBcmHOsE9RUv2HtiVfvYeYE1aQJiVXY-Z9eKg8Arp70d~Ovx6ru10vYD9nYM9WNGXzvTKhJdKNS2oUKGVF3nkX9T9xbferrlzswYSxxeBWjrU-rIw9rUbQzHE~hFXMHSvIwjQSsxl-MRDPDRttzGoSzEnGszKqVKlPStg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=16:9-711x400, Overlay=75%",
+                    "description": "Image+Overlay: image-ratios/16:9/75% \n(#Token, #16:9, #75%)",
+                    "created_at": "2022-05-09T18:36:02.564Z",
+                    "updated_at": "2022-05-09T18:36:02.564Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a9f189f41596b8182ea9b80fd4097e90c71e49d8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12267",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/FOV/Vfs/uWWEypuOy9FEJpiZ/component_thumbnail_17.png?Expires=1655683200&Signature=UxiglwhOnd9fAm8Da2gKhpte1PQiPUjsAI~nhJZye9rFXRLV3dQLCPwn1XlpGbKlOr9pectHa~m-srZse3IYpw7S3XuhQywtOp83Ancs4psokrL7Cj0n9jFRje~mEioor5hacxOuO3SJ91B85NFBebdQkGzrgAD4maht96hPLU~Q6vzvj1TPyF77OW--RyXfhK9XzA0-WePD-mp0HM89NMQYFsu~W8fQ2xPFhOerEdKsnqEqrKI6C0VaiG6-oDLCt47TWinLbswiQ6rnklWajBnpLon7THJlznjLk~GbOrUIRFetiFg2Z6cI1cv5gHOQIizEZGgImNZu6p5rpftxTw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=16:9-711x400, Overlay=25%",
+                    "description": "Image+Overlay: image-ratios/16:9/25% \n(#Token, #16:9, #25%)",
+                    "created_at": "2022-05-09T18:36:02.559Z",
+                    "updated_at": "2022-05-09T18:36:02.559Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c9df0f28d1b30a61e6f9e7cb8ed6a20d4cd5c167",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12262",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/l07/08s/aHrCzPT6egNNO0lM/component_thumbnail_16.png?Expires=1655683200&Signature=CyRW0FnAwB6fXydcOla5T4yHdCYf18ruNjdWe4J3Cd185FbrpYtXJWfcfeOJdEfpaz2lShD32QHpaGzKW0QEQrvVqyZQerXA~GMJ6C19Q9Ui330idLWsONcQMh0pFCHB5HSKql4Z5zuhAQ0915LYTXsQmSdtAbjvbCg4MpMTaz2nJYfNTxLniOzFWCH3PDmShsjNKx0ofBx3GcjLzGnsalGaikUydGh~gIG5l-zCwZz60MczCK1yKvMUZNDHE4LV~FbCk9V8QZLZKTH4dfDK3fBif5080c5h2Ex7gVphOpMIRs6hldjSwaY~O4D2SZ4Gp8Zn1NL5aLniAE9WNVZMMg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=16:9-711x400, Overlay=0%",
+                    "description": "Image+Overlay: image-ratios/16:9/0% \n(#Token, #16:9, #0%)",
+                    "created_at": "2022-05-09T18:36:02.553Z",
+                    "updated_at": "2022-05-09T18:36:02.553Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0f9c45bacdddd6ac9eda2bb6fbae5b7bcb6b8b4b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12307",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Kx4/XOx/xx3xgZi7NpLJ5SpE/component_thumbnail_15.png?Expires=1655683200&Signature=gn33EUCEh5aGgb7rKTWS0xuFmB0hLuDfwXtmu5zOuIvjC6E4QNAJv~5PcN4WcstGlhHtPKe7y5ZLoot-nq83bvdeKXYmBjgqIlhcQNmzMSULaSWQSvDJxqBlzjbPEtB63r-sv04DsjZWzxjPdduU1CEe0NUmUG5bCihn5eP5q8nFbGxmuiSeC9lmzyyJHJGmb9rbI5uTPA1mhXXxMKeGSKd8q2KbRLrNnDACt7EcwCiWUUk7nPlXLxl5SXaKZM3makYCLM75lCUWOFp4-Obo~qVSVeQ3~iA4Dn8yGBXMP4cFVM-ChX2nJRVjX-tw1-mBzIORtlJjd1R8hCqknxkpjw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=5:4-500x400, Overlay=75%",
+                    "description": "Image+Overlay: image-ratios/5:4/75% \n(#Token, #5:4, #75%)",
+                    "created_at": "2022-05-09T18:36:02.548Z",
+                    "updated_at": "2022-05-09T18:36:02.548Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8db83d47149e315b9e2d90a6a64ada67b70242d4",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12265",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/oqi/xdK/yAtt5O1IyYzfmQ31/component_thumbnail_14.png?Expires=1655683200&Signature=LHqjGTLvxk7wQf7gk72h~Hj2I41BjGS0~T~NNqX2njuaoLE3XkcFibAQ47aoWWOmVCjemVMW1zGkJqJfwHb04IroDIN~M-~MVGegJBGHknmB6m9ej42ahBvjEsrSy3C79xAgwTkwZJ98~Z72Da75CB8r-DZllAFz~-jBGrWyDCZ-oTyDFoFZ-assqPz9uwdQj1qM4z9py2XzN~pA6PpR8y~IZ48oZUl0Ljm1TSWv1~GxOm92THuSUrS1aykAgIeDF0ivUr8erS1f9QkLnNnuHsWBpi-pFwnCPofDgYJA8k-oF8~4ZViS-Yv2yXGwsgtB8NRu43qrTWjiauwYYEkY-g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=5:4-500x400, Overlay=25%",
+                    "description": "Image+Overlay: image-ratios/5:4/25% \n(#Token, #5:4, #25%)",
+                    "created_at": "2022-05-09T18:36:02.542Z",
+                    "updated_at": "2022-05-09T18:36:02.542Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "40897a58286c2aef80c5e1afdd41aa693e0520fd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12283",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/BrG/0wN/J1rbaRRdKI9pnNxh/component_thumbnail_13.png?Expires=1655683200&Signature=FuZ7QexOPKlYUrUIV2veP3Kug-ef-hhW0Gt7naim0x8KouZU7mQDOOvcqXGkx98-7HZs8fMaKjdcsn5U4UjXbSwtJGBx4exq-GjLp1DnlcYaTtwT~aq3xUftbHu0ExvrwwezbxLmUtlZ8~gPRQ6vYRpBVODUOqNOB~zc5O9mYjsxWXjDJSpcRj0eBoIiiPtCUabI3AJzNLVvsqsWAOqHMesjAHCRLGxqKJ8j6eyvRot~~xf6-tpMP9VkX0D-W-Ouo~quZTpN0HWmgrdH3zW8QaU-6I-SfKi~XCIDii-7ihdAcGe6NqOQD1N2DDJ1skwn0c7eiiGWqL18SL0hb03AxQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=5:4-500x400, Overlay=50%",
+                    "description": "Image+Overlay: image-ratios/5:4/50% \n(#Token, #5:4, #50%)",
+                    "created_at": "2022-05-09T18:36:02.536Z",
+                    "updated_at": "2022-05-09T18:36:02.536Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "414183e7320a30bde9168facb1bb46b7a1f6116b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12264",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/QJA/xm3/xMKJDg8Tbbs1CA3w/component_thumbnail_12.png?Expires=1655683200&Signature=PGreEs9ItDq~Y6eeEJKV63E6aZHdgCUSmb5IEH1b46rPoLiaPpmCA2yVnKCs8VWtWda0TTERG4gQcAkl1vzxoisgbnTY-VC8pWhbVKe~SolykKmvuOP0hVDYZCqLklYPNKbMXwkMNnQ6ccObhToiHogazP3K~qv9KoBvb8s-cCC3Olii-Yjl~MlkwZF8bTBFKPNSKtANnswtMX3UYa0RuLH72VJ-92XdpQhVWuvRriKZA1Z-ZePC6FGeE6sUjrzlvy9X3nkvpflhyo7gooeKsvOU5xzLDZ1YS1VCWgpR7ub6sWHb6Qo83y73dCl8C~CnjENjuZF24nz2XcFulGmYvQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=4:5-400x500, Overlay=25%",
+                    "description": "Image+Overlay: image-ratios/4:5/25% \n(#Token, #4:5, #25%)",
+                    "created_at": "2022-05-09T18:36:02.529Z",
+                    "updated_at": "2022-05-09T18:36:02.529Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "26b14d180e47fd2915bd0010caa83bb8e195b205",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12311",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/cF4/YpX/BZKDKhpW6dR2cPFv/component_thumbnail_11.png?Expires=1655683200&Signature=hMmafANeZEhFtpAK~e5ei9-b8Tnp-BgRJ6nXvkdSZX6h1sTlNqUdxLwdJuJ7c~SY60KjFj163PlSQOXsk1Os0j79dwrAqhbw3VKWumkTadMWIwJJ6KkOTKi7JjQ-cMggP-CvihziCb8nj18UrgGeV0WN9f~PcNGM1dFI2Ei9MYEwK-8HTBeQLr73V1Z8MtwdRWvXzV5T25t8gwEaF-yjS49WjIdg~nstx7012be~4hgMgxxiOGRyueKXktdJsElU8vRjjFHkwZqRmFPDKAS6NCPn2r5~3UlYvoX2u9rAwmT1aJUnC46eWrCHfTbF4DTde3cDzDtUwi874KBPSxbpmQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=1:1-400x400, Overlay=75%",
+                    "description": "Image+Overlay: image-ratios/1:1/75% \n(#Token, #1:1, #75%)",
+                    "created_at": "2022-05-09T18:36:02.521Z",
+                    "updated_at": "2022-05-09T18:36:02.521Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "096fa5ce144dcc350ef4ff08b6aeb32df3205b78",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12287",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/N6D/F1L/Nk7whiKijv5FV9Vs/component_thumbnail_10.png?Expires=1655683200&Signature=EmEG~imCOq~5T2EMw8DxbGM9AtPq~EH5DfCNgB4bgt2oGMgyCejAiw4kDOMLNmd7BX0KjZptSbDtXW7ufrWq0oBlZf6EHFLQ73sPHsgsNuGIQ6sGFvLY-2wDFmIjc9VGPA-5RJ7h5BQpO0hgLGrmnogCbkX1h9g87WXdPzD7qnbFE2fV2h-oDUZ-njL6nhW8hmrs3l5p9IfU4lKUENGT5Y9Bdji1lucnHsxvUJhfqSp7Dl-gbOqQRRwEORKGaolR8oQcimZDltAG4c3cyn7ivORTLOKzSfM6iNqmw~q04YIY~vxPglQ36qi8Nsd24agmKBPQEVAn-UzlJEoX4diURw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=1:1-400x400, Overlay=50%",
+                    "description": "Image+Overlay: image-ratios/1:1/50% \n(#Token, #1:1, #50%)",
+                    "created_at": "2022-05-09T18:36:02.515Z",
+                    "updated_at": "2022-05-09T18:36:02.515Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "342365e9368c546f473675270d57cddf3b45b29f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12281",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ppe/cR7/c2mH7g5CDmV966C3/component_thumbnail_9.png?Expires=1655683200&Signature=az9wwdd-T9zz~Q5f01FVJItZ5hEWrcVCcqRNOJR7Hz~seY3H6TTJ-epaxTTM1l6UzwG6PktL59kdZdSwBpvpO8q4OsjqsDFSgXbWIg8sGbTsgTCH09NLznOireEW2YvEYx4g4wuj6bRF6Agwz9XpYIEe7-PWSVWLvrZeNlZQLKONzlkYY6PJfh504XYy0y-3NSs27~flBZhtOT5vQNJO-C1IldS3JRIF3rB0vVQ7PaQkKpqaXBlUtxwv-GV1fA0ijCIkc-LpA6hYMCUMJiisgoQruTASYM3olkWtJsn9d7emsySH~B2wX1AGTwOlYmPbTbz4D6c1KFIyhlHnxY5n4g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=9:16-400x711, Overlay=50%",
+                    "description": "Image+Overlay: image-ratios/9:16/50% \n(#Token, #9:16, #50%)",
+                    "created_at": "2022-05-09T18:36:02.509Z",
+                    "updated_at": "2022-05-09T18:36:02.509Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "10177efcee8b73711a49df42c654378159c275c5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20001:12266",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/v59/pDL/mR7CsmuuXPQnwt60/component_thumbnail_8.png?Expires=1655683200&Signature=MViN8K3nwVeZqIW9C6XkT1WVnYztIeBs~tjFUWiNPgu44JAn0q0lsjyjxw9rl60hxQfbiST1wSDeRSlolaxJ0J4n~sjTxOloTfxIoVSX-4--Hnq6BSutrnCbBlZk-~WFepEfBaNJ0jOpE6EQOK-O0us7NWjuuj443C-iDHQIQac3l8OiwXCkCZ-BKNu0anUUVESEwZ8IOBn~~yhckGWZ2fiY9qn8p4cVPHgR8em8aCOmXTiA9XDCREw3nI2-g9gZWJn2eHqS9Lg1wMK4-uy~G6WZ~Jh8QUWhqaTfhFJ7nslsanXAWQwq0QL2r04ePBquP1Qi8FPh7hjt0siLfcXZxw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=9:16-400x711, Overlay=25%",
+                    "description": "Image+Overlay: image-ratios/9:16/25% \n(#Token, #9:16, #25%)",
+                    "created_at": "2022-05-09T18:36:02.503Z",
+                    "updated_at": "2022-05-09T18:36:02.503Z",
+                    "containing_frame": {
+                        "name": "Images+Overlay",
+                        "nodeId": "19983:12943",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "image",
+                            "nodeId": "20001:12268"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "eb9823bfdff3937ea6d7cf81dabd3c145dca41ec",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15259",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/qNf/2Lh/UxzmhZkZezvPaXiZ/component_thumbnail_7.png?Expires=1655683200&Signature=Los9splPsqUTUTG56LETpO9BOWcqFDBPieR~Pq7sVw0IhnU6fGlopSWoyOG-FQLtx1vRSTEgw0LgnzW4uTywK5borJel09CXdS3M6HMawBNA4z~NzWCmpufLgLYOkLvRD~sMa4rCSOhWu3~x9eFoHIzmqWLGXBgwWs~axSzw~73GzUvHTeayaqSmFxj1lXuYUGO6NS-07E5cBFU-GmrRbkL0KFvK3MH4eq69vjBLZkumqEhl1Ebtmtzi~J~P4tPmIZZTQsHSKX1Wpd0zC9LnP-jGVT7xsMSmmQhYQdmaVn5OmQasUUec3a-TBiNHSuAgsgD~9I0u4c2dad9fxxdKWw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Roboto Regular",
+                    "description": "#Roboto-Regular",
+                    "created_at": "2022-05-09T18:36:02.498Z",
+                    "updated_at": "2022-05-09T18:36:02.498Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Font weight ",
+                            "nodeId": "23067:15262"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3eced18d5e38bca2ce1c852fc334a0fabcc4c798",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15260",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Ckn/OQr/qaKzYjoVVAPGaSxF/component_thumbnail_6.png?Expires=1655683200&Signature=SdAHNNGubP0jT-s2E7j22qY3~Avtx~VU-1Do6MwaGvzAuWF9p5YoKyzC1Ura1B7CvVvEpQdFuLIQCdppv7xiz8TC-d6OBXaZwjtctv0ofXJI0NJKXdvphsI8NvMlyuB6BgC8BS8Qh8cKX~kz71XETwPwdwvIHJZHNnbFc~5dlV7CAYKVQD5uOsH41JO-8gFHyDFleROfojyy8h8xCpU7Cu9JLeArF3uhUn9Hpa6icrH7wJa4F~9aHhVBI-nYmLa1BJvwmB1dgLi~Mns3j91oDZEML0NSSnOwWnrsERNv3-X-5m7ceOMmu88YtEVFIc9TacjqWMdQAANCkOYpfhQJEQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Roboto Medium",
+                    "description": "#Roboto-Medium",
+                    "created_at": "2022-05-09T18:36:02.491Z",
+                    "updated_at": "2022-05-09T18:36:02.491Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Font weight ",
+                            "nodeId": "23067:15262"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "bdac5d0c2a38cc97afc7ef2f82117a4962824a82",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15261",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/2eP/5st/eu2JK7jGEkgHtPXJ/component_thumbnail_5.png?Expires=1655683200&Signature=KhkhATqbIAFWFTrraz-kpYwvdpBUJUQXNvSsWq908bfNzPxtQ~GEkmNI9EdBmq8XYh-2Jc~Ls8DEC6KRDm5BcIp2XIwW~-w4-1I3PDMkqrRKGY2FA5c27PlIM9sMIJe7f6JaCNUC2894vUldZsGn7Kwfuu1vQHvYhpPQQDFpaUpRX3TbQXXlW6JXLp8Qqa4J8n-lq4vscDK9K11s4-5VRRCB1n-ugewNZXCmPnA3SEyUSZ-nTv3Une3yyW7RV4XwTH05hwkkIDvcxMzJ3vN2HE-oHLXkJfqNTf4s-ap5Aso85hi6bD4RMOFs4Ntev0OWAcdGVqLlVq3iClQHut89FA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Roboto Bold",
+                    "description": "#Roboto-Bold",
+                    "created_at": "2022-05-09T18:36:02.484Z",
+                    "updated_at": "2022-05-09T18:36:02.484Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Font weight ",
+                            "nodeId": "23067:15262"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7e1e0fec13f67aceeb0d1db5ed438c79e6f168f9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21:14",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/XaV/7Ae/eIYSjq0WVFLWqd8r/component_thumbnail_4.png?Expires=1655683200&Signature=P6zQ09LBdHtHnqYwFWyRjRUBaUauoLWkmTTLP4Bbwv8RNtc4CzUUprASKYL1pUblTr0tP9xQVRNuczBhe3-UbWgknJUa6N7NomhxUwE1HchiZat9fVPwECPQD~Mi5nrXWQo2GnMTzvnXWeNhA~RMQRu5sQmHiADfPOqgu5~RAl6CFUi~eS6D9ba-2ME1JAFimFkeQnIFI0BYLcN9wKW3H24KNf-VX7PMrkhT-WsuymqkoLvzftdys4ZHTmUpoEgxWseIAPran4EwwaHdVvIVpbHCOw-rpGBOvSEtete0pJBaD1M7YNlrHp-8UFcY-B2~XYLHWr~KfvZK2kxhH9Vwvg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Label type=Mandatory",
+                    "description": "Label: mandatory",
+                    "created_at": "2022-05-09T18:36:02.478Z",
+                    "updated_at": "2022-05-09T18:36:02.478Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Labels",
+                            "nodeId": "20175:15020"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "687aa32faecf4bc905686a3bb72f14916893d24f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21:30",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ZmX/Qwk/4jNoVIDIWduYQvrN/component_thumbnail_3.png?Expires=1655683200&Signature=cC7~14hx4noNvL3gM3T0KL7RgqZ1kUydrRta4TCZzcK3OIT3wvbSdbSmkmYFhmmfid8DL9t1U2ccwzd6wvsmTMYPTVBG-U2f0QZ8AE0m7k3NoBJozDXqDXiqVBwOnj3it-ZXUC~1varQM5TxIOGjSVh3twivIxuBc7cxaHG8twc7SBBZ51CYqXrVl3KRxRE4dMNxWkyONfCHlbCJmOQTLoEd3DZkOJOTmb449Oeuact9~YfryyPWiZ59Axrbbn1ArXumawm713up8jg0NaD0WborTTW4JqxEIOvYVICGxZR689v5-sNMwjsKTx4s6b-3X5HNzefp3bcTg-jPZCTF~g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Label type=Optional",
+                    "description": "Label: optional",
+                    "created_at": "2022-05-09T18:36:02.472Z",
+                    "updated_at": "2022-05-09T18:36:02.472Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Labels",
+                            "nodeId": "20175:15020"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7579da7dd4998aefb273ecfb6778d06bb327914e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "54:2481",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/v9N/PeA/jpNRdmO0nVTSTAy5/component_thumbnail_2.png?Expires=1655683200&Signature=NeabBuRb4PCW0f~mANOAPFTRNR99IFio9EnrUjonVVqewnXVUEaUzsulxRQ7XfG8eB-4OnLxvajdQkai5GdSS49c6w1Slka3P91tnXHZaVvg4wg3Hp0Z3YhN3IrbuIMIEX1wQ6iv-PNaLPjmfo3z~NABRKxWN5xdo5JH3OgCNMeCHj2nU-ZKTQaFQrjxfXnuFjXWLcUrkJVt2dt045mkJOlrp1QCq3Z5C7VXxoLugqu7fRFqCh2DwrCXc4wNf~6ymOQlMSP35jpABOZo7tbTtvtsBu883blUBmXg1UN1sOIlLE3cz0p7VMxFlw-3htDJX03Ft3qBY5K~1~Be8A~TLg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Label type=With icon",
+                    "description": "Label: icon",
+                    "created_at": "2022-05-09T18:36:02.467Z",
+                    "updated_at": "2022-05-09T18:36:02.467Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Labels",
+                            "nodeId": "20175:15020"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "260a579a4a9c6a1531124dca9bc71b298041c9c0",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21:55",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/fGS/gay/44uQA5pUOFJPjXyo/component_thumbnail_1.png?Expires=1655683200&Signature=hBWMGrtNDbEfdJCz8eMLh~Wxx-xl~0x8X2Ab~DiccUdoQI8f0avuCyh6dpCQV3QlEg3qU-kZYH4btGj5qf1USZdAM2kqmFcvzuigTyfPcXWKLgi9kUyqgRDYPqClT-t4w46TOzA2tVfDwbjdSrzdK2q81C5-LDYrYvQ-7Qvs9tDarJLHcNTXCjGf5QqGpRLiEC1RwlukjeHGVXHBgj3ZZ~6sQIAkR39AVa~lX2hYxjJyQj0nSeAznyVwCAmz-VK0xsfoNC-wi~-NLPE-bcUs3GUaiAD-sDHZsRoZKbMPplMAOcJAub93~M5wp44a6CdxSyeHXgmuNX9tppwawwbFWA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Label type=Default",
+                    "description": "Label: default",
+                    "created_at": "2022-05-09T18:36:02.462Z",
+                    "updated_at": "2022-05-09T18:36:02.462Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:9476",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Labels",
+                            "nodeId": "20175:15020"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7b4cbf041a9848164062280a550c0ddbb4df0563",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:6068",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/kZu/xxm/3RZgN4nEZMrL7nQp/component_thumbnail_0.png?Expires=1655683200&Signature=InWELjUh9gilN3aILK5x6IC~ck3VFQAi7NvDV~K05aKDjwFojTJ73x221g08pqwip3wflvAKNj7fXI0nXRIvVoJ5Iy7q4zSbUz5HfZoUO4qdZ6h0y45LAbiI27x9E0mhMOaF8poMkiP4kny0UbXtgwK0ak9TGtjxXJLFsbkchMC3frOaq-sOY-suLbOAKbpqaShgq~fojwX3E59HJuXz1HhR-i~9-6L-pJB8tv868GTwVyUX3Y-tP6X2InqoBQ7MkPdLgxRydUVXHaDUSEfhuOiKLa7bpSstqd5fcTNpIkKBEV~6LYNDjyu~Vbflxhgcdu0HITb7KLk2VMFx9L4ksg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Default, Error Type=No Error, Input=Not selected, Left Icon=On, Right icon=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.456Z",
+                    "updated_at": "2022-05-09T18:36:02.456Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0a1d71cd10634e354dd5406ab8c9166a19bfdbbd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:11096",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/iKv/Sh8/aNRnBsqj8nE19cxA/component_thumbnail_199.png?Expires=1655683200&Signature=DgaiMChTBDRPva3Y~8HawLobWGrn~22k2HcWLcliEjAWXSnXENf843BvHOVtlgViC-lLz4kNTJQGk5wMFUBEQ~IEgmGidipKpoNah6kOV6BbmIKg979OX4uXGaYjI4LFg4R1jAxBIuweFUCuaBA69bMaNKyFXKaW5wqNUV0hVXKMszW1EB2UXDmJywO9ELYct-Bl3d6NBeuzpAO7iTBAlIiZI8olCzEhK0PMEvIz3dtEYYmxNsgdJcbOs1JQ7hmDmhBzg8BI8CwW86QmTUzahztUcZa6sjZWOhQZrzXHMRDRS9O6oYn33jDj3DLCulzSeCW8i2HgWU5as1qXOTtelw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Disabled, Error Type=No Error, Input=Selected, Left Icon=On, Right icon=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.407Z",
+                    "updated_at": "2022-05-09T18:35:47.407Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f9827e6a253a871886ec0192d7fbed8e3b41f76f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:8181",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/vhP/tCp/c0EKclo2JJL8mE2Q/component_thumbnail_198.png?Expires=1655683200&Signature=SNdGCtfjchGJe5U~SWlOH9sZtH3HLZeYFYHzeCl0qgZWqWQEQKh5rgxXLFKEgRsD3nYlNC8J17z~M~kFwC4izg91s~1yfOwAUHiKDi-kvT-NG0~b-7BaelD4GTbWpQgjiGVgvmP1uTSfaOOr2gCnBv54~9WD4SPaWf2XtiD00dLVuGi8TiBU4l-7h7MUCQ-yTzhFFYcARzUjiNUKfQeYaHB0i82O8a6jBReINTW3m0bivho2mGDcpfeQ5PeFz2wclVceuOGmeq8UezMsu5RFGLsPP9KQy-kyFX49RawbZ15TQBR0D4bb--V0211QitnXzn1Fy1rA46fOs1tR2G5N7Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Default, Error Type=No Error, Input=Selected, Left Icon=Off, Right icon=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.401Z",
+                    "updated_at": "2022-05-09T18:35:47.401Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "492b6e06d87d55cc71498ff775d9d5a0cf648095",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:8202",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/pIh/Vp9/QpKp5MQBbdnJXSwa/component_thumbnail_197.png?Expires=1655683200&Signature=G-ah6b8dpcsz440VBOY1yxlaCP1uAiPWi5bG9At4PHueLZWKg01TIuAZZKVkUbwbSQopQR~9c6KYPqF3JxKB8UbtqAGQQmLHtDJ2-OyTj56L9bssAPzFwiJuxz8T5t-tXQf1kIkIE2Ns820wS0fzvH0bCeOVvlub1w0acbrLJW9Sxs3ArSsZynu~72hTYR7b4yD44hMWzT2NRcRMJAj~fWP2khRXBzxXdz~F6nBwQorjmfYqq7cUJn4texEBG4Gm3w~TuUb1fYjUtGxaxlRuH2de0wHT3SL9d52kj0X-pFtFT4owu4dTg~r2YYFit70ZX9f4AL726QpJk~Qi1gyZ4Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Default, Error Type=No Error, Input=Selected, Left Icon=On, Right icon=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.395Z",
+                    "updated_at": "2022-05-09T18:35:47.395Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "009303b9980c77d6c16248fdc72a85f405773137",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:5932",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/vVA/h2g/PCLqxJu0WZxskcZL/component_thumbnail_196.png?Expires=1655683200&Signature=CeRi9c-4DdgLwJtmgVXWkOcY1fegLkihgOd1rnrCl4I4GGjwQ8bHYtgM63YJmGwlKt4TghZeLcpKkfWHqAWmdJgUY~4cxXzAMqP3Y0~YHRZT~6iSzPpB4Z0Uu727bHaUM797vLtPYr-aiaULuQZHK9k7yS09y1gNCXgXYr~oX2JlWVJ6t0O2Yuj6m1TUPxiC0OWMg4kkSdn3YGEMCnitPUhFEjNLNS82qjxCU2VrG9WViswlM1XBkNZxzOxU6qiJK-2pli8oBZZ6QxAWktWChx-IRmsXtMrnuPT3R1jl99FMaIdBK-FtNcMoULPGJJZnciWI8uRkgFL6PjVt1px06A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Default, Error Type=Error, Input=Not selected, Left Icon=Off, Right icon=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.390Z",
+                    "updated_at": "2022-05-09T18:35:47.390Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e6a97806e52b8b9f9c96d915ddef56274306d64c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:5915",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/g5A/dAX/VOmlkeYzYYgmgxoi/component_thumbnail_195.png?Expires=1655683200&Signature=SN4u3Xn3xeIkjK~X-npyn06gKYMuBcWNV-wnsYLWAU2bekyeB9xk4yh30DU1FwBjibQkhue5ueiSO3yLhwMGarG1y3yPJE8mDoqDk~6CjO6RRK8VHWXeKkKWWwjV01~UyzG1sNSzgJbY2GP-T1v3fAvv1ZEuKbgiUtj~jdF-2Eg3E~QqfU7bj8tRVbkT5Qc35waqINpc07r2GQ-M~TF55J43lVw0JBf~aqSOi9JRz1wXisVPUUtBmOe4GncKVE6gaO3omXAsLcWmVfua9cptF5xnbfw0PmzbpaZqYQ~jHzzH43Ir68fjpMVjwvQtXfTKHuKArzhWQc9qt3Q~bWyhfg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Disabled, Error Type=No Error, Input=Selected, Left Icon=Off, Right icon=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.383Z",
+                    "updated_at": "2022-05-09T18:35:47.383Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fb1e204d56ab56f5cfaffabc3c349d855b6482ba",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:5842",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/JS1/Ps6/58fj5WuxefvC7XDD/component_thumbnail_194.png?Expires=1655683200&Signature=ZGhnMWOLOvwKEMsxSofjQQDpWxFXp50qwPujnW9zvfq5CcFNVqwvhP6jwgQ~EyIk1pBp6vHNgaSOJzDADqIl6RgcmO3qb~aLpdirhR2b-n3ypM3r6HDcXNkMp6nW8eDREdEv~cxhlu-vjh0GbweC3kNSPvFCKRtuJw7oS9jzc-oq8vHlpq5KAbXHR4VpVfyeX4iNek29zysczgfkCJWKw1k7eUTJmT7XeELVw84adKqeoIHXS4I43Z~JVUTxKTGhsbKdbnABMTobaNBoQsg602oDULaoemHOURj-58tI43HYtyJgyCYxj5C5mi-ySE8RMGIynB05GW3EFTjO1xyq3w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Disabled, Error Type=No Error, Input=Not selected, Left Icon=Off, Right icon=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.378Z",
+                    "updated_at": "2022-05-09T18:35:47.378Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ccb4072b7dab8ee1c866ba4ec0f5d920df8befaf",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:5800",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/HQ8/Dpv/uZyv4UyDtC36MVL0/component_thumbnail_193.png?Expires=1655683200&Signature=PhLHhwEL23PA5y39Ruh~WESWuX85PvtAUDxdt5cHIq7huMCBbKJO1H9F~jtgl2W-zdtjj4yPV-UJqhJSw6l2tCRhTqOfdbwLPipBzyis~2qQ21eIKe3Spfxp~oA0JuJ3XEzCinxu-sThNrpQoLks6TgCyF4NAOmuyEoHwzjkLQm2obhFC8wdUYfc0N4LHOxA8k4fYXqpkm8BvMDgl2d-xuVmleE0t5g-bFvPccLnka-po8uoeURe~hYo5If3T1l8vHZKDYqx-6jmbSlRG0NS7z8kIF7pG75NGU2fFha7l22vzjdggItFl90UZYfeEEhws~b~masyNqQBMH-JTK8UqA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Default, Error Type=No Error, Input=Not selected, Left Icon=Off, Right icon=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.372Z",
+                    "updated_at": "2022-05-09T18:35:47.372Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e011b80e708e2129ec5ef320ddfe9b9e98d08af3",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21277:7949",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ynn/g1g/sebkN8aEA1Djli4w/component_thumbnail_192.png?Expires=1655683200&Signature=BONHdCM3dReRn-sSQ90P4JHIEbCCe5OQh~mkbfw78UGyJczDWVS8l4A1b3xsV0sKcRh4GYk09TTaxnbZvFjv5R9D955mPHYfKBxHwL3l~tDHkAAzcAaUygJWLSMott~fvigZTRO7kNObvf8PtOUYPiNq4JiT957DUr3ERC9O1AIrGh8aJOLPG6gf8ENTtsNx~5HqKKOz8Cku30BIF0vd~JACMF33aR-XSe3OXOXiEcH2ESAoavZ9nDtrxQk8t5zB69SDqROPmvjSY1Mxe4fYpKFmSzGFHiHYZymqAgoLTUpx1mz~4UIMNTfrycdLhZpUoS-QXQ3hlC6zMhKp~PFoRg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Open, Error Type=No Error, Input=Selected, Left Icon=Off, Right icon=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.367Z",
+                    "updated_at": "2022-05-09T18:35:47.367Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e08d9ea7b50165dec3176f0c97719d4154ba9737",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:5861",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/VYp/gvK/eJaVLCPchhfgOHaN/component_thumbnail_191.png?Expires=1655683200&Signature=ZaOnA3y8bVibcAUzuqIa8B031Wxrs9SOHUapftJBkog-UxJdGuixC6R9HwjNnDkSi9R1hBEC0RE9fAtWWrEts6DzwKTN9ySD5oHo5w2ZUTK7zS0~6QCSwZs5xOHCmQMdbb9t3OzZr~7rQGwj3Phj7QUGZHEeSNqGa-wfqipNQsrE8NrgEIjMpFhoLOYX32F7ALDrhKFGtEC1vwzCKUHMGJzdMEPuu6rwgTDJOlZvy3WpSXbvRVwymgTqnJCsPEf7uKwXgEahm2tBoAmvcgsTGfeFO5qRmTZx-xQwmYgT-DWjW2-8AypVsnlDkCO1iHZkhliGFn5B1LlRZhYxF0KVKQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Default, Error Type=No Error, Input=Selected, Left Icon=Off, Right icon=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.362Z",
+                    "updated_at": "2022-05-09T18:35:47.362Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0e37c2a65d3ad1f6441b20caa2a0e22728369f2c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20623:11078",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/5SG/rUA/aH6872dp1Cz19QKL/component_thumbnail_190.png?Expires=1655683200&Signature=ZHUrJF4KOgUd4pwCxBq-Xnhf5xTVYuDmODE2hbZqmCKZYPulc802dO1YSAASWgA54Ezkkz1ygSJ8nqPVDtIQsL3kCAnFDbWmMqBr0MwmR3brQYPiXxFOpVQsBeXIe2b~M-Wpv7br0mbKXEH6y9bWxaWX4EnEgHtNKQ9dYnspMNxpiNqcb9KEpc~D4dHfD7iMQioM284M4L5CNmlyI9Gx4f5qGPPyyRtF-ZpNd7yUZx~-uocPKOaDueI5fgp-HcAKHwXNwbv-fJHQIk2cEHc6c8dHHRJjI76fm48Y59WtOR423tQhkVXakhGXZGwvqWTumEPS5rvDYtw2QFHzG2zHbA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Disabled, Error Type=No Error, Input=Not selected, Left Icon=On, Right icon=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.356Z",
+                    "updated_at": "2022-05-09T18:35:47.356Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5c46663f60abf587f0da79105a9575835b875081",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20639:7426",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UeW/73i/g3ChhqmcGYYgXsgv/component_thumbnail_189.png?Expires=1655683200&Signature=f2crwxu56CindBfnOF47WZkiDTS4BU6f0S-dognyj02uudQgO13P-B1Vk6vwgWeaeTlk66clyLouXrnoJCAm5DTx-X8Qd42MLLQJ6jwMU-uV6Dp8XvMI3UITPp19YgjK2hgvOemolB0ZNEcWngwn0A2mKNJS5MGFK2JuKecTDauPHCQbYU6QbNJXRnv4DUUvjU50Hr5TZUMNzT0yEtdCoqIL3C4lJJuM3b5eclhC78jDYpbT5rTB7QY0nxAWZQP0m~IYF-f1xFxyDQYcBBTybQsW3X7BH1cXdXFesyqEMYJ14gBvfIs-xu8fMWQZkohUYFiPruR6iHAmA94Yq9I9pg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Default, Error Type=Error, Input=Not selected, Left Icon=On, Right icon=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.350Z",
+                    "updated_at": "2022-05-09T18:35:47.350Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "27c2613c941008e650b19bc4cc7c292827349862",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21277:7853",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ct2/dub/P3Il7eDim7y0NF76/component_thumbnail_188.png?Expires=1655683200&Signature=KzqYGgGwLDxMY5eRx~-6~Jz8~SLBf9RJ97rrzNlnZ87jCa5C3nQVNcxI2ULTmLJq3-Ns2Cqviwbz80U5xqZS8PdlkGthmSpyQbUeKVRr2V5TniiUKgt-xzlya4WtbkJt5hkXM5vzqim11R4n~yv24EBhM0hZtA9SNcHuIpmii~yrIEqhpCtKh6PY42rvNqL7h~xqausyCjno7Djjhnkkq2XxhhaVDlR-s8-BJrHWelGJFECCSO0lDs3lTTWiRrznMPuojTCTq7hjYNt5nUbWLKm37hN8cFbYF6ZOe~zxd2mf~17rhg53ms3wUDsOuclTM56FoR5ZYs58TV93uJSvdw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Dropdown type=Open, Error Type=No Error, Input=Not selected, Left Icon=Off, Right icon=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.345Z",
+                    "updated_at": "2022-05-09T18:35:47.345Z",
+                    "containing_frame": {
+                        "name": "Dropdown",
+                        "nodeId": "21480:9906",
+                        "pageId": "542:6317",
+                        "pageName": "✏️  Dropdown (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "dropdown",
+                            "nodeId": "20623:5805"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e2bc30bacde8c529cdee0a26177ac92ea6f41f3b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15298",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/lZL/R39/iZgRcx0zsLfFGVR6/component_thumbnail_187.png?Expires=1655683200&Signature=hltALnWtamIHrEJ~-bHEvvzhjPddyENV2ij8MPBh46hY0Uy7f9Gs8VJldZ-YYzswuqcv9TXNdNaP2V5bH2UArkESeAdZyos1To1KrnDZVjBzIjn5UBGlJ9dnfqlwlWUXYIiuHgGlAFBWjf57KMhpKlfGVzQQW3ds4SBYAOlHkgewW~JFcle0qXC~~i7bJlkDv3zZRpl9IhbIuIdOHy1U1kEvBMmTC-oQQJBGIxa4gy~v0K1hZekVsT~7Xa4894bD~9x6FPVHWyyPBSRVIv-ex7h-sGVMpzoyK7i6pKnmLjlqYV~nEAZ-A8P1YQOyUmiSPl02TpltpBgxU215S2xpEQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=roboto uppercase",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.339Z",
+                    "updated_at": "2022-05-09T18:35:47.339Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Font Decoration ",
+                            "nodeId": "23067:15320"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8b80453798c3d5f7d1a93d7f74a333fe73a5c9fc",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15297",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UFm/TjT/0P2O1dnFjV9iZRzT/component_thumbnail_186.png?Expires=1655683200&Signature=LsdUX~41MUOzzeY69R-xB1lpb-DPA1lJxrQkii1ZRdMZZeuCt5vbwyNCml6Ha70xdOsDxkO93lH-Y2MgdaTwOjhNYXUS7ct8ie4VstXe9J7xfksion0JVBVIjQfdQbtbM~enrUgemRS~Z2bRVIlfXro2zRenPe7ji2QIWTcD-FwD7Sna8yScNgOYIxoJ4MogXlfnkgCsdNxsrtsWrTvVeKmK3DrG~Y2h0-UANjS7-Yd~BSAiLj945T6mXQnvTG9F1gVd~zklYCB6UdsjIpUaULAuoWbeNmCg0uAn2GuuP-W7wn9xiaNQ~olTTpMKfWCAkUuQf89AY20nJQbdv1s6MA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Roboto uppercase",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.334Z",
+                    "updated_at": "2022-05-09T18:35:47.334Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Font Decoration ",
+                            "nodeId": "23067:15320"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "628aae6ba5f14e12600ab77403a18d0d317cb948",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15296",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/qSS/lrY/6xwHJSfQzYZTZGN4/component_thumbnail_185.png?Expires=1655683200&Signature=esQ0hGN5SUqgFT9YuBj96cP2kEdqXa8X7KmeoWRnsPPDU1L1dUPt9HYm1KOMbASy0K9DCahwBuQJlC45pcvMdBe2af9-7aEOJ4nZw5Szg84x2Cd0z22QJDVlKiElhTk4PKehKuWVjb0pJ1IxkfH-sVdTvhqJ2xEatbSMqT1y-t~ZiDV4kByK96lsOMabGyKZ0MqLqMiKRNbSHTfsJrnSTlEbDHdAoRd1SxTctg0vKXF3QQ7UVXf7IcTbD0CcvRQIuHgtfawWandGdbE9TNsTdlg964PdltO~Jm3caZ~bDLecFnOzNriNpC5LlvvWnn-VVWxQ4DoeFjqCokwCILmiLQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Roboto Underline",
+                    "description": "#Underline",
+                    "created_at": "2022-05-09T18:35:47.328Z",
+                    "updated_at": "2022-05-09T18:35:47.328Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Font Decoration ",
+                            "nodeId": "23067:15320"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "43c6f1013b72a69e8b0e13710fa06122cf574200",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11387",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/BLs/r77/OXJhqjIbMXCJdIT0/component_thumbnail_184.png?Expires=1655683200&Signature=RH97UzAVsD1omypNzisRKYrfhJUOA1ssSwRe2H0QQe-~zY9osPlYPmTGaTO7-bWd7EhyOXTMWrtz4HIeAGRSJESc0wcqRjUNWAApv-JdlazFMqc9kzwk8pCHCc0Bf-s5aRZQWcEVE0hD0i5uYDVWc1Sw9AwN~XLvTk0r2sTI-Qxv6c~DFUzeBJrZtsxbRFKvsP5V7FZeu4cqPjH9rwvDDN1lTcqQpeVAzxmn4I8Aw2DaJfFVEVXZ4-Ih5hik3DPi2LlcMdoVtgePcyiA8iOB2yQcci7-jMm3Nv4rbKl7p2rYq1g~aKP9fh4azLGBbWv1O3kF2u9jtrw~~e6xzhV~qQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=5-(20px-1.25rem)",
+                    "description": "Spacer-token: spacer/5-(20px-1.25rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.322Z",
+                    "updated_at": "2022-05-09T18:35:47.322Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0254674d6fe4dcaf3be5d3e54e3f061d01ffe5dd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11384",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/AZY/6dV/QJW5NFDxOzY8dGTl/component_thumbnail_183.png?Expires=1655683200&Signature=O1V7PiCiPEziRuMiNX3ddNe6cZ9TKqg40egOOBjqIgizmfvCSfWuVk3VA1esaJoqMQGBcYs~M17-4eyQhdaqJv5JLMLt-wZgfMjkUvXSu2ISJlPOqCA1~2zOnjcepcr6tgPRwi3hYxd6hlvu06eDweNrjw3qUW5-XFFiU7Asdm~BS-D8JeZi8JiLErJeQtcrc9Tglc7S1bypuYpYU93TzHg8v9tr7UjeQJWy5djJ8cBZF6KFQaNarWmN1F933GWlcVIRbgpTgadDKbXUD~rLJaExBWsKFAfb~CKKqZp6TIzjJYSbZWoGGWLs~ZauHxOokJYEkFEoV6OaDC9YcRhzXQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=2-(8px-0.5rem)",
+                    "description": "Spacer-token: spacer/2-(8px-0.5rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.316Z",
+                    "updated_at": "2022-05-09T18:35:47.316Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "25b4044cca28964a64f4dc0d306c91b603309c1e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11388",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/QE5/7eM/zXpOU8NAjRd4u5dV/component_thumbnail_182.png?Expires=1655683200&Signature=SC9LUaphdC7Y7qysxyLtsArXmcizagW53hxcH8E23~xH0OZf5S2CuOrUf5asXzoQ6AGrNcyf-AMZGEvg3OjcgSa3Cb9mS8aTRC5UHpwtCozHWJiJNY0bm4TfCejGShtVA3V-mfjcGp~knqWFaxcG~guNA65AVTeNoHjSCnpOTa4-2vgz7Slyv2NbqIuDrMXY85eq-mVc7s7rdOcK2YWKssEe2EJXVKHH67Ua6kJjlYAA8BAmM7PBVEmXuqsz2eTtMT~E5EpJvV3wGf9HXpSqtp0fYqZvblyQWcoJ1FTeMDTR4WWG1VliPplonw~UqAFNwgrImURu750ft-k6q3HFBw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=6-(24px-1.5rem)",
+                    "description": "Spacer-token: spacer/6-(24px-1.5rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.311Z",
+                    "updated_at": "2022-05-09T18:35:47.311Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3bffcccb258c8bb98880a53c2a9bc82a90644247",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11390",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/YxA/M4n/GASqBAWusMM0C8tz/component_thumbnail_181.png?Expires=1655683200&Signature=L0kFbtzi4e6yirHGGxsNZ9Qxz3uUhanA6TSiyFf63OJgxjTX1pFeH4sQtSnnqGsJBgipDdnuptvNtpmLf5Ua~HM9wgaf~aNlq7v7T16SHJOYFZvamgb3utQ9prx7XcyQzzie2jLw8f80BxQO3XZF2x-TDuV5JQpKeVzj69sn2ejXbpGYkAq9r3y~ksj9ImSpR2K2t-WMRPAfv7ljWZEiqHHY2AE81e8ybJD5n1EIjs3bn8C9~hghxlEoL2nfbb4nzKKZtaPKqElYhGrrNelHd4kGAI1VWXTsSmBQE2xdKZ2mAJI4Im~dEc72mezFKQQA9pApADqrsr1sIAuwE-yPOg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=8-(40px-2.5rem)",
+                    "description": "Spacer-token: spacer/8-(40px-2.5rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.305Z",
+                    "updated_at": "2022-05-09T18:35:47.305Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1656a3627aab9c5921a50c4db15d9f537731f205",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11392",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/LoV/gAK/hp5nYN8obc4PkVmN/component_thumbnail_180.png?Expires=1655683200&Signature=IJZj4wxxJ3MFYi-joiKPM8YhMfh4Qma0~C284LAJPzzK1qK93ouB3Y93KkO8HznM1pRLILACNcQPRWd7KoBpKAPUzFmFBq6p2na1JO2VRy4xg-oxtg~0ioMTkwMvj9rzoQ~sb2FJurCQmzLiPSbR~dT~nO1GBJ2aMeGnvDFjQfkvHqyBWeOhyaeb18Snx0pc6ERVetue3EFyBDSlJVvDwiDsa-DDUSZ1YazfoH6rdUUFgx-knJI4~ufClmP~sAvwi59YqrsLi11xJi-tTLcqeDSabujze-nMnDukPE17EKvqU2fh4ecGJNol7jVX-94rizEZSdDt24SDC00pyS1isw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=10-(64px-4rem)",
+                    "description": "Spacer-token: spacer/10-(64px-4rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.299Z",
+                    "updated_at": "2022-05-09T18:35:47.299Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e709dc3744fdf0e51771bbdb8daff43578cb2550",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11394",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/BVt/iPp/0wEYZesUHXbQCC7D/component_thumbnail_179.png?Expires=1655683200&Signature=fj7brQw41H0QSZ-zDyTT~j5GVLvrE8jvpf8rewl-r36tu5dG1nWzIx6YVhKh7XB4yeS-1a3RicDFJJ5OO2oggprpy34YmU1HWdW5qwcIl2LHZz1O3Hns47SW2SmWGKH~-VTYIxH2Hmp~VFZg2IiNEzEyJ9XRO2B1dz12tA58LmwXLUTb5DhEiLl~3wZHBy83-nIPCWKx0relIyBvonVE0BLJUKISBjWXIuhgAtQhaXn6dVxwdDey3vyZaBMojabounvGbE3YtKYpPvxLzajBHocAmj1KkOUUOl-VRnJ3tYwo3Y1gyclbcR-eozVnZosyGd7aGvpNjkB8wbdYkV4ZdA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=12-(128px-8rem)",
+                    "description": "Spacer-token: spacer/12-(128px-8rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.292Z",
+                    "updated_at": "2022-05-09T18:35:47.292Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fa07ea38d07d5845ecb001c1cb4c2a89c97c537b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11393",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/xm4/rtt/z4KisbWNM78j20PB/component_thumbnail_178.png?Expires=1655683200&Signature=O2lSsTvj-rcB0QNmyfsLWWbXH~i60rQpVYngQ0O57v3ev6cBCejXPJ~54tG~80PW5fcMxSlsOOGmXpzPwa7FThHEUFGb2l2i-Jwb4zCOIfeWmRmtREfgmghaYk-zaQDaCeaaoU-KmWrXcgHjPkSr8iLcZ7SXfHCaNyTF6uEHGjm9bJJtNmJDobg9bSby~2YL3IjXR1thVy91DLxeK3ThxEKwGq9wI5UP4WU3KZGV2YYuvKt1OaJ03PjwScd8U3mEmFZERdi9Sz1RB6TPqYMc3STDH1zGdpaAf~-jMBQ8OLq1AKSFXWSENhaMB2xdWQneScwOeXFduNs~5nfdDLWjhg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=11-(96px-6rem)",
+                    "description": "Spacer-token: spacer/11-(96px-6rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.286Z",
+                    "updated_at": "2022-05-09T18:35:47.286Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f4b04d15b18bfcacde35c7172dcdb22a87ab143d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11391",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/IfI/Z2y/vp9qUhBcPJySlktk/component_thumbnail_177.png?Expires=1655683200&Signature=f-2gQdfZWhX4vUaY~ao3srCOZ5KQu5DGRNeoliCFaiuFiNHAoFIbXQAJQCEIo8UtHq1fCz4KHr90BiDsc2q~ml7szhp27WM0Me~RPsWvNpe67wSWbCu9lAFWqW-bPHFsY49y3culkq8sGsotQKFLkCpDlraPAEx2DSf95rRb3IHLBKA5yiqEcrMALPdfDUpgtq8fADWOUs-JMsNZWx5Q7BOpwL1JFXjuU0UNPadfMU-BEhjST2FN0WF66bn7~4qQfg7K3weZYwR2eFtLBiBdFnIzaiavZtgaQ9~MFrsZN79sqbIC8DU0Ao~XjCF92jofi0wz3TGPD8Yrde8CWI4Jyg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=9-(48px-3rem)",
+                    "description": "Spacer-token: spacer/9-(48px-3rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.280Z",
+                    "updated_at": "2022-05-09T18:35:47.280Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "85f2eebcabd0010493b0c714e70a7581696e5516",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11389",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/8Z5/PVT/4wW6iUirktbglBuj/component_thumbnail_176.png?Expires=1655683200&Signature=DSm9Fgfotx9TlL137W8jnd0veULIHaZGE7bDguSNPXKdJ9Hs4v37rZCuu~clLOSXWSVFLCsy4U4nSKdmjOpOLOFGFDb9Y2I7HpnmpBS0r4votTIbdmwoWefywdtto74Yzk0ebcM87-up3jdWqCX11nprUz5J8DV49o24JAempSfVBnA9KYpe39hnldn37wk72ixARgAixrd1Qc3TTONAyAUNGnmckmDPNImZUsj74YTSQwVWxciGnFe9rxKbfZJjD3DZfbh1iV4SRW-QdF6gFW4wjOjSoRxv1PEKkwzwB8tWXPpUPeyfbyQVGoEjBmShc3-5dBANS6gqnlS07U2QTA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=7-(32px-2rem)",
+                    "description": "Spacer-token: spacer/7-(32px-2rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.274Z",
+                    "updated_at": "2022-05-09T18:35:47.274Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "48cd4c76e9c56f481404cfe0649f84fe890dc28a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11386",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/jY0/jEB/phY7xm7tySbeF5m9/component_thumbnail_175.png?Expires=1655683200&Signature=SfxJod-vr9xU8BmTqQGZzroE7XIZv9tkAVYrovVh1FqB3aEiWbfiHUlWlN0JA6GG0AbghJobJqf5LGESFmJnWaDQSQLMiJFPPvt~jguxsDcCkn6STDVzF~ChA1on7nfs2-mbzIu8nXsV6AeLNrn21w4EcTwAgWWE23JrcZzdDh5I~RlrohB4-pASVppn0cF5ZShPYLhUmGgY-oy~m2J0s~xn1bI-XqlreTPHzN5fC9~sQevDJu4tEgTEdSlZAsHGnqpabKKWt79fQfdV0ZfEiieHnGPJywkEkwaFJ~JSaM0GKTn6LzKpsbhzUXTELAYOJ~ys6zDLQWYZygoJmAOxdA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=4-(16px-1rem)",
+                    "description": "Spacer-token: spacer/4-(16px-1rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.268Z",
+                    "updated_at": "2022-05-09T18:35:47.268Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6e5cce302084c4d715e5b348a24bc2e672c1882f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11385",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/L8p/4rE/ZF4AdyiJTdoMHlHb/component_thumbnail_174.png?Expires=1655683200&Signature=CqGJN3skDqBpSMe4FNrWp7C1SzeOjt454zEYLZS3hEDgGKrswumuYjo1w9sBo9r0Bxuj14YBCeq9mAVOz-97DnT5Dys6gSQz3VfKQpT~PY3ZfI10ps9eN-yCCGd6HzpHvSYrqSfadKpAAb5l4u9CDEL8L7EK9OfXDxeviSQJKJ5buLDmkppfRkfO85Tr56SJE626JYvwdHzbNUU2g5Bogm-sVnpCE-Z2PYouBNhFCFFaeMeqToY~-sRIwUQbMpeO01-7xU3RUVOT0S0Ytx4o8w9MX~RerCTvrPHVUhGxZ-wShP66Al28f16UqlhH1e6BB~Kk3T0WOmGIAVxgrYARLQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=3-(12px-0.75rem)",
+                    "description": "Spacer-token: spacer/3-(12px-0.75rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.262Z",
+                    "updated_at": "2022-05-09T18:35:47.262Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c7699f9db7602e240ac09a2f15a79f39f08a5a9b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "19987:11383",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/vs0/FGQ/ZRdHHzGTpB1V7BlI/component_thumbnail_173.png?Expires=1655683200&Signature=RwO1P687WeOo8CSMc0~U6jI7o6Q7pw65hruHAQVMakkvGWrjyTW-5DVrcTLfIYIxnIP8Pkga0OrBc2vF1Tm0zae3LHRL95z07qhRXAcWe8ACoOBh2i-~XpkC0eLL4T2idnpR9upU8WxGA-ItWXOjhqHUNtAUbns69PT5Rl2S40pyw33Hy0Ee0S6loeIVSZBucmpVrJ4UbYmE7AqI5FPWaGC26H46BpDCFmnpdjAPlRnZv8atdop0txOD-9UKRXfvEboPgdUCoRHocLq-8IalE5~CCUx3VMR1W3xQ~TlBYnD5WyDkLztABRV7oK6JRnpBmzYt9B8OmopZgGE2aM7vjw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Space=1-(4px-0.25rem)",
+                    "description": "Spacer-token: spacer/1-(4px-0.25rem) (#Token)",
+                    "created_at": "2022-05-09T18:35:47.256Z",
+                    "updated_at": "2022-05-09T18:35:47.256Z",
+                    "containing_frame": {
+                        "name": "Spacing",
+                        "nodeId": "19933:7957",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "spacer",
+                            "nodeId": "20057:9044"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "87bdfe4443977f55d110dd272ff482116f7349e6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23376",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/CAp/Txq/hJgPUOZ1EDYy50KY/component_thumbnail_172.png?Expires=1655683200&Signature=C96VxXa24jKpKzx5knOHKO5~-o3Gr-YTkzhHk1m5Aii3nDeKTyJe~gCVa6~z-dtbdbAzGIcE9U8Ko-5AimWj2xSH48K~rbWqZaaVqz5IGMMqMdlf6vBrWU-5zhrgHYIEoshN8Cq7prMkspkjA~11ZLqgk5FOpJC9vfMYMT8yrqWFHlnoz2G5W-uOo5~2-OEoeILHPvX1Bfy2TyW5uHCl2OylDQL~e0LoH3OGZwIlZAEYG88rssnguroLi17meyUAd046UdDpJzcL3tjboVuMuIXW7ABZDKUSMqayo7hLBvbh2fzPuduMtjh6AB1pnr4qbTDz3NEXMNib5CsqeV4VhA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=default",
+                    "description": "button: icon-only/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:47.250Z",
+                    "updated_at": "2022-05-09T18:35:47.250Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d5ca20eb76fc06e634bb48f4462c29e441e3d779",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23392",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/RVm/8dF/lAb0Mpb5zvr1uxZz/component_thumbnail_171.png?Expires=1655683200&Signature=hB2FTHiViN744NcXJVV-16ukXIRsuGorknCcRrrWgYMFrTBOwxnlxiSfdeaxhrarMpjmSobvjCJDrbmMvuPKepLfZmBD3ZIbMrm30A38auC66fCDytEw5dQtEUAKWUOJf0oP94R6rU9KPsnPVJbSdKkmv-BCQsmNbexXNK~ZjeFuEwA07Cj0RKBboJcdMg1XOTWoriSmZOrRSrIhy9ztoE8GdHGI2K7JJyn443Y~v9hSEwBU4Ofnotio5iA88HFTUI4-vhJanjCY6b~lPYSZqbs2YmDcGu~VzjjMAvZnZiS--axXhPT-AuwUbdQlprKMMqUqcmK9MuZ0cvr5bhHn5g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.245Z",
+                    "updated_at": "2022-05-09T18:35:47.245Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "801d588098caf83bcb0683f3a2665c34abfe0ff6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23394",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/NbN/iR3/9sTilJymZTO4oHoy/component_thumbnail_170.png?Expires=1655683200&Signature=BTk7xtcmVCrIbEBLgTJTA7xmAC6pLJjZ2tTQfNQmBKimryvqnJpJtpOSzRYz3Or4SunVslGPXNBpX0QnGAa~0mLBPL9c7PFikmwyUQwc7bEs90JSX4xiguJEsJ-rZTOOgd8CMcPwu5XduUqMm9U-0PkK2Z0hXYjEaI3m2NXHizkhxtfP6jL7xjgBAlqyZINfA~JPnL9uNx89scIP614uBSEbhEPwflm7pYfGFiTzL5ug0lpzHxWfGWdlGGUo-GjR3wE29kmP5QWTQ5Luu4UdYX~CkBdSNyVPD23irYpRmWx7leiJkzeScAw7v8v-HLvwtLMB1qtqXJa5~kq5tQyW8w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.239Z",
+                    "updated_at": "2022-05-09T18:35:47.239Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "698d155113ecf54f4f120690b1fb03032eee90fd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23380",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/vpS/wFN/3t6ewRkl8VCXJSOd/component_thumbnail_169.png?Expires=1655683200&Signature=HyH-HO~KqXBW45JRrJMlGuTdK41VHOi8KJcr-ZOfaCfA0d1yc2tbmolGevQXnug6UpU-~geQe-7Q4CzPK1nXDXWp~joistkvGE4Hu2b19mH~gL5Ty2txGt5WVuOANjVq0ZnAM3qHHw3Az7BPtJlmTI8G121DfqVhtdo1SNHLQRpd4nAWulG42aarkNSP6Lh1S9M6Mv8iPwDbRzAFoP7UwJX7smXnPwxDqwFn3NzaSiCpBedioyB~3X8bQLZ2OOD0giTnTZ5gCyaUVhdugw2cO~C6~OCi9Irj9xtWN~s0oOdHC5gdViFmLrDGw7PwxLMVz5pxoG4g7XCuV6UGGjGYWw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=hover",
+                    "description": "button: icon-only/hover/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:47.233Z",
+                    "updated_at": "2022-05-09T18:35:47.233Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "05141e5eb1e56afaa5928b13959456073cf6e557",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23402",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/jNK/eKS/JkTorRy5m17bdfld/component_thumbnail_168.png?Expires=1655683200&Signature=S4wgMSNVTH5uclQLubA4WPLFCC63C8e32mDOeHr6uQ7wdLs4qND8mfIm2JNS2MwBVX2rcAqKV7QbJSNGsi~GIMxYWT9DBLTczW4CT79ZHv2UwPxt~GgTKje3a~u3VfiR1ZTqAQziso17tK8J2zLOlkml~9jEDTldBk00f6m3Lo8UARkKmo3nX1p7~XX0D1UGX0SaAboIdnN9YCvpAnGpkfMGkyyJqbyeM~trIYErCFXy8v~t~uTIRO0R30UBUwa7f6LhXtQRBk0XQz9-gRZXAymXjHnCaDFTgjN4K7mwo0u-Cq9kABwRhgo7hVppANoG~zG7hmV5SZhOusTJLWGxtg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=active",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.227Z",
+                    "updated_at": "2022-05-09T18:35:47.227Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "55a1376c90fec46b745dfdb2626bcc3cc25860ee",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23378",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/G1J/tZR/gRYbb5NHzD2Ms8T9/component_thumbnail_167.png?Expires=1655683200&Signature=OhZLEi-memdtAhe3ldZE5hj6Z~yxtEqw9GC1DmINIS~8zCEP4Ai-UgSDFQAGHetGpmhdlmXFftKuJEad4wsb-laFfb8c2ZMBN~sX1BONGztkZBXUg4ZUh64pjLz2npHRAqfGYXfrhv4jEjXavrYfLZFeTWo5dhPXf~1y8OBMDMvoma9EW3S~a5KO-NT8-eQcSvDRdVqj6XS9r39ds2Xf7gjiJ6xw0NSwXleEe148cX5t-4gU98y1jQsjThWGcsUXmqdAQwP7gjd48Ggc2trXfPhZ46rmK5C1Sa9UQV9pzl-HpTVCr8ez2vILipt0QUSKfmdu6hQ8l9zqBjnyLrHR5g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=default",
+                    "description": "button: icon-only/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:47.222Z",
+                    "updated_at": "2022-05-09T18:35:47.222Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "32f6d35ae9442a3a0fec6a8e0077926c716ad323",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23406",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/IR6/mCq/gNiL7vmN7YezDms8/component_thumbnail_166.png?Expires=1655683200&Signature=EpBU-dWs0CCpMsZIXh3ziZux~kLgaGdjxfS~3yQSLZO6PIzZEfwp0o7uVKDwRuNcUcqFXOOtwHqR3U0zlUDwEw5B0MR8rG4SbcKXIe6cxboCOhmI3bbXeNcAqaKYISaV2l26H4Lkj~quVdcrncHBMFfl~o03reH3h-oFDQJcX5CszgQThhLzpoxh7ehnTj7pz-D2DXunCMeS3J2RehwZDLEU~ULyGOTl5Isd1F0n4Xn4WWjserXPeOi6Zb9bzIHw2N1rPPzIe5BrOCYx6JFqdAOY9EUOeHL36vYPg9XoZCRvcaa58eSOvqIjG4k0SuUikL3mSY75KUuxwqtm1Z3gag__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=disabled",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.215Z",
+                    "updated_at": "2022-05-09T18:35:47.215Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fcc544a9facb92605f68bb8403cdffaafebd1ce5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23404",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ebu/7bI/eSCBuRCXpLUWOgD5/component_thumbnail_165.png?Expires=1655683200&Signature=ItF4PfMQWyJqqW5XteQspc~zLITrNCk5Cq6344ysDXqiVk4uLyHvPwUGO3QCmmY0QD7Clv8UucQ99XNA8sLMJgGIBO3gLsU1S0l7shsAP9eKurrjZNlXCkHTdpxHAn~Erq8A9dH7llcBgOoV751RP3ak3YJzttmWw-c2tj0sEk-rSOsk6ZeVQ3h8uhuQGQbdINhaVdIkvJnQpkRXgju0M0p-XvxTzZsGZu9P3zMrFwAhCprFR0nlPRf6P3~bJWEG5V8pwNaIEj6SkGJJPenrkT~dNpHFZoKXVaurw34yRYjhs-QLPtKp61DvCZxbBkdxmOFWBPImKQ67Ntc4o9NNpA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=disabled",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.210Z",
+                    "updated_at": "2022-05-09T18:35:47.210Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "83177ec27bf1f78bc4a69afe2a2d6a7db261c0dd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23400",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/WV0/gTL/Lte0gp65FNBh6SHB/component_thumbnail_164.png?Expires=1655683200&Signature=WTNnCkkzzqE8NFpNeySYuIGsxEP12pwVQuz9fK~rQvEx81fJlqnbeAJAlvNC1wIjPpayDaUIzX8gQwA0ELe9s4fdtFfMVUk68I2WNygNLBJ149swP0pVUNqVbSgPlJNBKHS0kX2uy~eN~D5ygYVhntCQ-eQ-WxS4ewbi~pKNMwzWd1hxDRxAqL8TjNi6Bwryue1AKFWYFJy64D4ZhQ6ZoV0mPJ224xndiK56w6CqUwBbzs1F1S-MJbdypqId354xM7fHo0uSDkV8hf5nD54uBPoRk3wOVwAic6XdrnMXH8BMO8HXm0un2gKxVEebUSISPf4uGjVzsZacSmP3lz6qKA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=active",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.204Z",
+                    "updated_at": "2022-05-09T18:35:47.204Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "eea574ed426ce39150dbfb0bad3d8a51c808e27f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23398",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Iii/M6S/uaMdkudPtbQCPxZy/component_thumbnail_163.png?Expires=1655683200&Signature=b2T6T77IGbrvi8w9V8xlXEpI~i-wnc5GW5NmftCmVXtHbWh14JrxFAz0QVqam8D9yvpZ6rD91vh2IKFNCMV~E5x4MTaS0TSo0U4v1x5HOoquswaDlbCDtVKynLplF7bii2pGFbBdZ22SlQ~4EanmjGnIAjx7jz5D6vjrfHmNOUZqXCQQDr2c9vMdZjomKc~Z7Biq6tRTWCZd6DsHbUo-38MPja3cEjVsOkDNhotIhtLUzmioVffQNTPz8mMueeIrQb~7c9EICJT-54gG-y18d0Wk0vN9lTCrn0xYCrZJ-jprNBm7o3dtwX2l1sEyWxYG1OIZF9kmr6YGTWp9FESIqA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=hover",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.198Z",
+                    "updated_at": "2022-05-09T18:35:47.198Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4480bd5d97b7a3619093d75fd3bce7dd864e7cf8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23396",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9kE/wUi/GrSfchwhA37UO4wB/component_thumbnail_162.png?Expires=1655683200&Signature=FOBp-Fw751GrPLq7NNTUqp2pajjajYJNpc~OgbVB88Lw68EsN7ye4RJul7NXycHH5DLourqMG9SNVWImnDP67AZktqj772VwOEw7ME2Yd~VVK~nSROGlx~Sh7rx3EWTf6DFjlJFauQQeuKvzfHBpTVNz3~ttPcZZMJGPYAeQY2Pl0icQQxNEfLRt2rU5iB~sjhVA98q7ufBzZ6o4~oiYL3hHoXyPT547BEc-mO-XM24JD6v~NszJ5me5egM3mygo9o24Z~nQCH3y5ucylleoWKIBY~qrICcGI8ujKJiUzYH~JMjsKIEDfX-L1xx0toIoKW-1OzUp3iirEczSRldq9A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=hover",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:47.192Z",
+                    "updated_at": "2022-05-09T18:35:47.192Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "02657a4c01cc2bd8e545c972b08e118f56609e05",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23390",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/mjk/Wyv/PnuIdmotUbJnmSk2/component_thumbnail_161.png?Expires=1655683200&Signature=BOGn~RA97L6rXtZcRZA5B-HY867WXzeJKkslPxE~EOhAt6XgEXdksI8ttLCe3t5RKSXeDC3M6~~mGPwm95SCbf7pDJRS5RPH9un-ZVGMtiQMdV~~xmbGSVwjTxV7vcpvIxSH7lfoMw~IpyjqBy3hgeeOgJmAqSANx~F6BZgtlIrGGEWopP37NOeWxpjXF3FsIgOK1ZzpY32m2WYComLhYYgKleyJpq11KXdlZCTtwOt5fqlQumkoGDxShjYfNmiG58ehawwjymDI7zVrSIsk-XxBd4fyVj-ZXMXPLGYTqI4q5WF9OyPB2KI-PR-z2jFKyOHpPSb4u5ef-0FxYGaslA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=disabled",
+                    "description": "button: icon-only/disabled/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:47.187Z",
+                    "updated_at": "2022-05-09T18:35:47.187Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9231c42574c4447d92f8ac478b73af2ab3e3808d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23388",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/pEc/i0U/tfmfMje5pZxbEwbo/component_thumbnail_160.png?Expires=1655683200&Signature=TIV~sV0LZF4kYFaOLJWf~lMoBC~aZ5VJAVLWG0ddLaUWWRdE563FqmZMaeHNPJCBw9ZnIUj5Rzs5TTEJRBwao8bbyG~y69Ijg20Xh~hy0TXkP5iQ~s8pm3RSbz4QFZuOAQt0EeiawgLaHMoCAicIn~KEn~iQIizpvPUb8o7ImN43tFM4vJuvhrSctMa0vt-pmZ4AKQ-2HD8sg4mOZ1zTPAhA9QFIv78jCQarm3xrBPXuyYHTZiHq6IrmTZXzVoKuJ15BTxozCgdlsPNMcI8vZYuyrJ1JNIF2qJOI~8~H6rTGd7HjLsUtBlv4Un5-DvEMddZsIX~MkiPCibzZpd25Sw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=disabled",
+                    "description": "button: icon-only/disabled/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:47.182Z",
+                    "updated_at": "2022-05-09T18:35:47.182Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b2180b1e517d67b64b6f4be0c4a57ea4bd2fc72b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23386",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/4K5/ia4/RFAceIGyZE1Cz23g/component_thumbnail_159.png?Expires=1655683200&Signature=eLNKSSnRAZpjLkKPUnBYm42A1cDIbvIzI3QLcB1HVqJom4Zk2L52n0zIdenzuDh7lyDSFkwNJlC2IJKYIAZvmYLVTuLBqFppcr9kABUwgfI1cuRSEoS6C2WQOCC9D0lXCQXArVj2m5bpaCGse0EoWKHjpNO5s5aVg2QtOrfTrBb03THD6PzFb2XHiUZIujrGwwgCVVRWWFlMMfCgVC5kNC2QOElq3RckdC2x3B3tpg8MQhREAI6y4Yp92LtLUQe0MUdnGboLjCAhvPS3SXh~KV8dnhj0pvJQPQUp5C6QpPqEqDNAS9W0ymM4eIVZkPuLq5s-QysYv6N80~Jziq5nQA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=active",
+                    "description": "button: icon-only/active/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:47.177Z",
+                    "updated_at": "2022-05-09T18:35:47.177Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ccc72bea12bbf562f9bd6d3c5a7700f4da8cc7a9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23384",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ViW/mxj/RljslzneSjTxzBPI/component_thumbnail_158.png?Expires=1655683200&Signature=KvUibBWx3tBT28iX5J26vq4DTSJQB2JBCCPY51KLRZqarlHUEvKzSpcjzSr15dnedH3ymcVZ1PpsVqevEmqG-DdQ2gDjW6OcbHdEhFp4BMJPxA-nXTbAOIbsjQEOExTggRI1vwlQDeoOqRPrlp6IaXc4svao3S3E~~7CKv~n2yioCuy1dTEqNZPI~H-eUSUGcB~M~6V18gkR~qORCoq8Hv1CxcATsTQihzFn8wRYBu7UJvv9zXarLKntYPrZCD88kVVTEc6YYZRXQx5zql1SCJbyovlpGo0CwTdQJyhbMxwzGn20rz~gBPfS~OG~e14GYRN9C99qkD0Jiti0Z8Cylw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=active",
+                    "description": "button: icon-only/active/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:47.171Z",
+                    "updated_at": "2022-05-09T18:35:47.171Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e1a6ca6b551cf3bd6c66750b54f57f25b6dc4596",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:23382",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/iIM/EQ5/wlfyoF36Ykdl8svs/component_thumbnail_157.png?Expires=1655683200&Signature=BuHSjGvaV17yfF~n9uDqVBO1nKBMsfe~1nGSKXehWTWlxFK02aUJD5VVfKE2QJu~axVT6cVdWCIkXctqVniX41v~dL9Eyw3jghbPEhdfHieIebqganZU45BvaDC-7R7XdUiSfwuJFgeXLGAKYsx85Q3KK6~ubLXpImYrVIEUyMrPHSStX-GbnLXl7xzEW2hFRyzAUFtyKHJ2lOpZaU71D~WnDA02HRpyO83PT7uIy1BjuFcDtaHWYgylbaQ06OBoatiDEl1TgwjnhVNs6nLrKXKarYkktlohmLiaQ28avgoPWqccW-iLdEPflcsG0vt~jjQO6OgnCeRAnURGaP0CGg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=hover",
+                    "description": "button: icon-only/hover/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:47.165Z",
+                    "updated_at": "2022-05-09T18:35:47.165Z",
+                    "containing_frame": {
+                        "name": "Icon-only",
+                        "nodeId": "21440:21120",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "icon-only",
+                            "nodeId": "21440:23375"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0b6498df704999b41879fb4eca9fe82225f1e249",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23067:15280",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/01S/mLd/80jA8ctZ4HbizpiU/component_thumbnail_156.png?Expires=1655683200&Signature=EU9kd~WRnRn5L9ziM11rzRq9cu2wXQtgW9z6usqmjkTUsLeviakJEj5Od~vqwBoPoPYkcxL53g0dTVIRaKyGjWK6k0pmpAFGKF1sO69nwJdBHKHEcskqrodIVNh3DdpRhACOI22f~Q1ACKlkVKaYrGFiBVwE2qn7T~FGZGoyjGIyWH9hh0jxHvQqe29PAmF~ahMtsRdFyvOkZM39VCRRb67~FXaYFt-TvYyX1Thjewi3nOX3VrAMH8R~uSTASHDI5m7X5~SFKSDyZJO99kErX4V8wwmx7EAfjUzr5bHtQEuEdjPy2uhij5pmK9-Mf~pmPSixCd71hhBqRoFUdjOqFQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=4%",
+                    "description": "#4%",
+                    "created_at": "2022-05-09T18:35:47.159Z",
+                    "updated_at": "2022-05-09T18:35:47.159Z",
+                    "containing_frame": {
+                        "name": "CLI test tokens",
+                        "nodeId": "23067:15317",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Letter spacing ",
+                            "nodeId": "23067:15294"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0241591376f3c2b370fda8993e3a9d8b965719bd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21437:17114",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/fKI/dNr/QaLqRyEeC2qjN54w/component_thumbnail_60.png?Expires=1655683200&Signature=MDbu40tsl6MwiTZiQirasSm34OHrCV~pxdGvhkz4vT2gDRlgMaHVUKiNY4ZJwHwXRNYe~q4FqfK2mYKpFFo1nSfnIOmYTsJNpIxkbijwHTYIlNwsg-ftpw8cSlc8SaYDwGY5FCbKm8vAguRMXqDN9SVTi~30Cs~e395pz8PNt4jvd2JD8YAFm5o9RZ7Leiknzsk4CH43d2GD9zaqTF7Y0Vx80kz768zBavKemc43BMLrBXMpiCj8bkceNEwhZx2629qh6o6BIfFkBzsfdx9ndA-xn~Gxt3sovoRmIq91Of5L3yE9smFalbTU~ha3ywhsEs2lbG1JS5u3fD9jwvp5Yw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Base Component",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:30.116Z",
+                    "updated_at": "2022-05-09T18:35:30.116Z",
+                    "containing_frame": {
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9d724ae0ce54c7c7d4d27f91fa6938be0bf23b73",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21416:13370",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/KIf/CXs/nk6fLgFIc6z9IWBm/component_thumbnail_1.png?Expires=1655683200&Signature=KCKdCnE8CkHIRFz5vZ6cO895caqQsVilB2rfn5TyxxTQCx~I5w2Rt~qKJY5L92mzB9ln7wb9XsdO6Cnj8m1YawHyEl59YHzWH6P50Ru42zNnjjdVSkaRb1JrPiEGf72-mq6FdY29QcaEMrL0Ml9m-OI1i27V93F03QC2C8tKiEQwhuBzEwtkOcrnunW7rXErVYPPoGwquzKI3xE9UpZ3l2ysOg1X751ZSL~ZNGaXIHAgPBDPaXTYAyB4rzWPRhIL5FwuOz1OEGKbXwd-c8SdsTr6t59Mq7zNYSXEOUQ~NU6L0JVxlX4m7cmYQ8NhLKu0NvPMnHbADJpF45M19vCf3g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "footer/mobile",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:29.766Z",
+                    "updated_at": "2022-05-09T18:35:29.766Z",
+                    "containing_frame": {
+                        "name": "Mobile",
+                        "nodeId": "21526:16491",
+                        "pageId": "19945:7464",
+                        "pageName": "✏️  Footer",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "efed45bdaffe72ca56ac865ad31ff1c068bb332f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8656",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/7oi/wfT/XkRYCYpxNjZpnqnv/component_thumbnail_11.png?Expires=1655683200&Signature=d77WPJr4YcUC3UETbh0HZYbZijVeHjWi1~sIbpHmQqO93kxwshDRti2QXSzwo9KDPqh-0SkLtrPUEALTa448VrjLIJyug05UD05XUdn2zwDC8DrcLfpvyllNZzNEP7Sp1GJj~yglMWVSvWffZGMjCGVMGSY3O--TN~OrED0jVjYY7fQRvNzAzhNzAp~KV1PRRVSxnIEkdjWZ1jBXN0sygK5Cl3a26D3Ug94Kn8aCUFkC0itNQ-YGbgwhk19zOFFrumZMFFEu3oKB2BXKyNxakuKJd3ux16P1h4hA9AEZhPimURKb3QdK75O5Y-hcDGxM8A8x6oIjpVG6edXJV-5BwA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=default, Icon=Off, Responsive=True",
+                    "description": "button: primary/small/default/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.342Z",
+                    "updated_at": "2022-05-09T18:35:46.342Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "58d7b7f49b592d805c35330d56d1059d095c856a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8630",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/wkz/Jen/Mlpr0pdIyqG6IfQj/component_thumbnail_10.png?Expires=1655683200&Signature=TeiFNtoNnsZbDyPI5IBsc3y-F4sdgZT0h2Bojwwx5UCjgTyek9mV3DJZGo9kBqY51ZnvtPWjIw49Qu84ermOtqqppr6vO4~J-LlcjEUmMyTgqOOxn84y0MnrfQPnkGQsnp2l4mfHozxGzjDNZGr08FFW08yMy0x9s~jtoaYx6Lnko8AZcsZl0vYeQyh~-L0TvRWxyrbrlgIhvirUulu53aXipLL1NqBI64OOWdnsCJGpUaVmVec0y4Ph7GG7kZWu8iVBy557vTur4JzzlDyvk8dzun5i5hPrQox9Xu-U92GmIMmQm5Z67GIKt9IDDR~6hEMh6UAJVsk7dA9qxPsgLA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=default, Icon=On, Responsive=False",
+                    "description": "button: primary/large/default/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.336Z",
+                    "updated_at": "2022-05-09T18:35:46.336Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "37521c0c0e1578ce1ad87c58ec2b1a64a6293719",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8638",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/D9H/k7W/scJkJjl3yQViDefT/component_thumbnail_9.png?Expires=1655683200&Signature=bnpgTouFvy0-Y4Mneq1ePL1OpIgYGfpHRb~kxosw47qhFx0yQAM6zmt0mpQKkVhLXBghI~qz7Ql2mVPv7B2pcNJ47jgsaN-l4v7l~Sfely3~e5UVBhmoFacbETH5wxPoy6qAg7kfKnwqTLb8Mmoze-o4-Xht8QdSY2pkU93F43c-YfwfWqjEWX2B4sIf5aHOlNTcfPrY4m440E4mijugyozLf00C1220GmeFHkAo2byh0jQrjyXDST9~8qyW3Z3y0U051OMNXxbFgVVbO28QQpaydMrB4864zES0vsXazK~vBDs4HKo~x0zpMR3YCbOVXV5oA9obfmTZv62hMw1K6Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=hover, Icon=On, Responsive=False",
+                    "description": "button: primary/large/hover/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.330Z",
+                    "updated_at": "2022-05-09T18:35:46.330Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a4ebc2826ad15a42b807f0fffdf9ecb6c01263ce",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8668",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/u7a/b1P/wYd1wQoC1AgWsAt1/component_thumbnail_8.png?Expires=1655683200&Signature=JsufPddH4XxbcicJDYc4TZFfbuNXitpfTfBZorNWuvc-TGFR6KU86o4cWTgDEibymEiw8z47TepIYbttZBymkRAjymvMuqklhMk-p0G-DT7nX4S1K-MmPBzUQDBLc93HroLy0Op1E-xragDnuuTrd9bH5f2DZTTnieAKC-LYqSObS126m960cZifh7diPeIFs49fW-N-dnhxp1OzVIpwKJHc6OXwVR~2N~rlGB5zYML2w5obwFjCS18h0ZsGnGsznPCf9PyJFvyY2LciLFT6qd0CtenjNajEKjx-Kjw29I3rF9GgddLH5onyhwpixxdwoIvlfJVKXN4wa7foYgN~lQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=hover, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/hover/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.324Z",
+                    "updated_at": "2022-05-09T18:35:46.324Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fb53b6be64dc8811727e2dfe4716c05ac125fa98",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3306",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/y9G/0Df/6i43MsGQ0MLiNplR/component_thumbnail_7.png?Expires=1655683200&Signature=am8LkDIst4zYGMePwPYzZRSqeRjlQalCFLJaFodaitzXsw6MSVT7lnfuJZxcPP7E0vfkXGupY0lAzvOX8EX3giSCGnkI6HnxPY9Ut6JDJfFBKSH7WVv8pUht4yNiodLDDWFHqVqc0B6rnPpLXNn~AEKseRmqVuj-dwlasW0IZhJuKRrQiGKiKQd9dKD8IS0vqd~jkAJ4DTxmOTQAdxaAye2wNeTq-ICAfkcADS0E7fnMetFKCPdprLtiIXjlB1bnP1umYmvnTmus82l8Yzaehj3G1LhtpPTsQ1uMVgFZW59x5QeTqbmGjvxK-5Gt~88GnPceU4QVc-dcRD-I9O99PQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=active, Icon=Off, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.318Z",
+                    "updated_at": "2022-05-09T18:35:46.318Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "84f2b070b853b86c73538e1e96cbf5534f8829c7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9686",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/NUl/rDM/4X0U9CItcTnlXjZl/component_thumbnail_6.png?Expires=1655683200&Signature=PZvn7YEvF8~WUODkybp8s~WC3zVod4ZZ3FN5CIhwmvuPIEyVp8EVODwJRFMhw1Un7OmEuQScdqubBprH2H3ZJib0lTsdwf11jLwMviUC~VvD0FDXGwxrbT2SOYkNTMab9IKiRcenIOe5k0KQEO8YGxuY~2-yMKUIsWye0RrzVBFiYRufiwe2JZmmCiPq3RgDF2-QLQZzSum3ZChfRRL0StI63er9b7VG9IWrDWlwHcNe71GXz29jJhGnM9~dn8680sfNRGwxrHxr-hNuQI66gl-80O0JkU~~VPuWh2xxPAXVpaUtw69u0LPR7ZL9BXQmyIb2bGxFJbfI906N61SHTg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=disabled, Icon=On, Responsive=True",
+                    "description": "button: primary/large/disabled/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.312Z",
+                    "updated_at": "2022-05-09T18:35:46.312Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4671cff6bd82f025fce4badf834a17d563acd6b3",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8640",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Wa6/VOE/tnftdB57KQTX4k2f/component_thumbnail_5.png?Expires=1655683200&Signature=h0eP~cSqdT6yBC9dojPE335O7ZxS5nzBGNUBKhmIdKIfp5daqO89AHl20XEiIA5kR5lZerIYcb-mVEpb5VOab4359BHz2te3hOim2xWKONxObH9UxqVuEz52DJqsElpL-TQ1Egum0YvJCQizqYDeROMzAsfkkWDqE-NX4ASBjJXbI0FWsay~xshYlO2fsypNdhcU853oGTp6auG30g2l8FHuBgFD6hJ1~yPkcPNYaYZxsPQ37Vgq81hvysetcTjghs~5cBA5wzBRgN5~AAmMLERHNwjUl0ehWRWIC47bYkUvo9VtozwoNFjuKSMPwCIp6a-tUhgxrnZu1s8KBr6zQQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=hover, Icon=On, Responsive=True",
+                    "description": "button: primary/large/hover/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.306Z",
+                    "updated_at": "2022-05-09T18:35:46.306Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "293e59f6440dcc62957db3976ca106315db72a54",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9652",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/VfI/TMu/N2OL6ZlAyGahyiib/component_thumbnail_4.png?Expires=1655683200&Signature=KXgqtVAzydZ3JkOXoLdJk8manGzgiI63v0t4mksx0vUxmvwcrJLrZ9tnz06MUz7Hf5URfBVX8UrxRbgAo4tcCJ-vOltSkGDvgyB5z~GlGg1dyPN4iatHAMYl1wgG~96Khzkx8gQaa7-srnb5koWgfQj3NVdUaVQE7WtHGlTjGEuGDHmAiJsx8yTrsBmKD9MP1JkDwL4sgElHMFTgFFu~eDu3CBHVrrhHQz32KbDMZPTyh6yiE8TJ-~yZYzY7MQxpwmecl8ZgfhRYYnGqH90O8vOXIgl9xWpAXTcmSdNcoQtG6DQBg12YsRwtMvNr0MHPYQUupwlVr9iMT-EfKMhcpA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=hover, Icon=On, Responsive=True",
+                    "description": "button: primary/large/hover/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.301Z",
+                    "updated_at": "2022-05-09T18:35:46.301Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3b75e5778e0530d17757e8d2a79d45a304f1f601",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9670",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/6Xn/AjS/ySX6AqCmhZqlYsWn/component_thumbnail_3.png?Expires=1655683200&Signature=D2Ii24vlH~oE53xIxTZzqOCYL1pquYhIlPQREYrbqkvyDs3-yyM7xxBV4a0XD4jcVSRhBXhD2EgPpaLdBAztXmJOzOAn8iua0OVqLH5JJ7DM5nDYn-QXgK7jyAHrS9jLSSBaCLhPiVi6Q9~Se3FlCOvAwA8GAdoUaM83k4TOlooJOLdCI50PNF8kTd08wCJ-FK6d220u9YZlJmOL50~QVASJ0tQhmKGTXGoB43QgaKU8pniJHbsCUK-wn8NTOzlMQhgFey5B8x0rdRI8rpUTqkFcBhQQ162j1qBg2msxmQhrB~zwYNXM9~-TOxbKegJMOtPwWMWmgo641kWmGuGiew__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=active, Icon=On, Responsive=False",
+                    "description": "button: primary/large/active/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.295Z",
+                    "updated_at": "2022-05-09T18:35:46.295Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c6b8f5375f763c4776128871d0222d7319c75174",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8642",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/X2o/tgL/8aNvlZy3Ugr2JAhq/component_thumbnail_2.png?Expires=1655683200&Signature=TibnII0GuJjntARKhmRDZlT8rL0Iy1g3fUxkfqXrcGs5ahijCL7d1ytPRAkd6-9F4SVcWekMsUFbuF~Yoa-cpOuyTNOEtOxBAsOyjV6YVmpXZIfHVpijhm9dl4tjucJu33iTus-L6mV00Ez6VyVGiKp5d~1sh0zlJEPC2fRcEqQHKhg2PWYtY6mPcemCrsRR5LQNdF4E2Rul5uzR7iF-zmc2ryeVMfH~bp~cxvjszt20F443Q0UapE-bDkQi-bs3Pr7oZ1aZc8RyGQnNJwE85Dy1fWEzYtCM-KMjwZsQti4sBGIG6OUMHwMWvnIxPYWa4KFMZrwViZy6JsSsFyMwRQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=hover, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/hover/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.290Z",
+                    "updated_at": "2022-05-09T18:35:46.290Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0ceb8af31658c23993cceaa0b7170657f262dae5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20525:4302",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/GiU/Ijk/qqsSsuuAfOC4sTv5/component_thumbnail_1.png?Expires=1655683200&Signature=Hq4sBe8ujRb1WIezgOAe6W1DRi4cm5bS6TWs3HrAx9iQMxH0M6xTSEnEWM3OG9sxq9k9RMWG3jML02Rxvl-EWCz7DrmLCDy1aPpHN-0jFVKdLGlSMx-plNfspAcHrWGIx0OAHWCVx7LtD~kwUCDcA5B0ARtmA4jAHQW0CNX2lFZe4ibWoUP98GUOluHYUM4FrLfmqtKMs7VyHifnlbQRMHYjxJ2W-zdYNSXRHlZgIEDL47zEvpJqVYj--2amtpOSmoUuEa2w6zYbp6FURpcIqq8wNODSl1b49V4lAZUTyOEn9BnFSsRcrtWgQ7zubY-fCAK0MFfs9gocfvvxdjDBCQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=disabled, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/disabled/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.284Z",
+                    "updated_at": "2022-05-09T18:35:46.284Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a92a6f81bf88b97d655cf2623c1565c2369f7022",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9672",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/DFY/zcy/BIU6ZFzxjHSVjmw2/component_thumbnail_0.png?Expires=1655683200&Signature=Cp4QMnnZm9YAodyOmIYUdFhvPo-FvQE7LtTHsRV5jha9aaM22AcH5gOMHnycC1KgRfOKtTZCnBRBLExl-WKCwLNSYNyCbjNgYHeBPdv-L4yawkZl5ALTL3XOqB6pWYwKDqYumZR8q3-p9jc2kdBn1EmFX~9KlVituw4G5GwNzVFD2cQit4ggypQKoZarvUsenGyPHMvbtzoMecIMq3N5zlfX~FcsuVtoms0-SxzgnXNcpY0IvTSF5koCejGbNIqhfZeRllp1F108EcwTOP414LjovI39a6peKBvnDZCilPj5E3hlJZjiX-mAmItlyY9plLW2Pcbm5g6VYaj7EHv~og__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=small, State=default, Icon=Off, Responsive=True",
+                    "description": "button: primary/small/default/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.277Z",
+                    "updated_at": "2022-05-09T18:35:46.277Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "074591e13ac04ff453b301ccf0fda16c827c5408",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8614",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/av3/Y8z/eVsHN0dqSBaxFwj8/component_thumbnail_199.png?Expires=1655683200&Signature=NItN6kwp9YshopaJ4Fagt7YrTL9AsEFb-bPpLbqfwkEBZF2tcb7ip~0TE1rR7Pawc91rbqp9FACze0TE9zDN1OUmikHm8iCdugcWx~Ftq0WDtAu1sTdf9Odf595TIdo6~KtjkOszxTRkNbu-3t6LYOSflCS~djMTxMkJlPjyfeEAyHRBR~0l5KTihsK5gWGetTWBjIADTeUOkWFajuykClM1NxSIsg1GXYe9JIrCznpo~CbZdQZFCsbSHLslVWw4HqzqXZ3AhGNfFh24N3aMhPZqzy5OXaHMuUAeizFbBybAuP-Wzxjxo2C60K2HFxe-JNTP~UvR7ci2grf2hVZ12g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=hover, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.132Z",
+                    "updated_at": "2022-05-09T18:35:40.132Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5c24028ec983813b07268762048bbb4c0afa7b34",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8676",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/xiE/CBT/6p94zgNJpDS04CyU/component_thumbnail_198.png?Expires=1655683200&Signature=e-8HaExFDQG0mTWZK2C16VRGn0GMy69hpvLwpJpF~H6msRv2WxyNJFzq~XO6yQzmsLQeXpDcaaxrvYeCviiFyvS~~r3o9SDMdJoXt9-XFekbYCWoOwE31rWuENdL5rUjVGy-HxEpasYTQoc6J9GP779eGFiWeoV6HwxnJzhzckECQ975BIcxTKgnDJKE99C2KJMeHlag4vyEJrTtEpmuKLBFqUeSTscHccOAiS3cbWmV085X4Uggqv77uKhukBaS276UEhPg1MbCst-t9CEpjdChDeqSry1v9C3VE5TFHdxj7T6Rc1ZWHH2TarSjvJdYd~2we-r~gqEOrfCri5MIZQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=active, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/active/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:40.126Z",
+                    "updated_at": "2022-05-09T18:35:40.126Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8167f51dcbdf623d811113820f432a6e8e597bf7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9706",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/01I/Txv/q8ZSqdjWkiwWkaEU/component_thumbnail_197.png?Expires=1655683200&Signature=B~zMN4HCstDiUMo5Qvd~W5r9nTTaPaTF9r70AQO9~55HxikBpKo3Ql0ICd2Q63VTXkv66t4fkecy0AccfzJftePhpofH9GRTC2T4QPfAylBiDBmUlYdamOuaYh9llhYvBHvc3~8pI1UvblrQiuE1lrjDN5VdfraP6GOy48dAqV476Cwlib-63SDNdCklIvrpaxH8Liw8egbphFlZb0QoTJWppccTmlMk2-zvrA6wvgiumxx5IFN4lfHbbzjD2lb5FwidOEgK1T-9kl84Da7BFCdApRq0GQtYwAs~nFfvIagQjF-e-hPndFQ9wQgmJV5WbNxo9rtr7iHz45xUoDG0TA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=disabled, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/disabled/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:40.120Z",
+                    "updated_at": "2022-05-09T18:35:40.120Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4273bbc17359c5cf98593f753de188f67c8a7f01",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3170",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ZFF/apg/TrHhG4ksjl8JW3Zm/component_thumbnail_196.png?Expires=1655683200&Signature=H-p7pq9cA~eU2PFGe-2n5MCgUye5MOf8QpBq72UJ8nGVW5j7I1D42cPsMTZn1RkDg4LCgZchfyHTwVowXJI9ZzE47~uzgMM3jBjcPnBXK8A1a4LKmT3vpntRDa3DOv-xqezNT-TNXwNGKNnMe3EG4tsb~gQZ~wX-QUWkh-aP3S1ryek1leR0jn8S1L2S~ih~qg-3h01K9CabV4geC33hSR4UCOf2MniOQWMWRSqG~idEE05zKXsWNl8dOVqtYHEkNkWy2KhCkhneq3Mkqo5qwqMLh18srBVJ3qBlZldP~vMkOGGipv9Ye2GH8axzAQGSIRQ4n9r1lRC9sCro6RmxnQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=default, Icon=On, Responsive=True",
+                    "description": "button: primary/small/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:40.114Z",
+                    "updated_at": "2022-05-09T18:35:40.114Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "43dbcd86bcf8a60d719a27339003331152be3a56",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8652",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/kz5/RvY/fHmx3sC621X9dW4C/component_thumbnail_195.png?Expires=1655683200&Signature=IvqiBI~yxmzVYzP5FmeXZnz9DIunLSgdgbpngxlXAQ4Rtj2xxJFFOIexV-tFoq0ZEjA5tBp7wyrlimKglU5qDuvF~ebyGcJX8uL4DP1d9xfK7kEXmt5TWKuNM6kxOA8zkuIFXvN-VRdgY0KyomxmBk8238DS-XyHfFAME4ev5YXGXs-l9BsAYR6JEmD84UNhB1FLEIYgru4PfbPxfFynkUCUqnwBkN5daR716gQhiZRmiN18Lr9E0TK0IUT8z8209I8uqquZmrBxNQ8BSLDXcIbdO5KvKd25WrYzt6-KJtM4MovR06rhP-ZHG-tH0Xk7vjL2jHhXAn~pByGefBCalQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=disabled, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.109Z",
+                    "updated_at": "2022-05-09T18:35:40.109Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "23ccda026142d8acb986c34ed6c2ebe6dd56e523",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20474:3674",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/pYY/h2H/9YEtMoMYzwmIFYCc/component_thumbnail_194.png?Expires=1655683200&Signature=ITzqWaTM1qJUplKFRb1SicC9vQHK7JXlQAwIREtB01Z-z-~twT4Mu8NE-KT~rg8EJ9VMm8Oe0hq8czIXR8OJ3ouHOCfBdtQmgUyBL7~kb1jpowr4xQZj1XXvXm~0XLgoXfSApq62qKZopYckS2eqsO32eTWHQKfu0j1yShSe-6ltpHV6VsWzjZ3b8rK4Xw6TZgaco3F6ea0ty1sNqWLSbyJHnkwv~ZqRbBUye04fPTrliy0x75xZX4nNM3Uz4ceuFr6KWD2WZBZMppt-thT9ktXXlQFuS2RZPbj5paIWi-dr7FHS5mA4WWVh2M-ioILvctpn3iJF~guiWMMI75Qj4A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=red",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.103Z",
+                    "updated_at": "2022-05-09T18:35:40.103Z",
+                    "containing_frame": {
+                        "name": "label-annotation",
+                        "nodeId": "20474:3675",
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "label-annotation",
+                            "nodeId": "20474:3675"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "31591f59faeb71b3a29d997786f8467195ecf9bc",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20474:3673",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/IIG/Nns/Dlp5UDdPTJ30bHGC/component_thumbnail_193.png?Expires=1655683200&Signature=OWr9q0WC68LnwxYEIZQEzGZC6POCu9TqApCRnf0keCBjDKBRwxTe5fVN5k84GfdP6gDtfjUZpOx7dJTSo4WIrLQfpytV-OTv4nDAgUvcB4kwlehO~jIfLqBM3iszDg7Rbo~-cn1xvRCpfonv~TmTKjGxgZCn2R7nidPf-r7Qn8pux31g4JT~f36OdPe3PPbf3ArcsMHtFLrmnasTWy-0Bt~CIGa4SxhumUwKDhHLtvfgR~2Z2ktwpokFajReI4We01u2uAcb2SkXKE3Q5JZNSfnZBg5ilHsoWkDKdA63yWPLQKYIQdDbH9WRxu41Y~MEvXyRJ0Oz3XJGc4PGP8MfWg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=blue",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.097Z",
+                    "updated_at": "2022-05-09T18:35:40.097Z",
+                    "containing_frame": {
+                        "name": "label-annotation",
+                        "nodeId": "20474:3675",
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "label-annotation",
+                            "nodeId": "20474:3675"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3f6b8534815877689c6af93d95bb87295713b2ee",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13617",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/HUK/D53/R5SoGCbcVx1nPoEr/component_thumbnail_192.png?Expires=1655683200&Signature=HXWBo9NmZ8YFNHMnKuhDIDXHTvfPbuCTX9VI-JoOxDSs4cYO6JrdFXObHYfIuAD8885V~dtxvWuOZpsS3PzdMSAq76JKFNwrHuek6QQEEa5M7M4Z8sTNNtZVK2iIA8g8J4oC5dhOK124KP9bgQ0X0yYDhrj7rUh~wU~o0FJC5RBqPzi59XVlaMoDe-TLUQa12vweMOgWyiezt~uAZlg628mSF-L~LXZ9caJ6XWXldewwCSZ9eZ3vHs4AeZfjfckJJW~VnBljLBN8xsWlDGryqMxJa-yijbIvyP3ZNslYmVz8xsNTfRpdfjN7m-~iOhHJXJQSBhFK79ChdE18MsUJXQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=disabled, Selected=true, Error=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.092Z",
+                    "updated_at": "2022-05-09T18:35:40.092Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "81d00ec64a5b6e3b8f5e55b1c8e1636b2993bbab",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13615",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/puD/emj/o5SRiayZ8cpwFM8Y/component_thumbnail_191.png?Expires=1655683200&Signature=Ky5SDwui6w6kW-T0tjXRproaJ8LJ07Z4wOMuL-qbQoG6-SRAtHxJKfIVze8vyOiE3UqvOUhSzAmKJ~QLamQKP5r1~AYV4YGxRFxGhP5MKASvEvZA52rROZnRu5eN2~psPHLy~CFxAGqARM4DYeJnX8hY--S4-IOAcFMfxQ5HBV7l68jZ0nilrAFGxmpw0~WhIFidVGBC~y4r8D9EWKcAhxRwPDyC-3OIeaiKI0wZY5ijBKXlitE89~QPnTNqbijkgXZ27jIuxGB0NHQeHbcistmHsICz4r7L66vwkkhEjPDu35vydjAMtM2GF~lXMQxmt56Q0Uu~rbnfCZ1Fjx5AFQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=hover, Selected=true, Error=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.086Z",
+                    "updated_at": "2022-05-09T18:35:40.086Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b03a5b3076b8857c2db437de65b5974dfc4dad5e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13613",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/omg/1d5/VhfdFiYTYTrLG6qL/component_thumbnail_190.png?Expires=1655683200&Signature=YbaXTPDgH9ADYHHOlQp9ao6eesxJYJNjvX74~TPV4eMAnXpZgQhSaD2VrgeaNVCG0ya10E-c45Ck086lGhW5MEmiNZfc9RXY1OowjWHqQ~5i4yxZgQCpO80S2Y6UI63-DwMKrZHQ3pdEzF0PC72q2gxUao9gtku-~xuq8DDGw2dOMJ1Q5PRU6GpLMVT9P5JMQzlh75zAU3tRsutVVixd4AWG14yCqaHjfKdaK5n9b-UB6J0dq2ZmD86UJsnZ9Me9rbun2t8dgoaLaJUO9CTJOgtimYRmG4PGF2mOdoxuOyr29SD45Ap74OTtFEGHI4YPj4SJyCbYBop3npUJDFFKJg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=hover, Selected=true, Error=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.081Z",
+                    "updated_at": "2022-05-09T18:35:40.081Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "27bde14ef310b2401b6565211e0eba961699b980",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13611",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/rG7/gtq/rxy9exgpcb6kS6zB/component_thumbnail_189.png?Expires=1655683200&Signature=dz9M7NKz~79jPyzjS2SMa940G~~DpjEd1~jUCJkauXmTGMMvfeKzo9R-N9JHYGCd1VTjhLny~4KLj8BQG3C2Z8HhD91axF7RxztVy5B3qXapxBbPnSHR6qMdSWuhCPidIU~WVbgaUdszmCtTEOu1e1u--~Jp2Xj~AzwLwz9zLgulY7znhVhb4w8Mh0wuw6krdsphQDUieVI1LFJu4IeG9T4DXrTWSLNprUK2Hr4qAYCx6yjC-06SJooxBxbbUsFwqt~G2Hr~K7c0JcVW09U~Ikc17ggUHwnUmAORLgRfhRkfBMCvcFuQOuMXWOxqSKaM7q1tLZ-vXxSYR5QzYnx9HA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=default, Selected=true, Error=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.076Z",
+                    "updated_at": "2022-05-09T18:35:40.076Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "710dc3b888c3d129a0f8c03b9cfa6df21a5c73b7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13609",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/hNE/oNG/JUevOnkC3yBGM9EQ/component_thumbnail_188.png?Expires=1655683200&Signature=Cro3I2GNVO5A7PNJkOKH2pErD~uwSkx5agmQRZ-FL2YhwuNJUjGPN6cJuZqP-A9qc1IFjXmAsZvQorSRuAZp3IUv5Htl3U-NiN5yQo8ibPPe5QO6tG9JLC16PFBMGYT-0binATg3deG8R-dN174PUDuYk9hB7LqT4BfegfBgPAt0LZwnofEsjTmb8vn5r8mxsVTR2kjQqMIQq0HsGwGxpmq9jB-81nheqZHDlLG3WdJkonmsrkT8bo129ucdfG9oT0iwkM6m1Zre6RaZ5FeT-K0aCbTvIw9fUfK~WM8yQ5U9yeLqN3To0PPPKlV9Zo9ncxgariHyfpoYYDYB9fScig__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=default, Selected=true, Error=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.070Z",
+                    "updated_at": "2022-05-09T18:35:40.070Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7f9867528933d9f1f7c84cc60ea6047a39e56cc9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13607",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/r2h/t0o/MfPNJvZMSrhSnS4U/component_thumbnail_187.png?Expires=1655683200&Signature=UupCJOcAU3zg0Lcsv3FvH2zULVMqEz8wNbqaU2HOwEZAbRONgcx2S1W9DLwARYfhQx7rE2C6-6CwMADb-oSOk-yz3x~4ZRMfe~hnO~wUvqznFIYUDElqfyiylbRDKZrlH2AycH-5ZhaVIu72chL0caA9-BkayLiE2TMBTfE5K3TjzR-NBeQZnBN37DQSoGJNWbQMsZWAPh-LlQRR6Ev6qJq6vYbsN5-vXrgaPRX3U-gIIpbkbinxgsTu2Pd15Ubnz9eldBbvWR9LgROLUkzdzNuD-BX9BKqvT61fXxTYvUrumuzbTPsLMLhyCSB-KSGmESdxCG~8IHQfhJE4bSmqpQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=disabled, Selected=false, Error=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.064Z",
+                    "updated_at": "2022-05-09T18:35:40.064Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "77641be13876da9c64c6c5d9cc0ac6a4867d0197",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13601",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/KFs/ywD/BMLSgvomMSm4WTqy/component_thumbnail_186.png?Expires=1655683200&Signature=DK8b3p59yXvXvXbzIHdQ2DmZmWgzUxkMN1j8fL-nTYwyHCYF8XVOrJu-npHJVWe0cympevgZOmZ0U3eM0HHbqObtMYSeNUvIwpDAD81TsLxQWT-zd2ySah8OugOde40p-PiDtzpTZsgVcU3usNKZqBDIF2C4KzXupT-zIwWdp3YB2BUyoy32CwUmVvgOxWyWOQ3FUjwoKNrHZbkrsizlK7s~qBZ3u0qipWFEnDG~b3yYGFZr1R-d0aUH6c0ZkRkwfnvxHZ-sC1pATJSmJADj9OSndBqbUgEiH94qiydqOZPdQKRVWnCzbouje9d-OALQfQT6e6g0auT3EQNQ~2qAHQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=default, Selected=false, Error=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.058Z",
+                    "updated_at": "2022-05-09T18:35:40.058Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ce10e0a4d688cb0d3693ffd772db238e747da7fb",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13599",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Gas/Yph/CjJJpJNZHDBXJ70E/component_thumbnail_185.png?Expires=1655683200&Signature=T2DJmDIiWY5sPvcEiw~zyPtDLvHR6VAUDCEKnHKBASk53v9jqPetw5Yb4GVoYWbGGeL3Ds9SLLiyhZ24mDw4JoPB~2wOQ2lRqFU9OdkVPZri0AUOWpBdRXqWH48TFUx2ItLhh-eOyTlKhw5YaGXJ4S9Wn4PnxpkhIED2PmCayIP~eMteDelyHkHpRYYUKqu-UN9Gw3yBIs4-0SCT2TJoCYmuusqzR9jDHwRwgzYbjg2z08sSZt4QkxDWZqGWErzVHv4xMJwrcOuXM6tLKK9wLHZD37r0wXthfQFGoHkSl8Ghtl-Lx8rtRgofE2Xd0jAVOXzG0E8OUFM32DWHkl5kDg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=default, Selected=false, Error=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.052Z",
+                    "updated_at": "2022-05-09T18:35:40.052Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d9c6d4becf615a80b6758be425549d262664a184",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13603",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/E76/gQD/mRjuzNXkJOA4Iaq7/component_thumbnail_184.png?Expires=1655683200&Signature=Dsb7CZSw-Cy8lYHQwN9RFepBF4uPIPOclGob-lL-YxaeskhNZT1me96bHskWXZl6q7wkOejNxz9tJkCQA-QJFD-7RYXFHubjNcSmbRWMy5o~04LEkrB4AGkvQVZgB-5cG1MfgjnoHRy2wphx5aXg7yqFlgUqpsPQwpu1WRWewiPwcczi8cMaekgPnTvAA42u5uom6ljVNWUwI-Llv-DY4bJGsoWjGKuIe46tFl9Njj0ISur4zwM2Hc5O-ilEBIM3P5ocChcsRWQV6UQfCfKwxUBkns-NIZcOguYBjARbMXHje1h1sKDFfy0JU0AueygdbSHVK-YbsAN3NXbyd~6EgQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=hover, Selected=false, Error=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.046Z",
+                    "updated_at": "2022-05-09T18:35:40.046Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "68cd16da42b0061155a187734a2d5d215aad5dcb",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21453:13605",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/K59/coj/nABtWT1c5FpkzYh0/component_thumbnail_183.png?Expires=1655683200&Signature=YYX0iBVEoyfQLOnyqd27cKl983pb0GVHfPXXkMSX97TofsmRT85AKymrMyGEbB1z-0Bd2AJ1PqxzM7nJgG29xZaRu6oibeskhGbrq9D6eq7lsJ4rxAE7kzkThjKvvUL6Ur00oSeNnGhH28kC-qAG22TSOgK3zKpgVeQnGbIrULx6lMQ4LF~IEPQ-NvxUmj5eUWmTIz2rLTirOc~GGlwdt33~J95E2bGxxk6LBEf6bxe~jZVz28QFOxQrVLeCC8giroVnMstBiXPRsgjoEB5S1GZ9lqdneOotgVmKQggt-n3f0DrcfLbDza3tjX5Xg5tzkQlIb0N9A12J0cl4MARyBQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "States=hover, Selected=false, Error=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.041Z",
+                    "updated_at": "2022-05-09T18:35:40.041Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "checkbox",
+                            "nodeId": "21453:13598"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5e2c6448370fafc1d9cf28e38d2f62996022656d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14887",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Npv/GNr/hoZpuJ7JqUa0cKbE/component_thumbnail_182.png?Expires=1655683200&Signature=DYBu1uFHwYm7QWUuV3rN8B2jsROragPzvwy5KIRp4vWJG8EKdTEhZaICgwWZyJLXVsNd1CWg1c2gX6RQ~Y1qJKDOKyQbEJXqPsVN-M12QWkMAe-yzFcXi46z5OI27UoqgvoTbOsm5tqCTQHh-IKjg13dLUku~Aiq56B-GJViK5mCpGKgC0HQ6ofx3GJTbpyxm0VgH1WVC7fe6pSVMTt~mkCKUUurKTWBTfvwvRU6mZderZ3YkIV942oRAdQK4k4huTZrYG9Hwv55q9ZwSXNuY6PmcIeAY6zv7lMqFdc2ASRO7FwSynK6YC5YdMeeJQmj5Uh8p473IELouOUvUwP8Tg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=Color",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.034Z",
+                    "updated_at": "2022-05-09T18:35:40.034Z",
+                    "containing_frame": {
+                        "name": "Mobile",
+                        "nodeId": "21526:14457",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".base",
+                            "nodeId": "21526:14852"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b469784894964d23f451cac9ac9a4f33a4b900c8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14853",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/kOm/B3u/hMjdRzmYTIS1zemX/component_thumbnail_181.png?Expires=1655683200&Signature=dlg~Gv12FfMf7BKcRUTcb9hTynpLQQr~Fj70Jd4rwAqU9d95CQ79B2Xw-dHKiCzlT1CH-ZcBHSX1fPwxuDPTk2W~XZKivkKwiqMJAk2CRprVVNGqSN2v2f2jsShZ05gAOBx3VlN1DFvQ~0UQqWC-U21Q4hfD93uUS9LpLv0auz855hFEg8M03G8ETNw1uTACdX2dAA~jjdSGkxx7CzqrSJ~~o85c-8rdndlyX4cM-USCcKFt5kvbDe7mKq7L7c4I~ayohwUPN6-WNHvsl8vKO0InCzq9ZJwse5e6naY5kZs5QuEVWx1v6KanjDz75i5qZ78gqaGzmCMQOcyoGkvIsg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.029Z",
+                    "updated_at": "2022-05-09T18:35:40.029Z",
+                    "containing_frame": {
+                        "name": "Mobile",
+                        "nodeId": "21526:14457",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".base",
+                            "nodeId": "21526:14852"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e52aa002258386d3c42633583d3afc511e7832d1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14851",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/p8l/iYa/MB6NS0JRQXWgcbEu/component_thumbnail_180.png?Expires=1655683200&Signature=aM-igJgZHc6ml7SlbnM0AkvtXk-2d47nfS8Vy2Y4zHHWuOIhYLOsDyXtc9FopXn5MYT6zTeasJ08Idy5UE4k1Fn3N4oo3RAVvgLi6MUypxWgBJVMHD8s~ZunHFjefx5TkzUJGZCNmuu4kv0UI-VTaufKyP1rDw1N9dKpb708kZQBA5nJlqOKbac9lu4oJrjaZ5wbWbzITwbRAunYuS7rnpyWHWMybqNIVmu-ju2-kaUQsIyIiWJC2JA3rP1JKPCZpy24Vbe90aaeObLyUjoxJAvZawwM75U5XpqnT9j7joKLKhn~bHLlF9Tt5WcS-OqGn9a-2~D5XCLrTBfOiLmbmA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.022Z",
+                    "updated_at": "2022-05-09T18:35:40.022Z",
+                    "containing_frame": {
+                        "name": "Mobile",
+                        "nodeId": "21526:14457",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".base",
+                            "nodeId": "21526:14852"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6fda95cb6638a86c9c7264b424b8c492a8e91429",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14959",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/kqy/Suc/GpV9ayqWz12P9XQh/component_thumbnail_179.png?Expires=1655683200&Signature=aKwaWo3t0v5c4KKJT9jVD~AgWlEKctNX~HPtJgJlujzP0Q338J06XmiW2YgOWuZUTHcceu4u-svBTe4mBTQRJKHwdMPKHYJ8IzB1ihy4C7t46vzuEupNkboNEu~Pt9YabPA-d4tX1cszFpR1HB9ygsuluEG9f7yFN4wiUV5CnVZGM0xcy~~92PYx98XrpuLdFjHzyqvC~nJPv8D5SGkXOzaFdEgjTK9TozQJc48uNZhrTB1N8-yXycTsIgDK~cyBn6pq-Yg7SloU6GLkk~CJgvMAvf9SWmxNfOXKgK6zIiG2JIKGvKayIzUE0b3SfNRfCYrGs78bTOyNyVJXyb95xg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=Color6",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.015Z",
+                    "updated_at": "2022-05-09T18:35:40.015Z",
+                    "containing_frame": {
+                        "name": "Mobile",
+                        "nodeId": "21526:14457",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".base",
+                            "nodeId": "21526:14852"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "81df573b2b4e73c2b5fae90fac8d76e97a24b03f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14955",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/nh8/q3Z/DSkm9RDvziop4ibq/component_thumbnail_178.png?Expires=1655683200&Signature=ezAOlDohAiZRC6cicXRzDoWWT4n-tvlpNWhiVtj0QC93qaCeH2LY7jWFs8bdsgIvyvGgs-GfJEoqmv4-kyhvX3AplUXX0gLKL6CbXEG0o7~xK34aUHji7XKcFLDO-SpnnPx~-N8XNtn7Q2lwDXhWbAhMdo~Pz4CMMsTHG2LG-aZUsnqcLfUsyFEhpEvE30VOJb9e-07ihB9fI4VQNv6l6P-jUJ-snVL7asGwz5xhmAlLYB5qoCoZqshrMAHR8f9VrUCIyH8K0isIGxkDDxqWhpRi38LP9Bc4LhM9wJpALoQ6JyHf7nVLk~Pbe~vybHOZKlCo4lXdYOFgq0sjhSQ3lg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=Color4",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.008Z",
+                    "updated_at": "2022-05-09T18:35:40.008Z",
+                    "containing_frame": {
+                        "name": "Mobile",
+                        "nodeId": "21526:14457",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".base",
+                            "nodeId": "21526:14852"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ba9d999929c59c8b1d81ee08bccf06359a9f558b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:14957",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/xdc/y6r/hx1nGoCdjgxo3IQc/component_thumbnail_177.png?Expires=1655683200&Signature=IswdpI-uuwTDeZayptqaywWE7k2IGFJGuBvJgI-MXm9UXRHALfuIelnSMwojTRoFG68p-oASuXYhHmUOBX6kt3-KaBybDOmQookNcJpfST3XOsvSWxLUv-OM7-TcwbbsufE-BwvwO6nM35ETKRZjJWvCx4izU5Iw1Wv~EDKDA3ItYIUtkz65JwBaFiUxEV9zvmoheSnHjaWvl-WVvlGGrXADWRcDDi~omqvEvkkGQHsaTCUP1RzPkBSx3FzPeqTr3CanLCtgA0FiE9LElZbF5Pst8ViIB2k8Mzx0ULi29P6EylKZgY48MkBO2YKl6aQKElA-bDDrsVd5kI2ASMyvsw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Color=Color5",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:40.002Z",
+                    "updated_at": "2022-05-09T18:35:40.002Z",
+                    "containing_frame": {
+                        "name": "Mobile",
+                        "nodeId": "21526:14457",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".base",
+                            "nodeId": "21526:14852"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8e27747b8ee5aeb6f830e18402308d1db67ec51d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20023:14205",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Vur/29d/4zkgFf3cx0hxrZmB/component_thumbnail_176.png?Expires=1655683200&Signature=gKT6sr9o~M16oqrDhY-fL35NmWxlzvP4BWwCe~pgGAM-9NygWELj67b2AqDFV3zd3aI6T~LhIEUbL4VyhyAWnuPfurHrJqpqp1TokHGCD486NzHAAT7h1TQ5sUSN9WXpy2MEgAwNUF3SL5E8gz8WeSLB1I4-dOLPT8asc7NJgmMNcbSlwBVVyWBsU6~EWw8PvEI~i6tGLimZpaLjotgOqefIrRi-W3Ru6YpmRfzpfZ-XSQzZ3fsUtGyyeDYGR9KRdYY0jwaz6EILsmxMHeRtrI0qEhD2NX6JDVs4K74aVPfg9hccZvS4HsRlt3IaaBDAPaQWeO-UPcNgjI38v0pJXg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, State=active, Icon=Off",
+                    "description": "chevron: active/off (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.995Z",
+                    "updated_at": "2022-05-09T18:35:39.995Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ccdd161ae7923faf29ef852ff0d5cb52553a02b2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20023:14206",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/8hk/88z/F3fKyQ9sRiMNQMer/component_thumbnail_175.png?Expires=1655683200&Signature=I0xOsuzjRlQpVTmHdqDPCu~VL6YtlU37dvUG8Zt6GBs747--LiYHiw1svOYEssSwljxRqVrvt9j9uFd0NBDUlxKg4vrVRqn2J~YyVkps~rR5iqYS5i~orcK6hQqh-nyW3pvbMSQm9CTCnRXYyqPCWDpblvjhLXI8mIfaFMLrC-b41znbIjbSoP9SizNHROCjeAfyVz35a~P0kOD-McsndFbhle8GS8wztakxcLqXwi1H5Sp-rE0goMyOaybM7HnMHkRglBPNXXTNVBU8vxzE9GSCURcgDdVYR-bh3~8Gcjhi2fXAy1-en5usA3B5s61NbfNrxnb36zqu-xEQlfcDEQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, State=disabled, Icon=Off",
+                    "description": "chevron: disabled/off (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.989Z",
+                    "updated_at": "2022-05-09T18:35:39.989Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "382821712736d72ec73b3fd835f9bea36eb1bec2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20023:14143",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ubO/acj/P3FE8VmQ44kRqbSv/component_thumbnail_174.png?Expires=1655683200&Signature=X4satiq6lVN~N3Vlqr4G877Lq2qXbvfJlfrulHE0p~ZtzO14z8kqi1KCQVXVT-wu5GWg58nrt48fEN6D2DU8DkNZLJ7PRkqI8EakniVXNOWVt9E7K8hRwSmnoDTIUy9G0g7-09zGisrTSz~KqpxNIgGtPU-pSNtzLspY5tsDLw7xFLH8JWfoiQ2HkFpTbcUrmsMWq9yQcijHCsLdlTL2hSLwX2Fxi6YtMAlTeHU8b3stNowRiZ1EU9ZwuJYnOsGSyvMfiDcu5jN983xMcTE62lkO5Xup5hMkuy0BTOIUcukQuEsWufJJG8Osxw4uFFVoeYFRTII~sY0n3UsPj5Rdew__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, State=default, Icon=Off",
+                    "description": "chevron: default/off (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.981Z",
+                    "updated_at": "2022-05-09T18:35:39.981Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "61b7bff5a74b770f1007fbc377b36776415a66be",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20023:14581",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/X5V/7p3/wajhIzKWsc0n0G9S/component_thumbnail_173.png?Expires=1655683200&Signature=aYhqPFIyx1DgDYBFOTVMhbfzSbdVwaA4crueEcwJ8xZ-vJprekDyrLkWCCmopNMJEaZiNAtoUNVaBfzY2yC~0fZ26Oyw72aWXY2A7CoJtfEXyB0SuhvoKsy8HPlcfDj56eg3EX-8AoS1HSN8-8jhEZb~uZPca6Iy7BifSraxdoVXfp55gvzmRp3GLkuQiXNSTpHmg-8s7CNHefU5LYRCKJBLTdMfT32pBwz1RfK0scHV~PNIKFky8PVlchgOccVAiNudpsfw~GUNfDSDXSj7-oWqjcGAUk2uXF2dNq4sY8f1neG0hh3fMJytIVZMXw81fzu4ASGQd-MXWDEN9VAQUw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, State=disabled, Icon=On",
+                    "description": "chevron: disabled/on (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.975Z",
+                    "updated_at": "2022-05-09T18:35:39.975Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8c646bd033b88818b7aead609bb410c7ffb01b6b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:11534",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/CFS/er0/2jIv3fLpAXU9MV6D/component_thumbnail_172.png?Expires=1655683200&Signature=d32PnSKTZZ71UsifNlqz7TS-KO4Bf-9JPtc4A0tEOBkKGmLAZBwbqskiAXfcPuUksyDJ1~WtsCujGoHueDFcBla2OUgmRw6o-xn9BeGdE2rOIjVyBrT3L6BVJeH44rESMyLVlYlH3poVWtBA0263yWNgNI5QZloUb97RAV75tBTunn4~VhEaW-WT8Z9ml5jdTJ52K7SOrnlzD7aHw-J2zaL4KevjGs11zYjgt0Ith9jofN~OZsECjGXU-zko~DCWL-JpoAhgx37BG4btMHCkLogb7rdjqpOJZNSGmnmIEavllBh9sMBJKcjNGEq4JdYmbxhTU3QlapCvX4bjzBPFjQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, State=disabled, Icon=On",
+                    "description": "chevron: disabled/on (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.968Z",
+                    "updated_at": "2022-05-09T18:35:39.968Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1c1af5b58806a483063f7daf4a22cf58a57bc9c0",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20023:14583",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/gHp/UBr/HZtsX7HP9JPHLIlc/component_thumbnail_171.png?Expires=1655683200&Signature=CHrg9r0AfHefFcAO-hNlz29Fgi71Bzh64BZ9uQRhj5539PlvUqaSCJaRERB7OaI9kuInnN6uAE1MKM5RIeneq0dDGpnyxSnYFYuwBkLKdrZaxjoWwbeOVZddfA-uQpK1w8o7Ydd2OzmcRgoggmAntevVx434HTx~twbXT8JuBLtcECIwc2DNTrENb1CEe7u4MKRBeHMQx40nhiLK7ypXF2hEg7C0hDc0CH2plFjh14XVDowFrfY7tYs9Ch52JAq5YNKhNLD~sKs~hh3Fj3XT1jogJrv2jx3A-bIjBcRcq1yDictN9029f2~QQHP0gl5fP26U3belq4l221lKWp-mOA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, State=hover, Icon=On",
+                    "description": "chevron: hover/on (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.961Z",
+                    "updated_at": "2022-05-09T18:35:39.961Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b712daae56cec95a41e4889fc3f02e23b75a8206",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20023:14204",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/y4w/jZX/6kAnFOuelGIPmNbY/component_thumbnail_170.png?Expires=1655683200&Signature=hvBuXd3h47zjqdxx6cyl1TI9Rkd7mcEdm4dUIOrlk83EHmaUOxIIZCQx1WwHlzUZW4-NmkJI2eG3km7AKFYu-5jyiDcOBsMipoLpTzRh-NpSQHAtotjd9a31~vZpu6Bi3af1vjgO1kUEMcVYJovVpGcP6suOGiM83YnhdC0Tu7e-HF7TWnAJi9EQ6KQiAnhJLKi1N9b6aGt-L7abBwFnamOTKJSfOiL08DzQGpU5Q82BmRSXqEJ8p4e6BNmk9q3bg9jXAd9RRYaRPAafCkW8x5lpURloKun-~mv8Zg0d1vI6SwLNCoBXqI66EbtcttZVjccmELD4nKDErY4HfW-VXA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, State=hover, Icon=Off",
+                    "description": "chevron: hover/off (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.955Z",
+                    "updated_at": "2022-05-09T18:35:39.955Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2407bf4598a7d085202de8afa28a5c06aa012eea",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:11536",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ul2/7kb/ef0s70r53nRxpd9x/component_thumbnail_169.png?Expires=1655683200&Signature=HdMrC1DtNNAiWKfF6g96ejcd~BT1M3InG3em7n5NOOinKNJIoSpZbCknOWA5Up9ILu0Zcu4Y7e5~mKUUQGhy9XoFBz542AKff38JrKpjGUhjuAMQINmCjzknOOTT8DZyTROk7W9N9wvXUtcFlReFL88FKoX4mrVwCFcljxkIU5N~errxtC75g0Jk6dGTgdsWfmgijIUlsD3RCocAyh~pOj2uWMAaRfsz7gHIx7jTCKx0WkPadneaePRw0uGrsdc~n7KcXF0vDQWK6MuzdsnABeE0ClcOAH~EbXPauN~73W3SrOzGzBrkWNQysGp317~Uz4wDAat3unXBKh8Sw5qdsA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, State=default, Icon=Off",
+                    "description": "chevron: default/off (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.949Z",
+                    "updated_at": "2022-05-09T18:35:39.949Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fdfd18e8c3fe30f19ab7d0d629d50b6c344ed4c5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:11530",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/JfZ/omH/V1YOoIAoVMINL26B/component_thumbnail_168.png?Expires=1655683200&Signature=hYl6aFMYN-ANm5yES7FAsQNkBBAsA3MuLZoFXanc7LgbFJvxF1gFqgo78kzSXIGlydxnoMK2DOAAL~jUjWXnFJKDKMcEsToNawBHDpHWU4~Tjz6VOm5NnSaUPWbG7tjLSnI2WAcJ2fz1AvFqtbN7O7Z0qmqwaaoU13ce71UQDGzkdtGYzPAK9wWpqrl6aJ9o3h~rFLIB3qt3w61-MnAge8izV0ZQjifMroyMvybNXg7JLSBo4GbU1CPUvwQpxF1AYDIFMv3nmvQUIaMzj-udY8lfwV70M9Zct2mWt7GdpbwDMmRkj-S-yS2cEPECWWKS2JDLgLZVGpfP3V8VfXtw3g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, State=hover, Icon=On",
+                    "description": "chevron: hover/on (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.942Z",
+                    "updated_at": "2022-05-09T18:35:39.942Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1843f0f996a78c3da24ee5b2beb067d31ccbcc3f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:11526",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/1fO/aeU/bqkIrsFeyht84d2t/component_thumbnail_167.png?Expires=1655683200&Signature=ei4B6-eCQC~Kdg6XHVM9Mo7JjoEl9v85JHzobZl~hct9QFIK9eUGfAYiFRbsU4tx~sxLIy6khtraahIREGNlCnhNV52EVi-OOBLEmeEe3Ch25tIwGlAJ~lFsD326Zfk30k6z73U5KX~bZK-q-W2zgL98gtWJvU~qiMk4vQUcx5SamC3monBQdmOGFgXCy7ypBmYrSDqy4Ohn-0~d1cUaAfg6~qoenSoYTsuXBmfjJ~DsAesf7X2f-4aQXcKX0COG9srmmDX8YZjdjYXycn48HQUspTq0jDyeC~~d91zLqk69c~MfUot4uYgWwCv40bF1tNtsZiG9N-LJrFlSp-f58g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, State=active, Icon=Off",
+                    "description": "chevron: active/off (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.936Z",
+                    "updated_at": "2022-05-09T18:35:39.936Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "657a113533c1e1eb5f46e821fe159c1e73e9e7e1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20023:14584",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/uqG/eAY/ZDZdQ8qsU9cqsSrd/component_thumbnail_166.png?Expires=1655683200&Signature=dYLTDG0SeMxYUeQzCgPtdDRUJxvJ78xZBM53KdhRG-H9i-PQXUy7SE7qfcCS2CowXSLQkSfx-4ND0rmhClJTjqp5GZauoER8wFJv2MJk-marVGidvRYccGbQVYk1yEWtTx-Nc4w5IEwcQRhCl0ZD2BEbOikqT--RECI6T5h952q-4yL9lKRDi9PgismsVCHNQz6csx~n9LUiCCeDSd9lVMkuC2ki5ryvEc6DhRIe4HNBv5~ydkh1bQ2FroqjKpkRR-HI8fuJSghdY4ezBBRtUGxZ8WS65WTb0QH2nwXmd4SajUo5lXgYNqubj9AQKdlAesAd7ePAQNi5d69nV5UwAw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, State=default, Icon=On",
+                    "description": "chevron: default/on (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.930Z",
+                    "updated_at": "2022-05-09T18:35:39.930Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c6528b91d76cde29b67331605177a810266c3225",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:11524",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/x69/E2o/chwfmfwfMnegudX4/component_thumbnail_165.png?Expires=1655683200&Signature=bvW35Cx57fjSJkjX5bA7qedGgz9WxUI3~~MpFw1JGHyd9KgeikBVCr1PbQqJFUoP8gqjNm1ZHC~05LYKxdeh9AXqEHMaozztHRaB0rPpKYbZy3CYpdZImWqNxoWWDZC0dhNDQpz-IHwwUTTrVDNqYx0mY6viHj0bMwFAtpTk8cUzaIRTUT7nJ7CaAnwTZTezc4XKnu6oStaU1JRKfdhnMFEaMzmrmKbzq7l7I7teblzoBNKZaFJPrGZ1-Z5ZyPENKdjBvLQZQGSLI9X9PHoXNjQi8tthgYeIImBsqnGqAD9niNkf4rItcYrrd1~ksYKssUkKs-xeKGVoQ-vH2XJuLg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, State=default, Icon=On",
+                    "description": "chevron: default/on (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.925Z",
+                    "updated_at": "2022-05-09T18:35:39.925Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0e64701aceefe30e02a5e22721b336a8e0c2854a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:11532",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/frO/Ot7/ZE8TUHegC5L6etUF/component_thumbnail_164.png?Expires=1655683200&Signature=KS43dam4u6DjRK0qTn8pXRrF5PnS0c0Hmc8DFgM1sc-PwfM12fMrDZcRcm5jZi5oHNSWI8acydng0FJIdyyWgpO0JBFCsMGl-GF-B5VnCxXAe8rkG6bJEz2vSoz6rpN02gKT7cbcPdycePt23gMtt0jhQ4GOx4cZDnSQ8BWPPUAgLBYd3zzllbLrwYFXidPVAByCCklmPfbRJiCLHdDHMYfssoFgMUXpsNkI3A9t5M8oRJ-vb9LuSIQdRTUqbRXLMznEMc2K591d46tq7BkioWecILDQbTD3X3MeYBPEKtqSAQrevJUE~GCQua4h58yRGlD8rA0SKVZKiP1ULkam4g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, State=hover, Icon=Off",
+                    "description": "chevron: hover/off (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.919Z",
+                    "updated_at": "2022-05-09T18:35:39.919Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2d57eac247d8db68dbdfd4a60f119772f0fc11e6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20023:14582",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/zLM/I5D/bjFkTU9nDpS3bCxr/component_thumbnail_163.png?Expires=1655683200&Signature=EjK8d1B~O9TOrPHeDmDDBYUuXzaFXY5Jn893vwLWoH1HdY7xd3Za6IqaU00b5hNNW3K3VYSvKdBrtljQXdTGBnE8h~cP2D9BHqe~sAFQLcYW30rodV6RQxfNn0YSfGHscRVJ2RDHmmHxfkVOquBrxgpXtNvf~xC5YAv0yZ8zVhMaPybGVm39jzE6UG-MIlx5uK8EJejgGDaSqbqpBjoTpUyZIssOZoHVlcB-p4QXcKf1EFogh0lonxjjFe~YXPmcbKkwpytGsSmIJ5n8mLVkGYEYks3Tv0bMjR8zcx-It1zEwUYQVwqiEcG~bPqQkTi~urZsZRmu2u~klaNYWPcp3Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, State=active, Icon=On",
+                    "description": "chevron: active/on (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.914Z",
+                    "updated_at": "2022-05-09T18:35:39.914Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f060415da03df8adeb450a562c9921760ddea4cc",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:11522",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/hTT/E5x/d7PdBru3sHFv4dEG/component_thumbnail_162.png?Expires=1655683200&Signature=WWrVk61GEYAJk0Z04lo44LH8oo~G-CF5-i9KrzK7D9DJy~J~E9g9xGOMDmA2B5KtSu38rFJo~TAgfesR3PwMZIPQvRBbV4I2xW8zlHlZhdmXKdfqfPimWhW43ynhhhmheJ4SLyCfFROXXwHB9wmgBLDfyQSRFlAkj94v5JycnX~BqEpV8LRrMvpnaN1LwjjJzCa5I~Ke89AKdAfmS7uEaPn3tuh5aJWBBSAstbuQz6C7NgXlOavTxy2uC-0oa-av16hIj5W6hwj30sVb76kFrepfuWau~ZFbbGuG5toKoIg5K7-uLKAPWZt8RSp9-anDQRiYPjmAeVociYwM5TszFw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, State=active, Icon=On",
+                    "description": "chevron: active/on (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.908Z",
+                    "updated_at": "2022-05-09T18:35:39.908Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "58e08c743b0bd0f1b4de73bf24b55fd0f5a00129",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:11528",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9vO/qBt/cFtpvVFNIqDPsiJf/component_thumbnail_161.png?Expires=1655683200&Signature=bFZbX2GkBk1JoZv1rHKGrmaEptb1TcPX19yEbj1ryn-2UCMn7BOq3Yu2IBmtkZfJcNhes3sn~aPyDzkaUeJTDhYhb5cGXIP8PvQk2QK-akzxY3q6x320kYRv9XLP1hUtXIV7Ovb77EnpywYN1iFqGyrHc6VwbE~lonAO8MRIK~QLzX1whiUAkGCn58ePfLrg~qedwQeLk2DIUBXVYd28IAlDwQoc97t8R0yUwcQ7hpfr1-lkFWppHtOdOvUas2-nDfmQG1ORyklc~BDcio2IUS9jYuV1fgiTioe03gorJe9ufoyxiFYMgIBBuU47z1RKQBpt~-PD89YhiUZLuQsveA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, State=disabled, Icon=Off",
+                    "description": "chevron: disabled/off (#CTA)",
+                    "created_at": "2022-05-09T18:35:39.903Z",
+                    "updated_at": "2022-05-09T18:35:39.903Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "chevron",
+                            "nodeId": "20328:3012"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9700584e845d7f942c15f17c8baf8123ac7f8edb",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20711:7177",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/B5e/TjC/V9dZXXBNjPQ0pG4O/component_thumbnail_160.png?Expires=1655683200&Signature=LrE-Y7A2~196riq7GZbZu4g-VGTXAIs~2c4UswD6vy6IqwOLXUOTjPOYRHjvBCW6Bl9W5twpwQXrqYpXBhDTCUScn5417AVz9ymVADyS24KPmuNHADa1oNd4HkZhEc5tevDenpm~cWjc5HOFxuxO1xxNcm9FCe0wyNp9E9pxW9dUyN2gqjgAKUr6UR3fWw~FORLsVuaxyyYyOH3gGFGDDQHlS6Mo~F1aa8V7Jxvdqa5L3fx3~n8Ly8nKBItuzJYtpMo3bTIyGr9pNGLYcmBgcT5nzqoB6aKtLQkjGd2sSjjABbnTCFnk~UWu9HaN7dg6PIQnlj9eFlWQqZvLh-9Qtg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Text area type=Read-only, Input=Filled, Error type=No error",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.898Z",
+                    "updated_at": "2022-05-09T18:35:39.898Z",
+                    "containing_frame": {
+                        "name": "Text Area",
+                        "nodeId": "21488:14112",
+                        "pageId": "213:3693",
+                        "pageName": "✏️  Text Area (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "base",
+                            "nodeId": "20711:7151"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7aec4dfcfc5db79666e8912da60ce2a1239e4b3c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20711:7296",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/M0N/YNe/Rw7IFNFQd5E9AOvD/component_thumbnail_159.png?Expires=1655683200&Signature=Ig~uXUEX5aScIjPTzNPnNCHIuVtZn~9JNxE18mOdgUDE1tL0Ef-vQdAJZqmIadhIjRbO72wHAfuRSd9jvhED0S4ruSRdyDtYLma3DtZM9qlZWhw5o2mH6nk1nHLijVLVCuhUODKyN8qiZtK3gwiPYMUf7mRmKhVZ3pWxnd-EcTotdodSP~qFera6SfNUSjeRPQXeN7fev-iuOCkZ0w4iGrERnSqc-1bXksl~2u2lu80YVhGu~d6djqBWd0hbJVaFhlx3Bq4EuWEa6Z1nXQHlPn72TNh68H6WMiERD39qyjZ~FZ9ympsalE4lEQCzX-LR3s2VipGyZETmCJ1gU7BP5g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Text area type=Disabled, Input=Unfilled, Error type=No error",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.892Z",
+                    "updated_at": "2022-05-09T18:35:39.892Z",
+                    "containing_frame": {
+                        "name": "Text Area",
+                        "nodeId": "21488:14112",
+                        "pageId": "213:3693",
+                        "pageName": "✏️  Text Area (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "base",
+                            "nodeId": "20711:7151"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7923bf09b92b944e27c8fa347a3d565892bde7f4",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20750:7066",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/8qG/5JD/e2myxtpQVvILBZqt/component_thumbnail_158.png?Expires=1655683200&Signature=R8PpCSMW56hwl1qK3I5ubSvaFWzopB34H3p91HtlaVpJJLcOqJtulQVPQLWEsNlW0SAOKrl84vu8fk3aoQdPwIusERF~bVu3xrRJxwRJuiuhEQLRJlBEnCtXAhvyd7Tgqv93OUACLgG974Qdz~2e~JtHjguFouOYlO8XxOVqtRcVOgLwg0jm66oio-6eFxrm7YpSDhywaQlmF~36FIq5NJiAmaR2q~dD~hUQAXCZpV8bzwUjkijCqKQ4N9nHuErIBRP2NZpRy1HS5n5na2CvCxAfFdeD67ld2kEkcUmm~wGl1Q~9nhZzbabVwpFPl1Ej58Lrdz0ADqF1P~QkCIYkig__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Text area type=Default, Input=Exceeded max, Error type=Error",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.887Z",
+                    "updated_at": "2022-05-09T18:35:39.887Z",
+                    "containing_frame": {
+                        "name": "Text Area",
+                        "nodeId": "21488:14112",
+                        "pageId": "213:3693",
+                        "pageName": "✏️  Text Area (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "base",
+                            "nodeId": "20711:7151"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "200262a2cf36acdc0ebbad518194bb9ef0cd3ca0",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20711:7321",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/OKa/tux/6YtIvBjKPb1FIWVy/component_thumbnail_157.png?Expires=1655683200&Signature=TX~CO2i7jV1PVw8Io6DUM6mLU2r69ZCk70h6vs6zUk3HhDvcfc-1VfHd86KCmYsMfVbyF37hMTGd9izMorNOmAvL0Eo644tk1FokyNVxAqayXQLX9F30vCxUneojeJrrowRhWQHJHS76p~lsVq3YlLs1fcBCZsOUTwWfZntlPlfGwJP~RoBhd3hi6qPuMzc2-kVd5-7psK8Q6oMx2W3gvFXFa8aEuM~1zDrKyvPVEp1M8ExreyP6KdytCam58FILrT5lFagb3aHnY~mmVW7DxN7DWbT44FHHJYzO~HuNW5qlb9aYxV5DpzRcN0EePjvqbIdatqVSRm5othMvemPd-A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Text area type=Default, Input=Unfilled, Error type=Error",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.881Z",
+                    "updated_at": "2022-05-09T18:35:39.881Z",
+                    "containing_frame": {
+                        "name": "Text Area",
+                        "nodeId": "21488:14112",
+                        "pageId": "213:3693",
+                        "pageName": "✏️  Text Area (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "base",
+                            "nodeId": "20711:7151"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e8cb1cdda64d5393c5683b614bc3ccad20249d1b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20711:7304",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/VLW/2Qn/4SmhlwE3vwXXfIG9/component_thumbnail_156.png?Expires=1655683200&Signature=b-sTb4pTN28XJUd0zux7U~fQReZMKDyyTotMvUD5HwI3yMLxQEBODgHiT3fvmou7zUXwyK87e8Tkj1bE24IY-jsAQ1NgONq9fpEpAHdokndQfb10NEzNJxYTRe7m6CXQ7Hn6fBW85vV8f9th6GebAVLxl~ovOlhVq5p3Fnm0gYvoQS4KkzarY39axg7u1c2tXMH7zxJr-sXFA~r-WUq1YcRtm~4hygqz0agLa2irLcMW10zunhJwKcaKZ4gCGAEvzmhNyqWDku6bAk2HY8DjgNvAQjqxCtRvdepQ3DguNGurH270ojT20UesY0UoWwJCMbFUQbqi4dmV3cQnjpFAng__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Text area type=Read-only, Input=Unfilled, Error type=No error",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.875Z",
+                    "updated_at": "2022-05-09T18:35:39.875Z",
+                    "containing_frame": {
+                        "name": "Text Area",
+                        "nodeId": "21488:14112",
+                        "pageId": "213:3693",
+                        "pageName": "✏️  Text Area (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "base",
+                            "nodeId": "20711:7151"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "828113d1c4a9683739649a015d6bbcc3fe3af515",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20711:7169",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/SHj/G9E/9tb8LRcmEZBTnYxa/component_thumbnail_155.png?Expires=1655683200&Signature=UoWNeZNDJHrUkagB3gfM~afZ0Sz~NK0PLKpX67MtVHWNKrOa9U92AeGQBKDEHIwxcevmSu84QyPmAuwq~VAg6e1Fb9O9YHpohRnAbMcRKbF0yOjmAZ1nFPLTOmCpuLLmKEx7YKVUxnkrVE11fN-gpE8jivVLgYcL8A5fsipRG~67ezWorsa0JZYvB4VczxFY53gEhRv~Ep9LzrW8N-NZ5eiSTQF7srliIPdLAyNmfYv59HJEu0DjDQ84S2KVohPhUIUzAA3VXZ657jQnJRwMtSrHMddyBTA7rOXDIg4-pTeuoP4MyShvT8uFvp7o2GZBmvP7G5ASvp2jtIgHzpt4jA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Text area type=Disabled, Input=Filled, Error type=No error",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.870Z",
+                    "updated_at": "2022-05-09T18:35:39.870Z",
+                    "containing_frame": {
+                        "name": "Text Area",
+                        "nodeId": "21488:14112",
+                        "pageId": "213:3693",
+                        "pageName": "✏️  Text Area (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "base",
+                            "nodeId": "20711:7151"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "39aeb7cfce9184cd64d38895e9b05ef18e8161ce",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20711:7106",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/uGS/53W/rZyXZ3V6dxDoaxKP/component_thumbnail_154.png?Expires=1655683200&Signature=BwmOVoRsEtii474yHF2VOFlbr4PqyWa-jCtZpXogKKcEZxzTxp5s2ueE01unERKMnSEoqQqXXwqiAzvYOKSAA~ePElZhhg9TRF~OypIt8oo9J0MQZaEMIVPtiTtqThH2FYA-eZqx7NWBzeFFexh0VA7CtE5CNKOYb~s-nQrRTUaSL37meII~L6paLv385KKokK~HUCURxpLpLzPLhn80J9N7sfGCqHZMtPhiX19cTMhdtnrY1dhSwn0z0zMSVa~-8VUJqS79aBfYaPBK4P7oIY4OvQMHKIyvvFGpff2SqTuV9JgUVrA0iGsQin56PLXQzBnwLHMS12dp~AeW9Nx~rQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Text area type=Default, Input=Filled, Error type=No error",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.865Z",
+                    "updated_at": "2022-05-09T18:35:39.865Z",
+                    "containing_frame": {
+                        "name": "Text Area",
+                        "nodeId": "21488:14112",
+                        "pageId": "213:3693",
+                        "pageName": "✏️  Text Area (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "base",
+                            "nodeId": "20711:7151"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9a6e25b58d5f82a01c6a3bea1d48776cf3b9693d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20711:7313",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/XJg/EJx/aJSJA6PPZF3Ni5HU/component_thumbnail_153.png?Expires=1655683200&Signature=IVK9vVgaTzXU4xtKGpaL4RqLK8Uq0z7OeRyHm0RBkHD4JdxfMhmlGR6tqZt3lYCms8Eil3lhMH2FfB0BnKzEpv0A5UUesOr3Ab38-0ptaQSduuqkdIFPepQ0qHr2ZVePI2ZZy9M8xOnshW6HTWWD1jKkO7MqzpKDxWk1Vg9rNYUKB5Ct5hRrVNth83e~TvRhzqXs6QJj8KMRbd61EXO-vAB7ZD3sF25iuEjegWfwUPD0wUYZULRlxGE9Vv0tvWig~R11ftpZ56Vekck7ik4oAOhXJWuLSP8ojmQhJ~ax8wBEREl2z0yvqTmhSsgK7masKmWLIXdkOctxySf-KKz7pQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Text area type=Default, Input=Filled, Error type=Error",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.859Z",
+                    "updated_at": "2022-05-09T18:35:39.859Z",
+                    "containing_frame": {
+                        "name": "Text Area",
+                        "nodeId": "21488:14112",
+                        "pageId": "213:3693",
+                        "pageName": "✏️  Text Area (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "base",
+                            "nodeId": "20711:7151"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "cbd77bf9c55d2d1fa279addf650a6491a343a4fd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20711:7267",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/rZI/3nW/rn6bfSyB4xPzqvgT/component_thumbnail_152.png?Expires=1655683200&Signature=XAjiyFml~UYY1z-BuxRtaMM6Nx4o8gdZ0uqFi6ejt4RmZlzBYmLqzH9hl5Co1DhxvzBIBnBFxStK7SnjOwdYBnISSxXtoAFVWvTsGzzKbQl0wQvCxI2d5-Iam7v~x2BsxSiSS0nB0AzyPB~BFOvKcrCvJGKDpZ7x8W9xWgN5N~fZXviMPSxp3a9AC7DhLYW69gP05kGmKChmK3AUAwq4bkyJBAZRIUJ1hJ9fMRWkf-dvGJ5Kx-6b3WvpXOzXPlGlZnoX9ovjPoznJYuq5O96auozWSZTm-cJAGRFxJ8v1Tnmc0x2pUcNJxMTm0IZ1S5nV13CWkdDOSailfouzn31~Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Text area type=Default, Input=Unfilled, Error type=No error",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.854Z",
+                    "updated_at": "2022-05-09T18:35:39.854Z",
+                    "containing_frame": {
+                        "name": "Text Area",
+                        "nodeId": "21488:14112",
+                        "pageId": "213:3693",
+                        "pageName": "✏️  Text Area (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "base",
+                            "nodeId": "20711:7151"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8e4e86ae34c72e8a1cd83a905cb5b18f8cae5145",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20615:5248",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/B3O/90R/iTFYqQw1qzpb8QJd/component_thumbnail_151.png?Expires=1655683200&Signature=ELGqI9q7IZLKvHLtp66UCqenCoWBqnajZ0JMxzMVnNBseGS8YX2on8bOA1-oZFqtC6pwsANO0qHQ093cz99iy9NmWH10gLTsObiyJinUnmQUuuRuYtAPdmI2fNRusvXLzFuTPDFVk06vTAesYOpvmu5EM-l0CFQIo8bYviG5zWb4YBJVm7FTQ7Dc~Kbexw1adfHasERVjNNYP1vavlqlfAFpqB0d-pbO3Og9Tnkr9sEjZHyZEXzVi~FFZErswPok4q9HN4X075Y6FDhD9x~90~gOfDLchChQjYMZAKbgilNIn~YGDEy2VFUTr6Y2teFJKnVAOc-7jaa1v~HDrBra7A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=small, State=active",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.848Z",
+                    "updated_at": "2022-05-09T18:35:39.848Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".tag-icon",
+                            "nodeId": "20615:5276"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ceb99e6a09e3a1b3a7842b4e3eb1a2021983fcce",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20615:5249",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/J0w/W6U/Tq0KTwkFONdjHXAV/component_thumbnail_150.png?Expires=1655683200&Signature=VCwvs72DLEhA2~2q4SgFz5gKVuM2qlKin-HcnMLwRxtyT6khEyedw~RW8WGisk-q6WkwfM8gFrZBDsBw9d6ral~tlJBVK4H8SWSq75F93Uc4UaiR-CNrph65ZNAFGCMEKGxHVY3KS89NhAB8rhBug619eftVzvTt0Bqp795LPNZ~vZ8uKtYZsWTc2GWdmmh2mWTh1c1sL5i05Po3pXC~R9eJplfCfc1O3RHYJ8nFmLBLCALVBFDat4lhGzElb181aqwFo4PFIY8aSk0ayKci4RrS9-rwLb4uWM58-vnXLl4xl8jjk4qZZmsakA5B9wYBybA~ew3TOhXig~orfHErXw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=small, State=hover",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.843Z",
+                    "updated_at": "2022-05-09T18:35:39.843Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".tag-icon",
+                            "nodeId": "20615:5276"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d02dd045562cf2210d7861eb4544e993d1416047",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20615:5250",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/F8V/nTc/si9KK1c6lKJtZSe5/component_thumbnail_149.png?Expires=1655683200&Signature=Q0Xp3TXuzL38cUih7sfhQoesbix2KeYav6rCH2BQHNeVOEWDjWXHePa5lQ~vk7iI71m0tUznNC77OdlFiTrwEVlCMtMfVe3yd~gP8oIWH08I-OKjQ5zcvjILnJNKDGAt9mWlq6heT6wUrA~-PYfELcRjqGfrv8BLfMb9fDvZsjU0qrszxG8JaLDdluyI8~GibCIBqxdk8N8xjAt4SQeLM44Ov2bpjX-QjFPlkB40Xfgs9EByPa3f8JT5r4LB8HLE3bnKfyIu9LxklGTUKF7~ByMBcR-MwAE5nWngV3PoCeKeF2KGT9uDmH-iPoz0eA67XImd3NZTXgUYDNCxMfe3sw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=small, State=default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.837Z",
+                    "updated_at": "2022-05-09T18:35:39.837Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".tag-icon",
+                            "nodeId": "20615:5276"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0f7ada4c13f82e5de29e24b88c5c0fbab4e21caf",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20615:5246",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/qGD/OQw/FCng8znb4gRsmzZm/component_thumbnail_148.png?Expires=1655683200&Signature=S-Nxsbr-e9xR9Pw2MoS9OZ~A0IXedI6BXPi2tnpM~kwCXfH-ya9Wk0b0U6XtO4tFWa1fB7yh~lh5fSvRzD68gE5hDEzeFtgDCGXAfdxTARgkpQTf1wIkB-QfgYtmcUHV~kGfbCOLMrmrAXwJl6EL1vcDAWYxXavvXxiHJ0VwSG92kyaxFVBEivL3n1Rt59GQTVHARePRk11K1nwfw76mom51AMIpBxGaDG7V8KncENMqwWbm9FFElPXY0b~WmF1DdswpFW1K~-nTO~MoVarQWlYIiORTMifYM~JSl9c2Kz5oiSBvMWMDEytnD7R5aUQ4~v4FjsUMdYnnFAOSB92dRg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=large, State=hover",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.831Z",
+                    "updated_at": "2022-05-09T18:35:39.831Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".tag-icon",
+                            "nodeId": "20615:5276"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d6665fa219716240ce77cd99faf67814c91895a8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20615:5247",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/hV0/sNk/h16JliHEr6uKHCzm/component_thumbnail_147.png?Expires=1655683200&Signature=KPixS-qliKDCoVNIcWG7qyea0iguqztLvuUJVRZId4eu6YaC3GXR4jEXRVSt1pZWJWeBUp2dJ88gwsGfjNQdzg~hUoq0rX~mVsQD5cZhDFHLcA4fqsrrD6enaPU~B7aXRHa7bGm5ZR81q~kF5oJkk5ZPW3TXUQt56SGrGddadoHp6DND3KoYDgi0Ev6h7V1N4BVIEIOciKKSSAgEB7UM3spqMHdvWagR8gV9WmKIsH9IhlqfZO9WH3S6hRcaKhYu0vC-~0DEceTfeTf2TxUFc4AYmQESBwbNWuYNW-3ZjUbPAjPVmxpYNDdmt0e2mivSl5sgcus7rikkf0kcfmU9Bw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=large, State=active",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.826Z",
+                    "updated_at": "2022-05-09T18:35:39.826Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".tag-icon",
+                            "nodeId": "20615:5276"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6ea6c21515d991836ff2d96cc2589ffc8780203e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20615:4865",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Jbb/xeW/vaybe1DgRzg1RcRm/component_thumbnail_146.png?Expires=1655683200&Signature=FCh0gsnngTAvee5Eyg4tGQ7x8ul0pINt01eE~751qPdQFElBFDG-ASpLxufhsX-eiVjTZc4sDFbNnwROKlaABysir~4eXT4GLXIMY-Be6eAdwQSx9f1o51wOD79JfJVO66IdVILzt3hkHq1UupdcaSLP7zsj8LtAnkXWOOmCBaWwB9xGYoUsWYUUUJXWTZtXDXbA-x38LM6AeipOlgokFU2zWdKHLurAisyt28TiAknnNBu30npXDqEBWFJ3jt0~UZtYdPf3-I4BF1cALuOUixu71Jew3FaZHceholl5u7PLqG6PgRBDi7mbBqjK8j3fMAdunfZy6tZDLCwMTvGfxA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=large, State=default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.820Z",
+                    "updated_at": "2022-05-09T18:35:39.820Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": ".tag-icon",
+                            "nodeId": "20615:5276"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4ad09f0c4d3d7374cb57416e37f2303d570282b5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21970:12150",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Snp/WGP/ZOufkCkI8bymu4rx/component_thumbnail_145.png?Expires=1655683200&Signature=Tb3nkLWhd2YznnjfjywC0mBHlodOD-ph1zbN79WfOpcLDU6hyVchj2l5QBByXHzkqX4uNhRneMcKMKfjQRjCuX~UKzEIF7FbQ1lWtMQ56B6bN-NYewOsMrZ~8x7Fbb7geBx20CQNQvf62eq8rcca50tUpFvPeNjDhsYJ4RwvWK1-ptZAwGRFS-FZwDphlaM1b-vHTrJVN19v8HSpkc7EwGsoyVTFC5CRZ--0lxfqjIVLIHOAcOepLJgToFNVspxH0t4L6JMST8qLWC1T94yahs0J1mDj4gWDrcobLW5iynUW9ntVAq~AKBArkXm306-sdm0K9JjDVi254eVHKHiMdQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Accepted, Mobile=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.814Z",
+                    "updated_at": "2022-05-09T18:35:39.814Z",
+                    "containing_frame": {
+                        "name": "Alert",
+                        "nodeId": "21910:11952",
+                        "pageId": "19945:7460",
+                        "pageName": "✏️  Toaster/Alerts (WIP - Flo)",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Alert",
+                            "nodeId": "21910:11952"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0e2c07a6d61230bcdb475f2bed5369aac3e9a2a6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21910:11950",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/wi9/KZU/s1WyQMon0xvQErBH/component_thumbnail_144.png?Expires=1655683200&Signature=Sfrv26flTOpbDCybzitY4d1JdWDAuxLchE8EgtfZj6QOcEjzMgK8Kbn0VMnkykGiPPiEisI7O-Q4YXBnpNehrPYeN9RduhjOR6Y0jQdXPjlm2~T8T8btKaGNbipwRkZiqnHgPatPmRElYWtgQskSpkGzBWZYpPw59Z70CE~39C0DuEf9cnCW3PteQP8NT7NNEUSw9jEbjJugbgCjAwS~fRjFfx3ntZ0c9T7lcF5HeKe5h~6HWS~SKJ3XZMkz5NVU6rMYmVBVUyM7gp1eYbD1iQSXi3NRh6pezP5-a2MVoj9cPpT~6mt0rPUfsaLq0wYa6M04r3irR6rJC~pLj8PBTA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Warning, Mobile=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.808Z",
+                    "updated_at": "2022-05-09T18:35:39.808Z",
+                    "containing_frame": {
+                        "name": "Alert",
+                        "nodeId": "21910:11952",
+                        "pageId": "19945:7460",
+                        "pageName": "✏️  Toaster/Alerts (WIP - Flo)",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Alert",
+                            "nodeId": "21910:11952"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "575602af6585c98ff34abb3e56c83f350dec8ed8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21970:12155",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/7lN/Shj/cRDHU2Q7WMrfIjNP/component_thumbnail_143.png?Expires=1655683200&Signature=cLUF5Gyye4h3UK1SR-aibMraTpu-pQfx5~KcJioW3aeo40VcG1btBMwkKizQdho7P-EXPdvN31lpr4AiHWksNHnf8KnN28SGgBtontMeBT6u2zgR2U6YD6lWjRwUY9JV5YMKXjJwQ~yBcnyqDOYfjk1ZVGU5RWGJxE9ukDrwnDecf0Gud2Mg56elHyVNHdhMYyg1Axw-xd9s4m~gSAshmFIT2LRjPBb-OSnDNPBvhiMAokzXDoE2a~Mb4rnnk4PaxvPBrv9i~Bnjptn0uAhyrEi6QUEQpPUx-AQPzG9N8vov7rmT3AN52kBUyakPgSQJBhJLXkNjPkcscr59XTDwGg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Warning, Mobile=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.802Z",
+                    "updated_at": "2022-05-09T18:35:39.802Z",
+                    "containing_frame": {
+                        "name": "Alert",
+                        "nodeId": "21910:11952",
+                        "pageId": "19945:7460",
+                        "pageName": "✏️  Toaster/Alerts (WIP - Flo)",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Alert",
+                            "nodeId": "21910:11952"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "094df3861e5b5f5a510603b6a8fbb8f901fa9a18",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21910:11951",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/gPL/hca/S6vzD5FFT17VaEjN/component_thumbnail_142.png?Expires=1655683200&Signature=A9OaXrIsO3mNG2uqW2HFynKrjgrI433O~D7V-k-Sz29TxvLn24izdSYUPKQDe4EPLIlffZjFZg36U~hMT9g4MUeIHxdi4k~v2X1RuKdo7aXVAdLnjZaKbuVcQHAx6pK0YjJaKHJsTgdAMfh86lZoaJ4GPifkP2FQ~d9BGT5bqTEF5hHiw0hjdwX1tDt4DSZ5ZzLbhNYOMoKqfYODe1OW-bJ8pJxfuLZvk6PPyHyU44g5WcvGFG~mkSnT60h87A4aCA4nJLisOYUpyQn-COGAWJD1Go8CFpzHHCDxH0NykvN02WlUMExCKfj6W--eJ2lLW6ZbLJp1jyrM3zHMqYb6ZQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Accepted, Mobile=Off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.797Z",
+                    "updated_at": "2022-05-09T18:35:39.797Z",
+                    "containing_frame": {
+                        "name": "Alert",
+                        "nodeId": "21910:11952",
+                        "pageId": "19945:7460",
+                        "pageName": "✏️  Toaster/Alerts (WIP - Flo)",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Alert",
+                            "nodeId": "21910:11952"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a92c104a298f7ca2c8d8c6250c4eb4f743ebcac6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20573:4034",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Utm/nzZ/IkTt9hdHRgTi36Ru/component_thumbnail_141.png?Expires=1655683200&Signature=Yk2ZbfrxUw4LSgSmVBrDBSGZI-R7-VK8F1rOM-T3EyiSEcqI5VYoLpkgV8zJ8mxot~GBKdrDIdaWCpm-JuErS7hOh~D~UIkKj3qilF81lQSWFVqJkbTfeZZ7BPuPeZgFzokJ0jg7bbhXKaLAMcJW4FQ9f5AYip2X6jj-hoZOhvQyHI3-g3pab8GzTuR1E9CGnK8ZmMDHa9C7AoRzl5goLZhGBFuSb6QL2KgfeYquXkPPyEcI2UME1qrzAemXtEr7BsccgcCHeDawb0fIWbrHN0JBD7Xfcu2QZ6R~w3n7djShSBxRbAXGgChlZ9nXzD4SW8LygbfuYF3nvI0HMgm3Mw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=With error & hint text",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.791Z",
+                    "updated_at": "2022-05-09T18:35:39.791Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:13531",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form fields with labels",
+                            "nodeId": "20573:4035"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4c6fa5a373b9e886c19c542b421826e116e920ce",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20573:4061",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/YC8/2hv/Rgv9ULcBO7G2mgpy/component_thumbnail_140.png?Expires=1655683200&Signature=XiOwM5DBSHlEip-Fy3aWHuNfwBS5ZtLZlzYtdDFYnlbtSH7iQ6jCek8uaGRO8zYglS~mmwu-rAaNa-vWnPKzSkIQMS2YiVNPsyuCxF44SM4a-qSSWWbVJ3ym5r3D2oY~t2sDRfjG9edSYqdwiUXGi5tJ4rKpy-n1Nto3x8jrFXhyfIbRWSwjaZTO5dfSxbn1Ah8u-5oDEAmp5xEHClklLcGqJ1M6QMV99L4aLBSc3m8mEs8h9bW75hu4~v4j8pN07Oi3m2I7j8N3c-UILidbnzFA1bPwEI4n~RCLsj~A2BHZcHMRhSIX4NisdLPXHwcfYFOGVTv7ZVeiKrMLclAiEQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=With hint text",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.785Z",
+                    "updated_at": "2022-05-09T18:35:39.785Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:13531",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form fields with labels",
+                            "nodeId": "20573:4035"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5d97ead6d7b334be977901ac19301895eb871927",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20573:4036",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/bnl/HDO/XmSWDzIOFOlJy8CF/component_thumbnail_139.png?Expires=1655683200&Signature=W2hB8Pz4h9CeU6IBySAXxChyFQYNRxGK4YjQnhtRHPziD9ncBoxSX0H1nu90r8hWtt15ZeXR9Bq1wecgmILPSRtHHSmSb4UthRdUqKDl0RYc85oH6L3N4sSzFP2uHsODjEU7lsSu8YbowB~9UM0~7XPfcxeQX1slvPFhfHdvdPTVJNigjURUMTnOGdCVipUdrCVI71aDIDeXvKcV-B2vgPoXshZ1j~SAsjNSNETkwtvOhduDASFY4vM6hdo5g6HEfdWqRadzKVZnmzhhBQa-L4wtsUnB3f1gdA1iHPYZ1eYE92YZNKWuoqZCxSgvYN9y5prUmuMu1PYSRazUgV8yLQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=WIth error text",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.779Z",
+                    "updated_at": "2022-05-09T18:35:39.779Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:13531",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form fields with labels",
+                            "nodeId": "20573:4035"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "74ae0b08c9965e2ecfaf16697a5a96f83eb0ce4a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20573:4084",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/QaL/iIm/xT4m37QUE2OcgPMU/component_thumbnail_138.png?Expires=1655683200&Signature=KN2qA6CAEuVhFRw6CGjFK7ByG4pW0eszqOnAJ8RVM7rU-hjSso6OTXykI39woB8irb8RkNknnxuDmZmS7QV9MiUE36x5J2-9qKvNT88qi1kyG1Xip3h6CQ8xZxC0zRqnCS8~S3ZzX7fdGHYhhPPSVjMamXHLDI-40vp4c5VbaUWjQcMSpnX3owFlW9EPU7r2WAei8dkVerqhRlRq6NHVdb~M3X6oRpdPi5mqsJul6Amzu-zffb1K27RCVXqpJTNsSlG6Y4IjKZP0U27t~RNzKkYfJjg6a4Bnqk-CCe6yga859wjgWikbPM7uXeCUMPrgQi8g~W~MPeNSdEBJfPjgYQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.772Z",
+                    "updated_at": "2022-05-09T18:35:39.772Z",
+                    "containing_frame": {
+                        "name": "Form Field",
+                        "nodeId": "21488:13531",
+                        "pageId": "54:2",
+                        "pageName": "✏️  Form Field (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Form fields with labels",
+                            "nodeId": "20573:4035"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1335513944fe4c42bff50cb292c772991f9f1c56",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7423",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/RTo/vKn/Jz8KiGtLdMPLWQ8u/component_thumbnail_137.png?Expires=1655683200&Signature=cx~iEW73H0BBnNJ5rh-ILVxNugR9QlyOgnQMtgkylIfkLUOcZkTCMTy9d8eO34eVc0lhEWu2k2GxrPnSfN9thPlv88RmtpQ1hAyzIgtj4TaJxaX28e87E1yhk96qiDUsUGOR-h1e7BDaK5~xf5L0It29KGXJPtpgmdPzHbfn85TRG1Cf42cMBTxGHjoPolmWPiV1uNt3JY5KWh1Pe7tGssSFoePcUW3Bplf5hNdZW8ijDgNm7zUFRUin26MnLcsubb-wo0c88yr8wanbebNkcx33LZDgIfI-zHzLEqD1gWiQp0FNS9HUoVqfl-dM319II0OudJbmP-swBEtlKoITkg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "structure/radio-button",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.767Z",
+                    "updated_at": "2022-05-09T18:35:39.767Z",
+                    "containing_frame": {
+                        "name": "Radio",
+                        "nodeId": "21465:9314",
+                        "pageId": "21465:9312",
+                        "pageName": "✏️ Radio Button (WIP)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "452797917aab997880c233f019afba8353169c80",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20188:4707",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/GPF/kVG/u3tWnyXnUjoOzp2V/component_thumbnail_136.png?Expires=1655683200&Signature=czs26VCnXLAhltJ8or6uquZ3UGTBWdKm~mTJIl8w261~3D4EFDHphmTf1Vx-9PuJvEVhRBNUcZIZil-7BDcWbANYrCzg679bhYp2oLSIhFcFpqopOlZyLshunpxccYAb7k9-w1StKVvA605vN114QB1y0uYLbPCd0W2J7pI43bb3GvvU8HOSeyai6T3P6Z9KHbSR23lkIcidkfQoZbEpYxH4fHF02VChACQsbpRuddhdMPnATQjziKPhqld-fk4WFeNsgaqBm9Px-G-apgdBaBRBt78d6xR5NMm0uuLPJ4qM2wTB4fFrJcIeK1XLdkK-jlyylgcvmxg3Gf4owJyzQw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "structure/checkbox",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.760Z",
+                    "updated_at": "2022-05-09T18:35:39.760Z",
+                    "containing_frame": {
+                        "name": "Checkbox",
+                        "nodeId": "21453:13213",
+                        "pageId": "21453:13211",
+                        "pageName": "✏️ Checkbox (READY)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "67355d2e864814cf524af148c1b06b51170c46cb",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21194:10499",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9aD/i0u/2oCHnHuaItc7BOLP/component_thumbnail_135.png?Expires=1655683200&Signature=DgQZky-wHWoDS6BNF-cf2lh3YfvorEsVBgx-aL2eFEw5XRabt2SwIpF0gCowPCbgjd5T45NMxeeTa0nHy82V5nRjtbQPmOq8OYhEbx9C6TWcvcMbMAE5rWP~nb7yDhNnK~9n3rbPpCeoDZoUt6-DmyeHfdvwMCSftraKmWaj7oHOCZ8NYNdMnpxEj31MWTPSXIMHAMGHZlKMS6OWwWMqxwAjZNhT8H3WZHdOWjlvOPTyCdpBoO-SGmFopac1qbgAfzcTWIjbRQrGlqPnd7EWEZtgWevZYPl1PXLKtxMmsmsE7TbHiZbg~RzdbAs0Z7XG1TXsWEUaeOhBhQE-B1rBrw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Calender/Variant3",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.754Z",
+                    "updated_at": "2022-05-09T18:35:39.754Z",
+                    "containing_frame": {
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ae2af8d5e3003cf71cbd49a643fd8e9efc969df9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20790:7945",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/nVr/uxo/je7Vh5nUM1B5jXEx/component_thumbnail_134.png?Expires=1655683200&Signature=Xh1AzRMOUhQKImzsTzlWnndbxXy5dbtKaF7Gr8Tzg5AVYhUEMOMAAj2vLx1AytHTJTvPm1hhUCDWwF5nUHxc7fWr29YiVWw2g6eoSyu67gs-EHyFVGj2KoonFvNFkVPdtO~Hwl8Pcb1A~PqXMn2zLQFQBHusGgyCdclJ4QK1ScntFIN63oJzkKUyWbQSWUtOoHxr7PmpmWZUMF7dYaFx~nql8YYmwf8QbolSGPPkcV1yjs4uCO-gk-tAzW~TtSYZogh8jhyA6riqn0SRKfkyAh9aGNFq8xhlO5n7V57kv6Gr4lZ-1tdNSMbGt5r41SyKkSecC7qN4G7ekWR5Va9dog__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Numbers",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.749Z",
+                    "updated_at": "2022-05-09T18:35:39.749Z",
+                    "containing_frame": {
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a493fbcf1e7a946f4fc4ef7edcd95677386741a8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20810:7440",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/52s/gnq/f7ILgCUDxCS1mYW9/component_thumbnail_133.png?Expires=1655683200&Signature=LIVzm0gHXzQKdNKk4tn9xIaAdYC7LA7yVIYyUtfNJTmk571u6kcgKiZuScsMuBZex1U9L~qJW8HpAkIUS7TjKq6STpwsweTyKP18vNDULtG2uzwCA5~Th5JU9STUfWV5XaOsFRXuKRxknkKNpP0-fuF1~Gy0aqfZlij-zvcld-ygx9sJpYRpGIEKBXky2syl5raPTrrMCy4PDQgcB8HqhZSOou9TOKXrui-R7rQG~oTtztbZA539WI69gxPJamoIB3104aMz79AjSzCKuYtjduoS9zpjoljDIsMmzlngOq7t~IUPr8urnYrPbYhNQC2z~DBG8JeMFjvmdJ9g0RFOAA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "day",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.743Z",
+                    "updated_at": "2022-05-09T18:35:39.743Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8c32fc159605892a2bd80885442a70ce0e5290af",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21437:12447",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ZYL/cic/NCUNkBsPQC2VgXzm/component_thumbnail_132.png?Expires=1655683200&Signature=bWKRDRSwLdxpnbgAHaImVTX1BrcpfWqZoQqGwaba4DMt00gFBMDJWA3ROKn6N4jR-t-D7HP37heaFZU~5bdmTZKd9VJaJ-KuWdASarSQAeZLElvIu5g131akQ8emXoWicNu0Ln0I-TgrELy4yxqbAzkQ3qdR3PbiThC2pKEH7KlS9TV2GkdQs-PiZf~GzLqmJcnyLpRkZui9f7SFF-wWm8ELOLcYRFaJx0Znl8dqSjmCtMr50utYhnhrmQT-DAQaQMBxNmAqwaKbC4rv3s0OGn6hIyHV2AOavTvM-4WBGyb0pYqlhRozxStApf~KA~guK9UbPYUQj~MKDFq9zBWj0w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Atom",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.738Z",
+                    "updated_at": "2022-05-09T18:35:39.738Z",
+                    "containing_frame": {
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "92c92770445680e91c0ae04badb3c535f60f9833",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21437:12470",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Puz/iZ8/34iIQYShluoES8Fo/component_thumbnail_131.png?Expires=1655683200&Signature=K2J0CcwJ7422DL3lsPlUHfe1DP7Y2PXKcKFdiAi1loE84IeS51bCRO25EbnddG2BlS6ljH9DBMhHwvWH2PrAZgRvzEN1nQoMhTthTUhNsu0X23JZGPv-qFp3twXODwyHKuXgBtSqFHjQDmTvwXgIDb4tkE~RR2SfkYQeTAdgKcfKF~1WOfh6P1ZbIXNxN4fuzpMOJIKio916a7-mCfdLgoI23nIpiV0dWNeFfwAdNiZWJr0ImN8OeStRTQC2MK9MNjFSsx5IeomJyuLVGl8Qi2LWRS4FDdegjeV4Zn1dTLEaDOW7xu3SyQfp4BJjV-hL6y0~5E-Myh5g4~ERvsQN-w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Molecule",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.732Z",
+                    "updated_at": "2022-05-09T18:35:39.732Z",
+                    "containing_frame": {
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a576e5e5cf0b97271eb1b150d9f87d41f495d8c8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21991:12987",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/rLT/gas/gZFLrOrACasWIpug/component_thumbnail_130.png?Expires=1655683200&Signature=f92SmHObbAG-BOkb0gbiDdlLbFxEOlfoOeznZ24XTwTd0X6O2L-XTAy~QB3ixmZvBgXAHOG3sujlGdufHaMMTTbB3a8vR16-hQYiUl795Z4CD9DTaKU1NWLRTzQ6Ol3MQDtv4nRfDDRwxycSFU~wh1r5TD6gVaEAPztxNZL663nKYUMCQV0IdvVWgwHNsiRTeIvhNY~6IPWXSmJJGH2n6O-bB~ONeLJUQffZguPUA6530au49GaZe9Ej0YqJt7UiznDZrFxyJqjyiZp6bIW~pcy~OYqCdlzpiRt7pseIQwd7T00MP8SNGqfaLiaT8VnWp3C1DNJsYaigLZkkAVD2fg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "RadiusTube",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.727Z",
+                    "updated_at": "2022-05-09T18:35:39.727Z",
+                    "containing_frame": {
+                        "pageId": "20961:6490",
+                        "pageName": "Onboarding Prototypes (WIP - Flo)"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9f2c3f51e819aab5637ff848464c90a10431e7d2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21910:11985",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/u0L/AM9/rOYbNBZgLrSTyvgS/component_thumbnail_129.png?Expires=1655683200&Signature=W4NdpIQHIWtnhC31UiZrYHECmi47wJwer~VId6r7W4-eSUPLKX9vz5bfzZQmEiPPlscuOEKLpWWpXWFhmAOolAi~UubuRghwwbybfKakgXdVD6tWKht-7vafCL1wUwrugLgIdb2~7dCznDj1vbM60PSWI2-fH5tp8bDJaV~CDSNXXhUsv3cX4Kmw~fX2Hj5Rk1B1NTQNTN558NjUTeHzpfpFy7atP13gNTt9f3D5A-pSGhCVsBw2l45~dRVghe2bL6Li7tHSKIAtWe8d-TyKGE1BgNqZ-XViTwQr7L64WvgQypkCz9DQzYV4mFmIUPz2nOr2oBuGOhaPlynvD3HciA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Card",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.722Z",
+                    "updated_at": "2022-05-09T18:35:39.722Z",
+                    "containing_frame": {
+                        "pageId": "19945:7470",
+                        "pageName": "✏️  Cards"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "58e5c5db3ddc50a20cda63e97a9e43a5ce3cd904",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21416:12389",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/rPH/YHH/4iIbGcFnXPUCRIdl/component_thumbnail_128.png?Expires=1655683200&Signature=KyjzrDBXE6suzCTpF7XBl96TU48X4t19gEDXiZlKyJuR6-VbD0WbfVGxA5cuPl6HqC7UeDydSaDUSbkBoITo~fLSncMShp1EjnVPhB2AZSSgugUang2Owbr0ceJMuUbdx7iPkCnhRmWzQpQeVYbRr-~nObeMl-cglD4X4xYpbBqY92mBpezP4C86Y7exwZRmQ4u17mNxjnv0sXy6LQh6VF~frpdjQqMqBnXJecl5Vn79FW4bhyl6FJbRmI3nDFYx0min2p5QEy1j~vvJP1hD0qoIXvEnxz23nzrWQZpQWkMasgLFwvz~rrYI5m3AhTVLo2O1wl4aEJ8~xJp4jx3dng__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "inbox_24px",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.716Z",
+                    "updated_at": "2022-05-09T18:35:39.716Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21526:16368",
+                        "pageId": "19945:7464",
+                        "pageName": "✏️  Footer",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "69754822b849720b799c675144533ac79b6be690",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20179:5598",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/PN4/d2M/9vDQMWeKME5EElK0/component_thumbnail_127.png?Expires=1655683200&Signature=h0WPKAmA~6goSV14ss1CuG3BBRW-4UKBrspi8A5plT45rU~2e4qWuUa6jKRVulmMGaTRK0AXgFsVti6xejSiG4Ex1PpCFD2psZqctij7Jv2Y40j8cLQTQD5eVchWASFkxnYJFXnMqD7kbUC2ybgJKXe10TBTfpDKrMhmfUQDtMw07RQkkf8jaqd4h1zILFZZswwE0elz6Pv4oRTLNWR8cKDoZt5K-qA5MzDmgeqpUdStZR6S78GOqwOhhOfWzbkUiKKxG-WtNfdsy2JObq0PYG3BgJMuYAG4ru5bjP6k6qenNahx-ptbRgP1B9xoyQgyNekSv3B0QzdT-as~EYJj8w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "structure/toggle",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:39.710Z",
+                    "updated_at": "2022-05-09T18:35:39.710Z",
+                    "containing_frame": {
+                        "name": "Toggle",
+                        "nodeId": "21465:12787",
+                        "pageId": "21465:12785",
+                        "pageName": "✏️ Toggle (WIP)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2f58f622ed1b233230a94de325d0b7ff2bd25b97",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21536:10847",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/VVl/U5m/4KmUjLmpsU33Mw6C/component_thumbnail_159.png?Expires=1655683200&Signature=TVReqzxDYuaHxM2dgqPJgOgijIdZl9m5Tp6lDUZH23ju6TO8-vCi8ISrEqMTYfi4sgrqDNRVzDag1~cigyhGve2-h5N5yiB3ljTqJBHLufHuqUwr9jwUgvXbnpBbhnPV5RgufEh7iuNn7guPNMszNLSTpMf3vl-O8-ZU5tYuRNr1mQqracQa9mKqvKLKIzV2gh~0AxeqUDSL~4Cm1WgXTlhCPaQ~ldP9waZW3XLgH4DJjHYjgSPX0yKIU0ULQp5clKUmllg0q03DKDfLYXsRiMjtzwlo0es8DwZl-CtfkckFZ5Yp0RLJ2vD2lZbSo75hcca4PgtLlU05gs3TpIfx8g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Illustration-01",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:10.319Z",
+                    "updated_at": "2022-05-09T18:35:10.319Z",
+                    "containing_frame": {
+                        "pageId": "21536:10685",
+                        "pageName": "Illustrations"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "55bb0c480568709ac6983c01374129ed391d7a58",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21556:12244",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/J5v/Gzs/uZY4hLlnH5XlHJ8d/component_thumbnail_121.png?Expires=1655683200&Signature=ajhttgQdgIcXrjJg-0KF1pPoTQnpmxs9rnqd80a8WxK0BoRlZw8CRtwO7Mm7kmhkJs-oGrNrq~qiK~9AERXFSbZmFX8jLcZaplbDSU4QNCq~NQAEFWmLWwQGGI8e3oDlRLPr6RdS~NYMiqfVFCW~thYizHZQrVC4lEe~J0cSp-5H4gkhvJ515CvaosyiW4v7M~rIEbIckvQMk5cUA~UnvR6Iv1fMc64l7N~54Uu5yDW4aT-A2wzBb4ZLyRof9UxbQ3w75SC9q44xDek-r1-wIeRP7Tizn6L4nhQ7Y0-xhV3Bz-9Opk2JXiL3OGMynZRfJbasi~qCmZyjIS8Dw4-4mg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Image, Filename=On",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.146Z",
+                    "updated_at": "2022-05-09T18:36:03.146Z",
+                    "containing_frame": {
+                        "name": "Download",
+                        "nodeId": "21556:11799",
+                        "pageId": "20629:7699",
+                        "pageName": "✏️  Files (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Download",
+                            "nodeId": "21556:12246"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "3e875257ec64e4ee698097c24c5cb49bf6225fa1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21556:11460",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Kx0/ReY/tolLhSzP7ebnWsf7/component_thumbnail_120.png?Expires=1655683200&Signature=JntFvgQqhF0mzmYVgaPLhTQc-480oDZEZRXYXiAosWRCHlkB67oFJLhio9Au2WzVbvUR1Yf9kxgg2cIZva0gya5j6gZDdJqE7QVjzDSkK-Szk9KJJRmF-agUexBAEbQnSZZCJkyMFX1KFc5AiII-ohO-fqbNTMnKdAIzDEWDNqSGxz7AHNjzZdAUnpCBr86SUImdOlIQRfNWLIFAiIo97B5MmZVdq5xPOlxKGB0-fYPbv3cdYrEefpur9d7rVtVpF57T70-0RCnz947ytqSiNbf55IR2ehFOCR4867t9rcPl~kmyGL78hWefivyU~nV7xLIvGgdQWplt3U~QzhxU9w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Error, Size=Small",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.141Z",
+                    "updated_at": "2022-05-09T18:36:03.141Z",
+                    "containing_frame": {
+                        "name": "Upload",
+                        "nodeId": "21543:10953",
+                        "pageId": "20629:7699",
+                        "pageName": "✏️  Files (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "File-Upload",
+                            "nodeId": "21556:11325"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "01e297c262579bdc624adfda24a5a9c90cb97cb6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21556:11458",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/rOb/IFo/lrOhZExRQaI33SjE/component_thumbnail_119.png?Expires=1655683200&Signature=FvTWILZTUOKer6Fh2UOUqmIuHBFtnxNqxvuMQmtUn~ba-dFvoGlFxfDFsFIqAvtvL4VCs1LYr1zCgrH9BNes68Xpja6s6Mfj27xzLcjytN4CvGdzxpzEYVeIks753gv3o80JPMjUGHngKC7RxUkY~qHY1c~5C9TLox2x2uz5n5p-gDNGNe~JFVPYk5bVGSOgoP8SejzXylF13zFOqMXA7k4GvrgvkReFvsaug-k8biI1zBas2ErlPXI2GJw93BxzqlT5k7BwiQM2TP5e6hHalYEpyNSaNVIBqgcQfyn12mJTmZ-oP0MP5mSjODLyB3B~1NNV78iuXn0FT1zgThOtDw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Error, Size=Large",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.135Z",
+                    "updated_at": "2022-05-09T18:36:03.135Z",
+                    "containing_frame": {
+                        "name": "Upload",
+                        "nodeId": "21543:10953",
+                        "pageId": "20629:7699",
+                        "pageName": "✏️  Files (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "File-Upload",
+                            "nodeId": "21556:11325"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "55c110b0d8473233833d4463cdf24d79b507d753",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21556:11402",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/HY1/zCW/6GtodAwZTbqjNkf5/component_thumbnail_118.png?Expires=1655683200&Signature=gQ50As~C1-PYDHi5O-~0Ajrv1DKRGo46W~ywL0qnQsimNcRguIBqrWnYArTljDbTmuLE8s8ZfcbPuU0iSMsptDdj9Gkqw4PC4ozO7p~A88fRm5CKF61vJwrG99LDBZh60xagiSVczrnlE8AI1wujmpOXJMVzvKRYHFrN7CZQk4xugdsRspiwg166GIXufix6SaSUSnQAMDkU2Gq20Yoq6ugPwfCQHBXoAPE8-zR6DdZQR5qr~CEy3BZXCe8GOPww6m3L6we908zO6PeJHkv--vLCT4HagI7nbQuq8mUYS5ZtKnCwG4U692T9NcYH8q8rrD83YOZonLW4M43TAwAUow__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Default, Size=Large",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.130Z",
+                    "updated_at": "2022-05-09T18:36:03.130Z",
+                    "containing_frame": {
+                        "name": "Upload",
+                        "nodeId": "21543:10953",
+                        "pageId": "20629:7699",
+                        "pageName": "✏️  Files (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "File-Upload",
+                            "nodeId": "21556:11325"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1cdef97c75fc3771c63f335c782eda556c4f73db",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21556:11322",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ALp/jYo/RNzzJlmrltyZKfcA/component_thumbnail_117.png?Expires=1655683200&Signature=U75HB1tVlQQsza4-GjHpJrK3ZqqR9Y3h6ERxbj7HMXVvUbkHAlC32cw~nN83jc5vDDGEU4dC4jmYK2c~LLH4DkCQB6flzwtUovDpY0-hxkPGpnxjgE3a3nV1ImCqnOEJMOLCbZzCRsB785kaUaDg~oNHfRee64-CL1WwrACuZD54Iim7Js~ZePYYJ-l~YcbjoMAR39JRzq9m-7kyey99o0mZOKBkZX6yD5gAdoylHvrOov~f0z8RhRVcacIm2ejQCYQ6zflgLBkrSwdjyOBCGwuo1YEdjjbkMaELIz0FVW7asc~WL73WasMeNIdWFwbEwPU6f8BPf~PEJs3Fo-xUcg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Default, Size=Small",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.124Z",
+                    "updated_at": "2022-05-09T18:36:03.124Z",
+                    "containing_frame": {
+                        "name": "Upload",
+                        "nodeId": "21543:10953",
+                        "pageId": "20629:7699",
+                        "pageName": "✏️  Files (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "File-Upload",
+                            "nodeId": "21556:11325"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "04641e800befe8e2b824ccf780d1a31301f64fb4",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20815:9400",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/kAE/hOA/x2HXkflrHo99XLvf/component_thumbnail_116.png?Expires=1655683200&Signature=BI17ONzzZgk9ZLkYLLYLmAdjFhjEk~7QtgERuJEggVjhsgbrZJT8eMN8g3wnD~h3rFf9mqOP2-BtAXEUYrZOLUP~X4S5uogSq2o375OaiwhI068lmZ0VJ1ymZLqPXv6c0cVfwNo4ZmSsGxmbCNBvkNQcBQpmfwJ-ygRRaFN1UQpWt~gd7wUFoNFDsZwhnO3YmEzOuG2KdUVi6Z58JApvbyriQHAfK2hfxiLPbGy45LUmMuQfeuFu3DONScmLj8gdqN32WBmx31DBE6Ii1oae-KYlOvYTjiVR~yDN63Bj1IdM2NMsggpEfWQ1emhCVCVxuXInce57tZ4VDVesxtvANQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=with form field",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.119Z",
+                    "updated_at": "2022-05-09T18:36:03.119Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Calender",
+                            "nodeId": "20817:9128"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "32f93887e7443b39bc6db557b51cfa2db7bb55f9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20815:9551",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/zSr/r8F/1ix5Pf1X8Fsc18NS/component_thumbnail_115.png?Expires=1655683200&Signature=M5vDq4k4UVDJSuk7F9UK~RmXIPiNpUmDT~VqD64jJ9VJj1eDHPTw7K~0Ju-wisWNh84Kylaf2QGW6BvTPPmPeIg4nVjSHbRsKCzN9IVZ7ccgB2v5qLP4eqdihq4QaoeOvi3FbHpWzKCLPOQECZLJpDMqd-g4pCq2KOT1hXzBn5TT01UqGM2kpt1aOlPE8-qxdn97IYzB~J7mzEm-dJbZbB14KZqrP0QX2NOXnwoJHTBf44ZXa3LbdVGYE3ci~AlowGXXpkAWUkLdeBYUOmy9NuxVt-cf1~4Mf90ODVyto7iD-ju9937r8q6yPt5FE4WJgAyflnhKpT2V3MJbW2dZYQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=without form field",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.113Z",
+                    "updated_at": "2022-05-09T18:36:03.113Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Calender",
+                            "nodeId": "20817:9128"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a33894342ca665f04e6bb08a1a44425ff8e5a419",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20868:6656",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Yk9/Ujs/4qumQ1k2LE2W1xpN/component_thumbnail_114.png?Expires=1655683200&Signature=SXpNy0DHhRFjiLyH4LVYcapn6ox3mofrlUaOjbu3AscGlRG3xTXePs274n2hBXqp9dK1q31W3qx52TpHVOsm6pI9wzQE8cpScKPAyUmHxxYWcQyUc5uccTIyUBUeOIVXgRBP3LFPp9K~j9n6mkjpQnMhU0jpdgqI2Q6KP3IHcNzCHU4dZDrzCR4Sx4Gxgi3y5BJUFcNZT1sGv2gltgCRATm~-~2PyeZgy0v5BTtLHha2fCn8sc3znwiVdcrZQ1YRbeoMqOcWE4-UbZbYwRKVbiuNbO8juyKNVhtQbhw1w00DT4ic-DIiNMvQbogUE7XhJNLH37rPq-Y3z6p6ewkjxg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=small, State=active, Icon=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.108Z",
+                    "updated_at": "2022-05-09T18:36:03.108Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tag",
+                            "nodeId": "20722:7194"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ad8cb5ad0e80cdd1ee648eb62be14c2dd40c9900",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20868:6658",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/QAI/Z9E/Z49fpRgWOV8YDHIO/component_thumbnail_113.png?Expires=1655683200&Signature=e9OQbf5gpjTHp4KdIShnRmzJqwpa3luqTkkYeZywDyLtIuY97OnvVmV2OMW2ar32VJcfpg1kIHkFi~HjfixlkaxAGIz-OtPdf4gr34U2UPe-bTrDukrcSeoBgsUVpT1J7~B0xAAP92k3Twy5JvU6ua9YDpabaPoxZm8PNzzR4SEJZDAOeqP90meKmQ2zi-sn2CIRW2dHJqIoxzK3LAUAnMeMIUSLkRwZaPuZsM1DIpiyc5LLTC0pmNEudReCAEekNLpCp962TfvVViRmmvbXadqA32S5Jx0w2b1BGwhX9tdzLWpVRQsqKq-MvXy8G9cc4hCqC3WdO5~VJ7bjGgaKyA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=large, State=active, Icon=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.102Z",
+                    "updated_at": "2022-05-09T18:36:03.102Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tag",
+                            "nodeId": "20722:7194"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "efa4a1931860c522d94a38ad37504252ebc8efae",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20722:7031",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/85E/vqw/b2yzOrgg7YfOlJb3/component_thumbnail_112.png?Expires=1655683200&Signature=IcNh3qV6CMeAPBh-19F5q4C2Q4UoQm~JVTVpTTeC5S5RN9P7khheUumiSgNkQ3iuEKvBwPc-uSq76sZUqrI5RhNfNXOLPUwXmQcGja8phV~LB4EBdg1QLy0J0w6CA-eeZmTIzFH01FxFoF55ftEG0dVoV~ujIBJyka9PhcyqFTQc6TbmTXiSyx-V2lR1prS7lkJQyAizl6COMjvjGScxWafcAptxADfHduoppSmw9G5Hfz7tpqsdgeIEyrxNH6TpKH0Ddn479AWYLzurCarIchHCO0uCEhlu9hoJLo5a~1RHXoUjJs92FyKcIHl1OgIbAL1IB3U1oeJOoo5kFq3DXA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=large, State=default, Icon=off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.097Z",
+                    "updated_at": "2022-05-09T18:36:03.097Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tag",
+                            "nodeId": "20722:7194"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e7247f88d2d23be7d873a258b52ae70590d9671f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20722:7182",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/8Bc/rAF/Hpeg6mcP6C1ZeD2K/component_thumbnail_111.png?Expires=1655683200&Signature=YuX55kMQIlouFPR~hqws~rZpbqUioQuqzH7xGwTuXVUYGWSb20RHLAgBZcuMPp34O9J2yB~TNw1J5yY95owTmirqFJEsIK32ME2os2tdxMXJEM4gO9~ERvPCkvD8XG~bjbvd1-GVc2U6UcXBLKXxFXyUpql5hTOyGwsPgsDERvfeuSJR4thsRB3pkLf9fVLNPX4vCgN-ApNQuMM9~czjn3OinONFKy-QWE8EwLKrwB2~96Htf7FOiDoSX6YLwJO1Qb528518Shhm-5-4TfuD~C15wCLNvc~i2xW2cMec34RZ5PUMNcVtTjXMW8nJyYMH2cQKnSsbNETUV~ahdRJHaQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=large, State=hover, Icon=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.091Z",
+                    "updated_at": "2022-05-09T18:36:03.091Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tag",
+                            "nodeId": "20722:7194"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "f28d7ba009e0cae814a2454e4fbdfe738a4193af",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20722:7184",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/K1s/nZA/L6YwDoW42VPblvJh/component_thumbnail_110.png?Expires=1655683200&Signature=WXZ92LJRS3C78OzRsylst0Pe2jKTKlbdTBS8dGiST7pU~F2j18q5a7rVFcY4NyFeA4gkG4avg1Y3LOdmKaWGCXF22Qx3l7HL8m~4e0HGXEzCWEaN1IOfX2Rma~~xhGqpOKEcZ9Ouy2x4C2lN5FeS3TCHaqhgVx0E7M57IkA0KWw7ePJ3H9ZmFqfz6NDvMXOcnf1JVpLTUXYgjMCE1N2jC84p5MCiqCn~tEGXfSiwAV5li4WiZIITg835QBohnpd45gO1Z2YUyJuGpNQz0qdExZSfYNwPcsxxC7cOI6WWiL85pSmzBmT5RwzC-UemM6SNyYRXWYE3Pm-1H5fGDEVLJw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=small, State=default, Icon=off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.085Z",
+                    "updated_at": "2022-05-09T18:36:03.085Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tag",
+                            "nodeId": "20722:7194"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "877da18b0c18a04319b73ca0173492af99c141eb",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8664",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/CMp/BTC/hrRVuJIDTgo7cBY3/component_thumbnail_16.png?Expires=1655683200&Signature=dYZb0usS31tqIXRHP4fJV~rq1uzv0otsqyx3hIZZytLgzE7qplFV~iNFzjYCbxtHAAYTZD3ebgCQwPEhNa8It9mjAV9hWCnD8xZYTWyIiQQU9ZAGn-7keq2paot2cP9IE1gkNrs7oP~BLvWsCldHQz0wj4X0EKKrmbghpJrn4MtozMuu2~cjP0RW3kmorfolCwEo~8-Qf9EX91xK2M77lC2rJ6XHxraFT23Xzz2F0F3rWFBEQBL2EesPzwilM4ZHeoLM~atlpVGAbPyqauTxqszpN72yZ2TkTVjExHZ24Wz2rRmLVODfZ40RfnfDlBqW2OISeSa9v7zyAgt~XHe2zw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=active, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.372Z",
+                    "updated_at": "2022-05-09T18:35:46.372Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e1ee8f4f3827d03a63c0c594cbc74c189c3f286f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8672",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/e2c/mVO/KqQe5KUnlq9X2POG/component_thumbnail_15.png?Expires=1655683200&Signature=dxWqwOqH3hqLs9HJ1hpR2a0e6TenGTD6cbFXzo9vGDYbh3QCDl2anOJ-MAXoxj5XrbFnB7KTL9HadA1wQRnutj6OBxwVdoOPyzOpR-DNfbHxEa3YXcoYJchx4lNysdzZN5oyZy7qjT6obhB545IdoJPgLkTKq9fhROi3oUwsbWWm1JGhJ8pHdcnVjxKtlayp-vvFkV29BjKzpMHMDU5b6jRKD~7djXjVhVAgM2A3xhucuX~vlnyKR7AqY0Y-C36JQLSobarDgcG~7yW0lr7oYeWsPon8tZLb7Nm7Mw2s4X5U~PpuRKaeMAWTeunz~ke6TQIFTRMZveTb3KI96Gn2YQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=disabled, Icon=On, Responsive=False",
+                    "description": "button: primary/large/disabled/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.366Z",
+                    "updated_at": "2022-05-09T18:35:46.366Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "06c46e3e86bb1e339e871b473b9f7b305067d236",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3302",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/JJq/BoC/VngPHasioBjT0gyy/component_thumbnail_14.png?Expires=1655683200&Signature=JFFBcGDAscefLvMCYj8adMPiTNTtkV1xNglTYgKL4cnc0ywAY5s4m7RLLIK04uMijxCjakwLr8XjJuWs2we9b-Z6pMYnFYEnvptMv2i8updlqBtCSDfHzte95Duq7lR0~83pFGOpaNfxsPV2IFXK48G7teDSKB-CWX98dOt8zP7rHH73L7BoMntPw9~tBwR~bMijCr6PBX7qesgQ60qDhOkeFusjhqFbExwApA1WKtO3aqcU1pP63UR4I7b0OjfIo0vbW4ptADu2F-cEjj~AOrSckDjZ-Bc009-qUAhkOrF--1cQJDkrusa6Vgk38ZU8pFdLTADvW9Zr2po~DrmjRg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=active, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.360Z",
+                    "updated_at": "2022-05-09T18:35:46.360Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b62f934e6a745d297c78a3a7937ac610dc2f2a5f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8628",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/cJJ/sBX/ycfmJMxuqeb7Upoo/component_thumbnail_13.png?Expires=1655683200&Signature=NsCsmr0Jgl8irn1TuwSAWfMcHuXu6ZA3ytsXe-RYL4EzQTtL9QjyhuosMFEZvRwpJffxOfMpEMIEa0CDL79L-BqX6G3QkjG6hz4PV~nIZBs19B8rQcsZdVvPvdy33pQzzGOyz9RTAWCG60sfxnzNvYqWiSqLX002oc3g-UdDLbGB~ur6dH6i0JzY4U5FZqlVtfqdnzm2oXpgWsw5f-Ttg-32yDH1HE01JiSXDDaV6d364sabQQkgrFGsnxC9A3KN2q260X1h2pBPQ04W9yJHzkDZb~LD~-FIuPPLlKebDNmY1nTZVIqi9WIkV25yu1Peg9Chq9lVVGPcjZQ3FlUc~g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=hover, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.354Z",
+                    "updated_at": "2022-05-09T18:35:46.354Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a1981fdd0c3c5cee7721b41f2c82b9d2d1e0bd9f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8650",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/74H/dL7/WBgWopJxFaOAgLhZ/component_thumbnail_12.png?Expires=1655683200&Signature=W4oaYjH-ar1nMaGB1CKDavboQrGzPUjzWGa-uCcqLyCEixMJgGWiHv-SqJUaSUnqpEG-QpS4G5H1mcyGL-UX15teuMLviscLmRQVOdpPjX6SWJ~z5YnM5hZGYNPeUT6HmN-mJhAZWMjLNr5rnWa1G4kBgMRrzxcUxuKx96qjlRxGbhbpktGDD8UaWB6VCyYaQX7HuV8~eFPhP0Wh3wkexJbE306AhC6WKZzfudsxqOjNPASf7EO8SjBm-Y0KctEtGYupAmmUpyqFQbuGbFLfMkPty0A-V7olpJvwXrhymgFw2s6TlMqPYhu1ezR1zglFl0SAIunLToCxXUWcTNc4XQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=default, Icon=On, Responsive=True",
+                    "description": "button: primary/small/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.348Z",
+                    "updated_at": "2022-05-09T18:35:46.348Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5f785affd9a24dc20dc3c4eb9765f00a2e3cff24",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21416:13247",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/8Z5/4cK/VG4mqt5eJGLopZgv/component_thumbnail_119.png?Expires=1655683200&Signature=WZ-C4xaKyzm2PnZBQIZOGDtGJLcStkrHoBLLecofsfIDdQdSSZ8ywJ62kknVkaFdmo6yj~navkFZoSXGiVCd13hl2w4Dnr-1UhxfqGNEKvIe2Zq7Spkm9b1iL~dL~fJglYdMBYoRA7dN72YSgH290HE55XPwMtodS-hem6juy5bqO4pmHSWJwDbZq~t5HOcScrDqMV~3wxFB4gEdU6MUP3aYenNNzVbgcutPYF1h6FA~0u3IXo49Qv5yxocKn9cHFtmrtGWgImOsEosiMfxy5mqwJi-VViTJ7G1emzLmFJTzTUaUQAfSom~DmhG8IEmpf7nAuVZcZTjkY2lDS-hlGQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "footer/tablet",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:30.538Z",
+                    "updated_at": "2022-05-09T18:35:30.538Z",
+                    "containing_frame": {
+                        "name": "Tablet",
+                        "nodeId": "21526:16440",
+                        "pageId": "19945:7464",
+                        "pageName": "✏️  Footer",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8f76e15322fb0054a1940f504468ab6e6156e3eb",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:12686",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/jkK/qOX/VTTXiqDAAb9RKIzP/component_thumbnail_78.png?Expires=1655683200&Signature=aqh5TVz5oZ5J5OTHyHt8RTBB6lRfYoX-mMSFWDsNVtu7~WSPzCecFwgUIUHChXEpaN9zs4Xm4lDDcI7ZgRl885udGbh6My7QlFAHwwtgSCeOcvUJngLXUw0NPwUs3ZenYJ85oEq6qXAfsd1g1skuwTPcFQphO5UVaZ8ie2K-BNa93CYH3eKM3goav5llDU-0uEruSk3E~nCOnMz7y02IpgBmnGkfLEckXQinT~L7zJ4eg6xbRGzVk757MB8KmkAu9ttNjdEI6-409jDtF3YhYsA08GwvwhNgkn6BAr5WFMJw4uZf1sVp0I2bRJMuAkdR5Ct1nNC94-7dyn8FgjKOGg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Variant",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:00.587Z",
+                    "updated_at": "2022-05-09T18:35:00.587Z",
+                    "containing_frame": {
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "177ac1be2bf22889ea3fbfe4dd10a8b96b4b706b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20563:4149",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/G6W/wkN/RnhsK3hVlDx49WEc/component_thumbnail_59.png?Expires=1655683200&Signature=PmXXm92YuZqInREqRZ1XfDDo-e99uaLNEHo9Iihs~7BXken1Y5wi-NXggL0tzZGMf6WdNGb-UUrF9xSKjzWRt~bnKOpQuKed0Z~E-VcqvmiE3cQ3wUBINDRmCapNo9ZHoURkqIasoT6-1wYhBIB16rNv6FdVl7zWwm~AQAtYJzKZCYGT4oXWvIsOiFsrf6IeViVjIpT6MKSD~FFDhpESDVT8-iCx1S~S1yQqkqIE9ikbq2mi3cATOsIpo3ajmTveL33qqyTdP~~ifPQQ0kasyT0Meiug2CjGoGZxLeXvZQaP~gJJQy-bu58kh2oyt3L4f2wgggwQ0erOtcb5y4hcRw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "screen-selector",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:00.504Z",
+                    "updated_at": "2022-05-09T18:35:00.504Z",
+                    "containing_frame": {
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e079f2c1cde2d3bddf1483b4288831e8928ea2ea",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:11213",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/q3i/Npk/aG5dotIvhCBJp6GQ/component_thumbnail_54.png?Expires=1655683200&Signature=BltBpiP5IvjzB~tr6VVifGj88o-EekCNpaM7G40pcdrq6yw14usWCcgsZcMDEtbcar2g9DdCVuD~20EyBCFhNOnjg2iIEJebcNAfXuiAV83EiC0gRyHBuAAD1yhFroP-kI-O46Mb5plj0kMt32vHRpcetRjLHJlHEV3TtBtteJfy437t2u7l2VeETAKUqtulT66P40599pWXuJOsDOvDjx31Hm6C-scln7Tx~ZfU11JJl2AnAS4~SBl1hhEbneoTJJB8087it-Zi2xXDWYklb-Gr~oHqqBMwNYcA6wSgmNja97sN4thheun7anGpvbrivMBcO-nrYBve1F6ZB8zepA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Social Links",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:00.482Z",
+                    "updated_at": "2022-05-09T18:35:00.482Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21526:16368",
+                        "pageId": "19945:7464",
+                        "pageName": "✏️  Footer",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "18f81dbb0ae2e5e014d82d82ebcfbb6e87c5ad78",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20722:7189",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/iKu/tQK/7nD64PnHKFXp5IRI/component_thumbnail_109.png?Expires=1655683200&Signature=ZucRtgnjx24OtwimQwGfhK5k9p-~~IbLvYkSQFVxzv1wljn3fCPdjRqwOjfhy6ngx21IqXszciBUprNyY-iG-V3VvKmYP58GHu1BE~k-FM5fFhfklDwQBN7GYMVZacs8vBMRxOX19rMRtjpTNEJMzSuRZx5yiqVPdw779PZD0qn~vhEdV5p7BfFyMRelG~qWSKeh98rOPD91K92XsXJv3eO2IAEQo1X~lnxE4YSkY3ZbQBTq2K42ITirwUGWvCm~Nid9DIjfHD4-KufOYu3w1yBNy4OmkuRhMO0C6j-Qd72fipMMnk6o-s~IJ5KHHEFkx66rcy751WngbvDfsTjGeQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=small, State=hover, Icon=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.080Z",
+                    "updated_at": "2022-05-09T18:36:03.080Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tag",
+                            "nodeId": "20722:7194"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4254dd9d99a363e18b2316d8b5bc155fae0d7b19",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20722:7183",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Uh4/tDZ/zRVcPNLgiY6pkc5d/component_thumbnail_108.png?Expires=1655683200&Signature=DgnMNrI-eQ5D5oAYd7VMj~zWeFADAZ6a2QGxROxZJtmlwktJ85ostNg4LfvdPMPHQXr8tT7w5BnsBi-sNKkVQzaO-SZpZEyzdsNhez7l5YlNZ5Ft-1KGBpPq6yMzONm4mbO7lB6eilB2aS4bWBVIKslz3NM6uhCCi6pBEQ0BSfZeOXC0cwIKzCUm8lRG2zt4ugTgttHVIXqhkLLGYnK~wHJDOvMh3shMo3Z47rkbV2yi9tFinJK1zGE4D-zHAmi64TJCzy9NLlg~w3oZNEzs3TUvGbEaurXsK2DCpk3oLGHb7Li36citdzL0Q9q5-a6eGiFwnt5q7IX7W8W3Sy9MEQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=large, State=default, Icon=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.074Z",
+                    "updated_at": "2022-05-09T18:36:03.074Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tag",
+                            "nodeId": "20722:7194"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d3d2d605dd5541c3e234d9f40b10bc6c0ffe946f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20722:7188",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/6O9/BIt/hvH55FTGnY1ptOW1/component_thumbnail_107.png?Expires=1655683200&Signature=BjyN~kaIrKWhUBFbYPtCl2gvCzN8la35GQ18NeNeifclx4y3J1oaNMMd3fqNNAUCywHX22RAkD0o7Akj~LqxkLLg6GjChCMzwRW~YGSj6Ee9XtEI-3xNhcS79Bxlfy7tlbCdqI30GEhjNqOuIR9jjD1BryTFGMAjWtxzogDhUbaB-lHwECPTcrlzQUH2gUdp~1vNyLQfmWyE0pOsP2iD2kDZ34LysA2ELB4o1Q7mYGIaBS427xkuhvpDWf~z0EddjzyGQN~3X~qBZCMW0FZBWGME1mTuRoECjj5in7l39oZWqH-ODhKNIwA4m4JaiAUPbM3I6u08B0-bBoZUz0jLpA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=small, State=default, Icon=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.068Z",
+                    "updated_at": "2022-05-09T18:36:03.068Z",
+                    "containing_frame": {
+                        "name": "Tags",
+                        "nodeId": "21476:9809",
+                        "pageId": "19945:7467",
+                        "pageName": "✏️  Tag (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "tag",
+                            "nodeId": "20722:7194"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7f9fc9c5ad5cf1dc50d9b5b39e74dbede7661dbd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20629:4844",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/qfH/l0n/AgiSz8DlzLgcWbo3/component_thumbnail_106.png?Expires=1655683200&Signature=ZBaSE7-b~8J9-NIgX-JCKU072HFgTMZzL7uNNTyVV-rrz0Rhc8X-29Z-eoCnEFZ8aMnJTOBlY58zVyt4uy7RDIlhoVvGO-2~hbtxd9AOz9WYGrNNsV9OFrTo8rWbeeux4g-y5XSc-KHXKvjoVErtFDNH4c1E9R0afudL3FD3VbqUZI2q8~pVj5nWC-SmYAfxDUMcOf-bpBM5JH6joiqouZOw1TMdMb7gFo7xsS2~8UJe13povEWj6yeB5qrsf5xPdPiPyq3RTILd8yS0IoGSMDuN3J0sPK7RZc28V9LuijU~xtKM--03tHv4woHssvfki4~CmThGu1zm0VS9asDFEw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Percentage=100%",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.063Z",
+                    "updated_at": "2022-05-09T18:36:03.063Z",
+                    "containing_frame": {
+                        "name": "Progress Bar",
+                        "nodeId": "21514:10610",
+                        "pageId": "21514:10608",
+                        "pageName": "✏️ Progress Bar (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Progress bar",
+                            "nodeId": "20629:4827"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2a6ef543ea070a92fff1db9a3bc6cb6806319307",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20629:4828",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/yww/D9s/Kdojcn21aeWXYxwR/component_thumbnail_105.png?Expires=1655683200&Signature=Ym9bm7F7x0pfSg902GtTP~PB1bsJcDnn~c-~NEIN8sPe8X3PUVPlLNw1v3D2TZ77n1XcAN3YHbft64BA64lA4Xj4Mx~ZD0bbf5A~bV6HhdrNDTqcsQituFsCKAgmsLUpf0RTja1rI1RCWeTeX~wb5cK~xBzTdATBk-gKo0~JesGDKSibCIXJVaN~FnzkvSkNh067jiWDJzKyo1MGTNe-7tkEsXRtMznfp1NDIaEwVOg52jReOXfqccClwGrHeDj9wuUtQ3B4spgJgRW5lavAr1xpHe1DoPwPZd9taaKwS2~uJE4JUzwsl2uS4tokxX48ZUXg9K1RumlKxK8d9zJD6w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Percentage=20%",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.057Z",
+                    "updated_at": "2022-05-09T18:36:03.057Z",
+                    "containing_frame": {
+                        "name": "Progress Bar",
+                        "nodeId": "21514:10610",
+                        "pageId": "21514:10608",
+                        "pageName": "✏️ Progress Bar (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Progress bar",
+                            "nodeId": "20629:4827"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "ab0e2e108c68482ce551d8bd247242a7113d546c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21514:10794",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/jZK/0a4/1Zbqw6hmB6eqmXMv/component_thumbnail_104.png?Expires=1655683200&Signature=ZFOiXnK7YiI6QHU7lSu9FUqol-e3MsvAU5QGXAVHD1PpzJMXVJplx1xKxn0HjW5phsPRFk8aPZltAX9wp2xOZB2Av73uLnFQKt~Cz3hNfuaQufJ4d27g650mRk8JCfdbn1MN8bpOrYyl0mEDREGUXVa-6E4fTv6QYuYxeeuXaUIxMApLPIcfXDOgCwjlqqKnQ-zp59U36DM7jJi9y-~fdQHfVnuoqzwA2r5k92byyzOmjthnl9R2obo52AfdJP1kwBOcvLlTarINzql1GmB1ieACtwtz8hBjgkh8RdRR0F5yeU39V6~LMtyRIfJmBuDF9WBaTYidCPmxVRQ6pcOLUA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Percentage=50%",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.051Z",
+                    "updated_at": "2022-05-09T18:36:03.051Z",
+                    "containing_frame": {
+                        "name": "Progress Bar",
+                        "nodeId": "21514:10610",
+                        "pageId": "21514:10608",
+                        "pageName": "✏️ Progress Bar (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Progress bar",
+                            "nodeId": "20629:4827"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "05c3f1f6d855ea6b031c86d6435437b1e3df2f57",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7634",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/FxJ/qAz/Y69KbVGO7PkKFO7i/component_thumbnail_103.png?Expires=1655683200&Signature=GZ2FXKDK4M-kCI3-gKFmOkx0~KR0Irk5sPOXyoUIr2YMAlwZXs2TpNHvw4mZbcVZwzPfUoopL7V~a0xvl1Aj1NU4fIhenyq3yX5uVRPjloIqlfBntC1i8WloD5xXBX00YCoPtvLliE1f4TmbJitOVwTa20z-Ngl29Mj~ud2xFBdSq3DZeuqsEmhoe6-5G~dnKCxR3v5g0Qafjz0sk7BFNZDYkrebbVRW4BOIDcy3r1jUZzy5AE9tFQBZY4WRszDBWVk417rzS8Ku597Cb21xE274Wz10HhdXeIVZYYMahVwCcEE3gVudvl38Id-npIZBU5TWKA0pBayDz6i3cj1LGA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=selected, Selected=end",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.046Z",
+                    "updated_at": "2022-05-09T18:36:03.046Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fe3aba63fc9c68e1f4c0915c0a408841784a743b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7632",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/BXF/m5B/9QJs8FbKd5oSJ7KY/component_thumbnail_102.png?Expires=1655683200&Signature=K4sI-my9szQukn~M6S-IwnIa5ZuuK-kkuD9T0IxECZFCAJPVaFvjsHXY9RwoeZFTHc~iufQVtlbA76ZHxJX1yk4OCFdD-nquB4sKWjLmiVh~d6LpgW9gov5oFbwUe5v7gSrSa~qvZ3alXBoTeEuC07sPsHXJ1h4Ap3jYWftax1Rd-rRfrajpaWnSNOlCAkyrFJGUpsWUom4Z5X6G92gDd81zv4pHNhQ8NKZsdAElnpCO~Fu4XpKQglFaFkT~AkmvX2YtWaSRB-1xUrwF~Zb740ggNUvp~X0lpJvsRs9Rm5jjncyHjJw3H36Gz3RgoVKKYPp5ivYE1A5bg7May-aJlQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=selected, Selected=beginning",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.040Z",
+                    "updated_at": "2022-05-09T18:36:03.040Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1b9c3e0c11d9df7e17ce9c3ef31a0f14bca4fc9a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7636",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9tk/GQC/MiDYfiDT2mFQhPfm/component_thumbnail_101.png?Expires=1655683200&Signature=IZGqLItN49eFVFvGRjrZDxEKNE4z~h2KBM93dm5XzPNSVlWvChaS348dIu8SdOESc2hPFMEXCNTD5vxAmJY54WFHa5WqxQEkMwJYcJsuuLmCFDEp83lE-kb0tki~nTn5WjyoeaYXOjSLFwxy4giahhO~VJj0CVRuqKCLsmG1BTXsjY1yJT--StJH-4o1~3h~1ytTxFo-ngQnKzslKn3is3yJm0eB4UsEU1UkZQHXDQmWjRZI59qROR8UGeLhFqo3W5xxsecxgCyHReV9Ql0VWFpoiVxujVE9CFGXcG~jB1YIXoK6ceKNvcJ1xqsVmAnEyEU7MZE7BRHlKvJ2JJY8NA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=selected with stroke, Selected=middle",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.034Z",
+                    "updated_at": "2022-05-09T18:36:03.034Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6caa30fc941a3fa29e86105a91f1552b2f4c99cc",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7635",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/RLY/xez/mI3weydVRArqv3Ft/component_thumbnail_100.png?Expires=1655683200&Signature=R-7reQ3kSYHyP9zQiIoAaZxFuVqqlY4fMuZKFqafqT4DZTCfLPQenVxvBi0ouly6KPE~aiz62O7pi9~ImI-XYxQ7xxzU~FMsxwzOC5ZKyfEJ3Y1HnxsW~QpsyK4iFUlYnvrPPQW4OUga2OwLYC1D65YJ32xJsdILbJL-AIVd9JRsyP1fO3OcDbjZJ9K3g2tHsvMixZdrcSHnZL9q7pTH75q8-xphn4pWriG1s-A53LYeNTjnj4Rl7e-V5BqDXudvs2szWN1mrN7PN7-4DjNUR3SQezQ2CLwyYwUYBZ5FAaRQ3y0~M~GOTtR4zlqx5WcPzUwfKAu7RTcccaYGCCZECw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=selected with stroke, Selected=end",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.029Z",
+                    "updated_at": "2022-05-09T18:36:03.029Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6c98241907e4fd21a2cb9376513c14c0972734fc",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7638",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/EkB/0p4/M759XLduyi17dfSJ/component_thumbnail_99.png?Expires=1655683200&Signature=JnQk1nLmabxxJdFucPis6XriRPmKJ875h8O5M7hCP0b3wVpKP6cCksKXAHQuT9SCbQIkvKVW4SB19LmpI4q1E0Z6NG5QI60~DWS9swejivwt2yclohOMdX3SFw28y2eO-U3h6J7xPBAYOoodjRniWzd0-oRxTmtyjitf68w24OLHUhRjNyuar05qBnYRSlIEDf~KmRfJkR01wnRAJJDm5wM-AtoECun1ashsbROyDVAMEmbRJqvHEoyqVXFniorTg27v-~ALvHZJGRGESLARJj5GvzElVDhMTKglr4X~YBN6Sh5tIuDgye6FAJbFoakjCxmgABl78CEdrkr7NvudoA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Selected with Stroke, Selected=Default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.023Z",
+                    "updated_at": "2022-05-09T18:36:03.023Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "69884f699b544f4ad79ad64f6062b8c080a11a27",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7577",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/TCN/Rdg/MTkpOxlWqTXyc9vs/component_thumbnail_98.png?Expires=1655683200&Signature=FxasLpTfUs1KS-E~A3qMmc5zd6i6M6w9OMZNww06y275IEojmNUf7n3REqsmlLis9a2nDOy~sfNn1tj9WqscqOqNGk9UWsU-M6U1PEC090kvDy2ao5JGm-n575sBuXI~acLF3-D8cyISs3ROTJqYIQ3MzkMBRfC3hOqAcW4Qie-wyfXZBgRPIWPZS2KmGJRFY5V9LebxbTPGw~KK4bBKZfC4zLPqUzG4g6Tx1Rw4xmblOKtuqPl1xDKrsaQnGifi6U3HWiQotehoAKTru-zWBZ1Zl1ptOkKrBplsOJydBeylZd6xtgtNSqtXpO5Zd1216NWR8LLzx7PoSttHVaNcIQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=selected with stroke, Selected=beginning",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.018Z",
+                    "updated_at": "2022-05-09T18:36:03.018Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e5e2add0bd81aceca857c341d1178bd1d3973427",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7547",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/rdE/pZz/ZEPU3Alq3XpzuAZA/component_thumbnail_97.png?Expires=1655683200&Signature=HgCDPdd-ap1OwUoNNhEDJdbqlisWnMbifFkoYk2LOlQ~zelbD~dnWrDtCk35-2YpdVX3m1KzOW1bJewEBdjl3HTs5TrbbFmEQhz4jUSXvi6N9R8PK90FRgnYXNsDsOQvMfnMDIzUAw73pwZTHaHhq6SYtkv82UQDU9mV~wsJERkGsuXGUaQcBabAskqARxoJG2VHhP6SA0oA7sz4R5ZoJPPLIFDbPa~fCHHIaf62-~EFIysmNNjM0MId34RaaFfUgZc2MtrdmPClfScE7ibj13U~8iSINEXUl09LGf9t0mnhcL2ue8o0S74LuD2y7~nwHrbY-ZgSf4DLyvzdgK0v1g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Current Date, Selected=Default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.013Z",
+                    "updated_at": "2022-05-09T18:36:03.013Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5e8bcfb1b56dc286e07acc552046765309d2689b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7637",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/0bs/qdo/5fbquKC2Uc522Mvt/component_thumbnail_96.png?Expires=1655683200&Signature=GjwLXBOAgLX05A9sqMoqU6UG~xYdGGsDtlMfCrovc8t9ElQv7K27lGA9QwQu5ZGEfQDmo-LD7SPxNiyFjv2fLB97jsNraLj99YxxQWxjN1EzfbjcuW6mJqQPNi~~5BgYPPuScuT100kSSoqGzXHsVtThGhE8E4WfEM19QOoQiuBJ0qTCc4DtQTDRV7Fba-ip~d8u-BRfdmDkVgJ9ipGqptqh8y9FN3063taF4c9OFr6D8E-Cl~1Pz2h0PlOChsBy31n5JZBDdll3lp6HLxqGpT3qWNFUrtkawQZIcTKPmE53U54pDAtxlV-BGEXJbr0TVlViDI8CjD8xrSTQHcABUQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Selected, Selected=Default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.007Z",
+                    "updated_at": "2022-05-09T18:36:03.007Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8d9d617789eac30f8def03ca1c93b4bacd8568d8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7370",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/RU8/SUb/FyrLDCicFLzzu1Qa/component_thumbnail_95.png?Expires=1655683200&Signature=hqYdpXgLqLy3v32acFVf3OMgGg5abiMoonynV0Pew-qnpxcOXz6XhZARUMStGEvE1znZbp4DItwpiCWAm7zhG1f0afuOA1oI5cnG9jAlMwSSzHiXZIXBNRyRtfAoVempjEXoc2STGp0rGMgAZdcufrwptBPGSEe1whuyBotb1luLDpzNLKRVE3a9cxt-o2mAFCeI9wLv3FY2j5vImb2iPUxXW40C-EGUfyqbc5PauKtebJ7Iv-EsqqBMU1W7fDW7mAU45VJpS7-lmKUrB9irhReSxfTyOboyw0j4ddEpxZHQLqWAj94xc~~9HifYDVLnCZvH3jzSJm-i9AunvNvVUw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Default, Selected=Default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.002Z",
+                    "updated_at": "2022-05-09T18:36:03.002Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "63ccdd70e4dba249eb9db5588320c8f9cf2155fa",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7546",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Prh/1Uk/Uh1P4vCUVfdaWWjN/component_thumbnail_94.png?Expires=1655683200&Signature=GZ0z-u7JPUPukbb601BB5ChRuEMWKP-EYXfBSTKtjkyd0mEECrPrmz2qa3gJfcUBUBl4VIAeHvesGN4~IoQwTawF6ABUNkK7I~CcJfnzhdHgWdlYVfV5ZSwDqHz8QtPjEbQu50lc8uFv9hS-AXbVUZMSib36I1qrPjAo~nj0kZRGbz7trxBhDJTKnQIg34nqgcvmsIqf~-vKYgfOWyB8Zfg-WwGqxpQuLFd5D--V9j2bAfrkSJR564Gw~LUpUkpw~tE1inTfB6Wc-xNw-aMm9DOQmlQTR7cwk7dxK0kAnqEFTRBnVOvTj7k7U1Dgd8q~W7Hbi2sFulQ2Mb63Ix4mFA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=Disabled, Selected=Default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.996Z",
+                    "updated_at": "2022-05-09T18:36:02.996Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2be00c487e5ce1d9bb186628a51e83616179f20e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7633",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/EKX/gTz/2nFjqGi6huv2f8oK/component_thumbnail_93.png?Expires=1655683200&Signature=hTbFpt~X~vCmpd8qKwIeR3ZXkh6m-rAaHRJli6zGbfV~ME4-Vcu~91j7bl-Rswpwircma-8yu7GgcSB4jv54qISdxiMBzfhteg-xFwxRAPvEkf39BYUIgmL5m~geABM~PCMpGD-leB9yMyBmIZ5RAJFYhH01rxAn~LIlxVPbJiowoqXzHAXCKJRdmN42MAgf4WXUQtlNi3M6YqTYdqfFsUYcZBWLlVcN~Kr46ZZ4MLhEonfEsaTdIyKZyJxiaiqn3JrvGQGOP0vlRDENqTdzWdmvwlZCcYTIHAlHEvNDD63XVJJ2jQuvX3~qJ~Txg2G6MXWjFc4Zgvx3Zx0ZqttV8g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "State=selected, Selected=middle",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.991Z",
+                    "updated_at": "2022-05-09T18:36:02.991Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "day",
+                            "nodeId": "20815:7679"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8f0a78875e88771b1a257a17cab164dbb3158a95",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21416:13669",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/bEV/k2U/jaKO6dBJCsvyLwZv/component_thumbnail_92.png?Expires=1655683200&Signature=KgQUb5tOO~0RG0BWp7ctpL6cFhWehKcF75JLwAU72yHsVTBQCUEsf1fCsI6ZOoNaWkliTt5i7q4QtRaSdD3qRswwJu5OqGYp5phZAJe01lPljDqK~I9bC-VUKZ6WqWmLnefkhcZx5H-XY5w1VIQuJAr3OAoE7nzlGlNjzsf1gwAh51JBaHLE-PK3v2UIZ3Amp6XO9BjCB1oVra5Bv8knm6B20RlE83FcqLeGqYaTexTPECtek2ifyX4Pd~BfXII0i3V1l49xXbKlVbJTzk3mWXR2IA1C4oesFDQi6dnOZeqGOQmreSFE1HtsSAfqOGIb40vzuR~cXN7HKwd0e5xFwQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=Desktop L",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.986Z",
+                    "updated_at": "2022-05-09T18:36:02.986Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21526:16368",
+                        "pageId": "19945:7464",
+                        "pageName": "✏️  Footer",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "footer/Desktop",
+                            "nodeId": "21416:13063"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "dcb82eeee803bde8143827d7f9ac3c86a34a729e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21416:13060",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/2UN/IeP/30RuZpHolVFcalWi/component_thumbnail_91.png?Expires=1655683200&Signature=CGBu6M7KlXnRVueQPqQVijS10nf19dfuhR1woYtlDGMWzfcvp-iXAGyOBAOaquOj4040wZ84eczyS-mMikYtGX2MaTwUSlcOLU5mydNfx6JhiauNEUF5bnJRK12rg0TPCXvWkq26x35Dx2ffjp15PZESyehJuNKfp7Q8TM3laQP5EQ4ESB3DifLQOBu22ZDvcRWIprPj-QYRRJCtX44jV2CgbhDMtXHZimS51Jh9SYbVWDuYPMQfZ6wQ0atvcYKNXRglvCI-p0leILunGPUhWzzLtsR66VmGnBUtjdTF14L01RhsKKjSK1rFyqNChZAgwShk~btvIZ8suqgrSjvZoA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=desktop XL",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.980Z",
+                    "updated_at": "2022-05-09T18:36:02.980Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21526:16368",
+                        "pageId": "19945:7464",
+                        "pageName": "✏️  Footer",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "footer/Desktop",
+                            "nodeId": "21416:13063"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c729caee53f0957edfa8a84d26cd99ea9ca154cf",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:16503",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ykk/I0D/iCu2EkA2vkJ2jWpM/component_thumbnail_90.png?Expires=1655683200&Signature=LA23h5m4ybx4BpM14gDcnj3~pS9D8wazhDOM5UJ4tDPT~iGB8-AeAazF~i2YEoMI8VXJlkzu19yPD89MfVev~8kpVjSCRiyuf79hncy3Q47yC3MZFbvJVlBMF57wxM12rBbfJEsgCtc8N2aha2MgIj6iwieP3HjXuA~KVlbmK7JqWnCTAoVdE6IcB0mdItpaoqW0zX60z3DE3TzIyLIl6hK8JYNxproptN0neWnRzO5CruYtJlfho3RKFuanwVfUaCVhvPIck4Rz~h5i8KaTovQAljvIksgi2VlDm3lYHIWq1fqhHYdSONNrkSOntpm~7QZfKvFKA3EwxAKiS7JBHA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Color, Color=off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.975Z",
+                    "updated_at": "2022-05-09T18:36:02.975Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-secondary",
+                            "nodeId": "21409:16440"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "87955cc26e978247ae8ca12bef6ab6e44f9405f8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:16505",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/qa5/toE/8WTeC1TXMuPvulU1/component_thumbnail_89.png?Expires=1655683200&Signature=aPWMOkIkBECwFPNKYTwWhLJXfpPXu1Ho2INL1yOuYXBgUJk9HiS4CNv8BEHiIaE-XeaVhhvPcrxABcBjlJFJ5utPIUJQMtMogQEbP0Kx55zFhkEPGQdcLTPm~gdAGi1Fc7jooRkdeIK8bb2XqnhyPqypDdAVBMigyRLCfSNzZRYJbxjawu8KdrjhW92j0O9aETeIcKgERMDC~WYN6iCTYcwZp1jd0aE8nHphpUd1Rb2x7pPoAel4UxV0b0A2KV9aPjQ1-uxiF9MH4VxeDwXGqqsYo3WviczzUDZ2~edgYXOfnfqkgK~EEQVuWTPqaut0YuRwoc1rYe38L1EgrkjYZQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Color, Color=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.969Z",
+                    "updated_at": "2022-05-09T18:36:02.969Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-secondary",
+                            "nodeId": "21409:16440"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "436e9c535f09da075b79afffa6459d446ba4cb5d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:16449",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/IEu/Ugs/SfNh5tOcH8Ra4Ep0/component_thumbnail_88.png?Expires=1655683200&Signature=XR~vL3Io7pH2nVHnTw~EkZqWx0zDGPnRuIsKS1xKD5xplM9iyllrUqXhTZbJ7U1YvolQzQ4KB6iYCziYrE4WEHuuua1bC~BOH5m6VwPxjtotU-3xLekk0mLkrz--4i-ZDgVPebdbRZHpnHFOsuMEjZj478B-nRY6akAqhkFRccKKUh0nqbsNm0kec~y6xWpwYS4BjfU0ocXn1SJ-sl2cxTNph1AgkSAE-8LqVzPnKNtGjREdYMdmHjcvmvV7-UrjkTtPcOfYRePPphhLOIlI-BHlGZH4Zt5iYP27NYCMGFciSY3Ur~jg39rhX82Y9d2BxVFe6PZiFITb7dvxS5uXDA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Dark, Color=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.963Z",
+                    "updated_at": "2022-05-09T18:36:02.963Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-secondary",
+                            "nodeId": "21409:16440"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "4c740ab3994c2033bb0653c0015f85f9f24d6c88",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:16441",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/huQ/a26/XRjzUu09Dm5pZDTM/component_thumbnail_87.png?Expires=1655683200&Signature=WbEnya3OsaxJx~aq9V7sWci2p8GYxxiIN6SGFwu7imAhP69n3i34Aaa~H-OSNqC-XPQXiVGTgMlOyuTwFpx1yLM9Hwbj-bmMoR35Lt71fw81qecHdZbhLZ1vxa0OKpcZQ0PsVYYbUMomzqH-EOosGjKFujSCvYCwvFB4k7Gkn6H9y9lKUuv1SeGoT3kihrTxMCtsBrXYRm1IVAriZg1S5blaWasUhldzf4f43NJ0sPZsy-6STkpuiugnpjbGjl~YU1sDo0~2sgmBLys5vs-5NcFduWLatYOifXTFWbG9LC5CRvjumLHxf8FqtaStWtMaVb0Vf6Ymzh3YIHwvX2YNLA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Light, Color=off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.958Z",
+                    "updated_at": "2022-05-09T18:36:02.958Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-secondary",
+                            "nodeId": "21409:16440"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6dae29e613a4719374a11e4b927f657501a15c9f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:16439",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/WDR/VCZ/OW3weJgbdgpBlxAz/component_thumbnail_86.png?Expires=1655683200&Signature=dAfb4ZYC1i37HwxWeSaTf6L4wUBgRLHSVYwy4u03M0btsb88UnhG7zyJ5rVH0OnZM4N5MYAg6QK12Kr8vRkFro0dglNg-sv1e4OmkSzHtsi4lkdlp4HlY2BjuU4t~aZbeH~JcHaSwHzCcN1rQm024sHqmZeaVHwwKqX-iIjWkAs-qXmGBCfDabaHy84I8B~8VzvZOPycdt9rwtrkk2VUa-mS70Ij4B-3jXodlvWZx70HpAPSw~agThxoX~xjM-vpgm3PYzPKCAvLsxrIToyIZsYcPRyHULbdCMh2l-iBkXc314wGI-lR8OAhedhsNyzJ2nQFkzijbGr1Q4Ja6cYlrA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Light, Color=on",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.952Z",
+                    "updated_at": "2022-05-09T18:36:02.952Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-secondary",
+                            "nodeId": "21409:16440"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5360cfe827a8be0d7b313b7909416ea98b588be5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21409:16457",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/mw8/j7E/laI45iEi2cFyemw0/component_thumbnail_85.png?Expires=1655683200&Signature=CTmPowiRbh0AMCg5~lbdQHtgM464bsTVg~3MCsBqdVSkxIsB6huVV3X991QS~aXBfsvmV5ng4LnecqRCw4LQuQqvOk8iGNMQwv~zIagQqbf4j7VzTBdD6m0z43-7~gg16JLyXESN6ReU7f-XGJxgVonQGHgdt~D-AZQpKPoFiuSXcuLZcIQKfRqryJ8-qXAk8Gv-H1cG8GdE0Lo1x1zmpeFFc65MYC6sh6qY7Lz6KUupFcvYaux7OlDIJGntQxkdbX1ibdm4vbfLqhmyMS2XLE4IlshSDk65ItUNF3Ml3cMyurZB2e4Iv4tTo1-Vt8ltXAGTyXr2TIxTL9dXzGD5lQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Over Dark, Color=off",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.946Z",
+                    "updated_at": "2022-05-09T18:36:02.946Z",
+                    "containing_frame": {
+                        "name": "Logo + Tag",
+                        "nodeId": "21409:11690",
+                        "pageId": "21302:9466",
+                        "pageName": "Logo + Tag",
+                        "backgroundColor": "#F4F4F4",
+                        "containingStateGroup": {
+                            "name": "logo-secondary",
+                            "nodeId": "21409:16440"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "cbbad2f27d584ec4499150088ead19927eb9b2a8",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:10240",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/UEx/hDn/koiYafnh3V4o2oPK/component_thumbnail_84.png?Expires=1655683200&Signature=QZQVzxKXvwltwBbrk3jsfR7BG9D~3riwtRaXNes7Q2y-eE-iWmkG~kTG1DrKAVhi9mKyhQkK2szJESWqeZ19hhFY4Dkf~XbApRpOPmf-~y~xzKD4PcOwRvD~1O1Q47xBMfF4GRqZFbSBM7RcodFeg8eTbDEp3q1yiocjLzXXqLFiD7mDg5CcId1zf8LnreZ-QuuvT9Nz8LH4hv52CZ9GIOHE-JZkR~fbdF46Q5CNee5JmKvtF4w~LmGRUaogltO~yXFsDs-P9~yuVHXfyy0X9YeWuAltZD7ulghb38wZQAC6M2NqjLG0uZrAVDLMbl0IFb5SkrXwstU7rCf7U1Ah5w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=XL-1920, Color=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.941Z",
+                    "updated_at": "2022-05-09T18:36:02.941Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21514:16269",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "desktop",
+                            "nodeId": "21526:10239"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "45b57d3a61343c816e5236a97dab2c7ddff5db04",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:10238",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/hLS/8N4/xFsA29s2pmYTFm65/component_thumbnail_83.png?Expires=1655683200&Signature=FFyniDc0fpuG~sIw2SNkKpi1G7zkrEwZeeok5u3JHIoUnELcI8FGkzcQgrBiI2pihLLQBHxtOmSZoE0ZFBMmJyLb-Szv1hXD4~hh~VQ6J5miuhInpdkE1p~WzTtMnEO5v5uIYMpV-c~6iRYUBZ4NUMw~funh7KDDHcKY~vAwZ1SJguunhoxwHnx9-hYGa-noYK1uUwPe5bRXHz0~MPWKok1x2zVoYfX5VCwGNfAT8uuAHJPexAmqBtvSp407MkyashOkpnwBKWP30KXs-DU5oq~coBRleVUo2sTrsP26fQd0rvHV1mdD-Ua9mSsFWsaF9FvtcIPl2t7cvEKYUPC86w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=XL-1920, Color=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.934Z",
+                    "updated_at": "2022-05-09T18:36:02.934Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21514:16269",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "desktop",
+                            "nodeId": "21526:10239"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "cb859f9c165cc026c9a2e4fcc8119d835f530e9f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:10840",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Gl4/uwv/n5hxA5RNtYzdLrdB/component_thumbnail_82.png?Expires=1655683200&Signature=CeLpQLfcpSCHtDcYR6NRVilWeziOjQd19rPSzBOJYQUHRoxbaR-zvP3Jx8p1TSngI13waAy5zj0DTHzCu727MOk0TGIJfwzqQ359PNnbNG3GY8h5zDScZ5qRps3Tg9eQLNAUv0M-0pUeW8pGl7TwujnWj-Klywo2jWjPfmULxRUbgE8DnCMXiPR~JXIttQ-Dt05ysAZPiYBJ4SPpNvsZNh4Wa8QbPlY4c6fzWSXNCoQPZ4ESTbFODuWPZEwJV~KUF8poDJ9Gs22D2qRKTA-MplGhCHbAkXSnGK47gJbSGoGmUGR5N0RjaVwG7-qDf3RkeBRSZsCv-pIXZxq0qNoPkw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=L-1440, Color=Dark",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.929Z",
+                    "updated_at": "2022-05-09T18:36:02.929Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21514:16269",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "desktop",
+                            "nodeId": "21526:10239"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9e7ebbfe9cd2fdf8cf8121d36d8166d828382c9a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:10838",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ufa/0sh/SXHNYEBJOMR0rmiV/component_thumbnail_81.png?Expires=1655683200&Signature=c2ADT3nTgd9rnG-D03bFIDbgOXdpoCyUBv6vsXkkzv9ZAefWC4tj9wi~lgFyda8S1CC3HFHSi2MnMQTCvRsO7BH3CKXQoRZ6k4yppx8i-xbrCU-aHYzFND-fSf4w5M~B6EBetvWY2IrIhKIZrrqsel9bGMnwWenOavHadk-xI3WbMQBWeGanOo1a4Q6da6dagyo4p7PeSqR5i5rwTGURYRmbVjDjHlZeRQhumOMVpl6WsJdUsxL0DqPRv5ls4-GF1aBGzU-NyBb6psXYH9c~w-3KUKYHoxwMAawqvijAvPhqw7242WiO~D9TTRNCG9xII5Oh~ZINH8I6i9a5wxNEgg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=L-1440, Color=Color",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.923Z",
+                    "updated_at": "2022-05-09T18:36:02.923Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21514:16269",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "desktop",
+                            "nodeId": "21526:10239"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "fabb8eaf3d192c7ad248ea2c1c560aaede8971c4",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:10842",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/3Fy/LRx/6JnmubqK4zHLq0k9/component_thumbnail_80.png?Expires=1655683200&Signature=TpBqsz3sqHXqM1dE4M5ry01QmvjbbapSFM6m3bwJCB2vCUbvDBAf1cOzpijRDDp~ILpQ22c9bllWSu-qkoSP5hTW0eMwU3TFDy-GHBRyZ0Et2dwuGTb3MCtaBTDYqQ4wSCThPKTYpOiJKt-DweBA6gHbOHkju1iBXOVX76mzjS7B9GQ5m1PKfP0tHxl5yyJlg182ZZq~XLeke4W9JE-ttmGkEK1mR9FYqkJc2kRk~2TKklJZM4lqNJyUoNmuluVJb4CUkTbLhhDH1DWcNeMZ5Vo9aioiJTYjEC04AzyaXiDmctqJwLHoZRj2u5NUUq7L8OdB5FKUKzVdOpBp-Pe8Jw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=L-1440, Color=Light",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.918Z",
+                    "updated_at": "2022-05-09T18:36:02.918Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21514:16269",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "desktop",
+                            "nodeId": "21526:10239"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "c16463b2ef065024140f4f9f770e22abf5907110",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21526:10266",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/lXH/cmv/sPbzJVOUpYjTKbDR/component_thumbnail_79.png?Expires=1655683200&Signature=g3t1US1b-5JHVbA0qxSFlmIbrx8JD4xazuqnc5RFMQ40Jxy5v7vAKg-7ZMZfyJDFhEBAZNQNyQlagTyaTPJrWnour~I38vqtr7p-R-Nz5WtGvdm3HR-OczTftJxShXlB7Br0nkvtRWA1C3R3lOv6AlDJtP4jGPOk1oXnMuLzlXLh50sCNzstcwNxo~FlloKW6KYckrpGOOqSuLAROmws1f9Z52wOTzfvLvwRKgJ6WqFBlp96ahrf1-1muTyO~NB9acf-6fEWWdV6igq~hBOrTgfJ4LHqToUPAx4Ub0HHzBKM8VQeJylxXJaj872SIqLZjl4QxebhuQo3pDdZKXU3bw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Size=XL-1920, Color=Color",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.912Z",
+                    "updated_at": "2022-05-09T18:36:02.912Z",
+                    "containing_frame": {
+                        "name": "Desktop",
+                        "nodeId": "21514:16269",
+                        "pageId": "19945:7463",
+                        "pageName": "✏️  Navigation (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "desktop",
+                            "nodeId": "21526:10239"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a2ca882f56f5979710755caf3af41bf43299cdbf",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21536:11934",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/H78/Izx/C2D3drxIgi6fQEFM/component_thumbnail_78.png?Expires=1655683200&Signature=RC7KWUJkYx6y8SWeDqAx8Qxp5K~b8~KMpklSw7QYvd3VYBXDz85POFMk4f9SBSvxmVhxdob7lFUbxKCcsSxmmpYnMyPL0lEHUlvz2wVO4P-H01BjXMVJc9DbPZY2Usjq4tELy15bfDTbWdUcLxDgzZI3g0~Ngxl8hfXcPB6Egp4NoLcLVShLMnEMXBZtLQzOpTQ1e3qJoW828eCmCLSWI8Hw7PBY6UZO~3IO6iNmKVk~viT8Nm7aWoE31cypVBihG8XWKX6NIGtCvLl7lAOat2ux66oa15mKLxBJubOEvA5BVaEYRCeHfVObvQiAiIS1aWboadDxHNz~Qkl5SxnJ1Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Large, Type=Default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.906Z",
+                    "updated_at": "2022-05-09T18:36:02.906Z",
+                    "containing_frame": {
+                        "name": "Callout",
+                        "nodeId": "21535:10703",
+                        "pageId": "20629:4723",
+                        "pageName": "✏️  Callout (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Callout",
+                            "nodeId": "21536:11937"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "6b61c91d4cb2f73b5745d12c5f95ae5ec0299a08",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21536:11968",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/lGd/gOq/7yvK2VfohfrQIGbJ/component_thumbnail_77.png?Expires=1655683200&Signature=d4cDhh68ZJBa7IJV3RwmMzpKF6b-qAAUMSrTG32-55uyYZYxRHrWar0GoTuWK~rHBhBuxxvy9exBRYxgSdysDp3A1Zzs-GrV6HNXyNZLEjOtT-6f910hBUlpHvVMzENIWTyoS46HlAGrF6gyUtouO5IbnziSaV3zFZdGhJxtkvaCiCiqzhNluHVNnF~bXc2yHWvbAeIp5KGgGwMWKTGUGI33M8MUV8Ayr1yFbudBfudhMNdgHjuMb0ZXmz9P~tdBNwg9fFO3yUQLaubmOlovMyang8RJldcQ2xIYSHTPLdKaPDX6dx73TtGJ6rE3g2T9ag8QUUBP03xjZeR2R0vuhQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Large, Type=Dismissable",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.901Z",
+                    "updated_at": "2022-05-09T18:36:02.901Z",
+                    "containing_frame": {
+                        "name": "Callout",
+                        "nodeId": "21535:10703",
+                        "pageId": "20629:4723",
+                        "pageName": "✏️  Callout (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Callout",
+                            "nodeId": "21536:11937"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "04f40fafc27b4a41b017309dcd37b7452340c8fa",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21536:12082",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/mMv/CMi/NKs1q6GW3j2DP0Zo/component_thumbnail_76.png?Expires=1655683200&Signature=DcgpQFyyD1QVsXAGVi09MbQJfivsNeh3fG50HmiMwPRpe0k91C4GtGeDmOXFqqRFRntxOQXGyfm6T1XSZ0oAtcrtzcoGSNF3rlqUwclE3B128kSyBuyCAi15ntk64dhc7zmlWb5rP00HdbDfiw6zWCaUJHJeOMa1ctjgrbO5TwHvzyuY9F4N7eFbio9tui71raLmcPxLxyuam8vUhd3ZIcWf1bG0aFvsxp-3rZrWa1k9YXDCb0byCHHYvP8Q8GET28zMTiPRKF-XMVMFVPBeYkm2~tbfCI-9eGArNX3lxUterMhacJ~sVbnPoIt52~nsK4BBDD-GLPYZX0-uY1qOYA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Small, Type=Secondary CTA",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.895Z",
+                    "updated_at": "2022-05-09T18:36:02.895Z",
+                    "containing_frame": {
+                        "name": "Callout",
+                        "nodeId": "21535:10703",
+                        "pageId": "20629:4723",
+                        "pageName": "✏️  Callout (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Callout",
+                            "nodeId": "21536:11937"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2431e6aecbc2f77f72f5949bcf0beeae36ac267b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21536:12084",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/TLT/i6l/V446mLOZcxmyehwg/component_thumbnail_75.png?Expires=1655683200&Signature=EDA0cfOH716OVtHfMy~ye47-KfErhMQC6Q6Vs9MIMvRThsqB0IWk72w5RAITpFOBsOFibZ4o2tmvEqBn47ZUKZ4a8jhfSCtE8MUYNh9xV~qz76H469cNQtPgfJPLSd4c2sSEb4-my2TA0-bNwfabgOrTjZwGazha3gJYC3DT0pi0fjmxQxI-UwiNRxE-1oU9SWPHQOR~CD97xwi~L6qgfz0jUTuif~17rqTcouCrFMO8uaDV0GiHxCVb367dMo8IVR39zggVr8EP8M4xl1iVF7mNg-j-mHU6Xj2CmjfIdEy2kv8ODUNSCtGmGqg~OM96rI1BUPDQwZ3-de7u9FJsDQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Small, Type=Default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.890Z",
+                    "updated_at": "2022-05-09T18:36:02.890Z",
+                    "containing_frame": {
+                        "name": "Callout",
+                        "nodeId": "21535:10703",
+                        "pageId": "20629:4723",
+                        "pageName": "✏️  Callout (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Callout",
+                            "nodeId": "21536:11937"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "64bf5303ca90b50fa45e80b79bf3b8467a8b1fda",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21536:11938",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/SbK/8WV/pgtIHDIcELwIM5yv/component_thumbnail_74.png?Expires=1655683200&Signature=RRTIFf~JUccbmXCbjP8o6De6sUhiuWYrddTqUCMZGf~oA4OJRo5Qy8McuHSDrQUw6Th7TP2Dn0S0DUmZwL8Fta7hNdHh1IBLMsjFNytJTaH1F~zv2Pnpc~3J-21vYyzGgcYA1YE-K-wCs~YRWI4RHknHn263mTwURwuhdm27X7WtU~Ro85ZPUa6MAS6ym6Pe-ANAweEB8i8nGKi3vCiIag9t0dEA90OLxfIw7yItiQ8RKlUfr6taIcE2XUAS~R~XctKE6GefrbOpnkDc4HYgDj5~bZZjRIPf1eohwsOeQDQwb9FhiJkJYjzguCOSpTRlmrYrqB-5~yDeMPqBlQTrfA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Large, Type=Secondary CTA",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.884Z",
+                    "updated_at": "2022-05-09T18:36:02.884Z",
+                    "containing_frame": {
+                        "name": "Callout",
+                        "nodeId": "21535:10703",
+                        "pageId": "20629:4723",
+                        "pageName": "✏️  Callout (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Callout",
+                            "nodeId": "21536:11937"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b284cf3c64e8633c7baa8c0fe5d84a3d93dda284",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21536:12080",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/yDY/lKN/ksAltwLxu3qfsYCp/component_thumbnail_73.png?Expires=1655683200&Signature=HF30HHRsR97wDduFntXHA-Fyyx0TrjgBqXgZl3gzQ54v7F3TxNz4HjCaLhjwYB-KOCDN5U60Tb8rSLUSdGuofTFoU6j91G7NWliqgQG~gh0-DsHgTWOGQOpNu0IIw3kDqL36~ZWqZ8VFcti70dPz9pCIcuHAxsDTQZDgMGZwm~DxbfsdaaESGk2FXQmXW5nZscWuuO2iKWg3K27rBEctU-m6NhrEpCwoDJdBmMOG2rUzOP9osIZYlttb~aRTEW6BbfgMNgr69vqBMUqs8CzJgProt0dxnQVxRT23UJETy5izN5zFRSfGP8dCk4PxX9WWtuP4A6U1uQfkNcMsRcRiHw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Small, Type=Dismissable",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.878Z",
+                    "updated_at": "2022-05-09T18:36:02.878Z",
+                    "containing_frame": {
+                        "name": "Callout",
+                        "nodeId": "21535:10703",
+                        "pageId": "20629:4723",
+                        "pageName": "✏️  Callout (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Callout",
+                            "nodeId": "21536:11937"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "179932ef0dff81cd872b19b48978c5fd231293c6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21514:16056",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/lj7/WKg/VxkOzqbyumOu7riD/component_thumbnail_72.png?Expires=1655683200&Signature=FFx4h9Gc-sYavqd7pNPEWIhSHCGLU9aFKkWMSSFv3UOOci6fIUTxkDEk2~Lwq3Y-qZZOzqztqv-lnsiBw~kZ~oZ34VmmJSNWa9MvaegQDtIMZIf82UGM5Jnvg15Mwfp5~orxal3gepVVW7hunR0HqpcwmB-Fmf2DwbdbQJbcRr-corvcbP40-mEhDOcq~cZfkG-BmYr5UqgJeZAdJNCiJPQfck-7b6-kR2B64m9c6Q4azX81OqCjeRkBhT60Y97Klk8ClhmDRBnJbAXZ6NM~kbGZgJMdRiROxHsS5C3oXUBauSy5CgGwwbUGfHPMwlZ93~0EyGooUZqeIdWqDZgywA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Organism",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.872Z",
+                    "updated_at": "2022-05-09T18:36:02.872Z",
+                    "containing_frame": {
+                        "name": "Molecule",
+                        "nodeId": "21514:15968",
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Molecule",
+                            "nodeId": "21514:15968"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "66561cf74f26acd96c1a098be473af00e03a7bb0",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21514:15969",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Olb/CqZ/WlLsuLLK62HPHPVs/component_thumbnail_71.png?Expires=1655683200&Signature=ZO-9IZ0qTiCoPuN8Q~F7ciXUKkuKwzZTMR6~KL156GdOgi-ooZVQZF4Y9UtB2Fkj2aF1phcvRpFwn7U8M6M8Kly~Oq5xuCgtazccCT77nGFnQAYU1rjAe0BVEMJoElmR4M6VI5IBrDV7k-7XmXJyDelsVlPxTjcdH-3MGWInGJFclb9szbYWKZYTW5vQKhUlr8bn7IhPUOkqUaIIaENHK~npPMQ5tp~G4h9hlzITO~Qe~tklKiHocrNXzVARCidttHlUAQz3DoBYYmHkWj~yFYwJbp0WwPWuAA7IEyjgUi0xgztD1JbY~Vdsk4~surPoh34RaoeOXy2wH2~hGNUXhQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Molecule",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.866Z",
+                    "updated_at": "2022-05-09T18:36:02.866Z",
+                    "containing_frame": {
+                        "name": "Molecule",
+                        "nodeId": "21514:15968",
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Molecule",
+                            "nodeId": "21514:15968"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "08536a68b983f41e46ca797f2cbbc30c9eec31c2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21514:14898",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/EFg/MDo/zxhloUgvlsB6sf5C/component_thumbnail_70.png?Expires=1655683200&Signature=aSqwKYoqg9yQWt2118FsKg~C3s0nG0sMBWuL5Cm~W4HLUUeKSlXs7z4cuXmmhc6Dcgrq2RYNKVvyaLBjir7fMXx81oDjVRpwIRw4Q0EHDPoEiyPAl8gy-Jngp0Vl0RmrdBjXSCKM3rXadnSaajbwjXVk0YB5Qy~4hVemTsk0A1s-~LakbiDOpiKA7RtQfjgteCxOgn8n8dXOGzy03DI9~trEx5APv1h8D~ebzaGj6wQuOR9YuOhKojbKn1gzjdE4qN7fwHpdJ9MKv-iSn5b4zp2yWsgUK1aFmygk7OaXKqTVKprzytVaQV4cpb68aYBplRLkkcfjmJdr~JLVXJSgdg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Property 1=Atom",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.860Z",
+                    "updated_at": "2022-05-09T18:36:02.860Z",
+                    "containing_frame": {
+                        "name": "Molecule",
+                        "nodeId": "21514:15968",
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation",
+                        "backgroundColor": "rgba(0, 0, 0, 0)",
+                        "containingStateGroup": {
+                            "name": "Molecule",
+                            "nodeId": "21514:15968"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "99425f9ea8435bea1c027c820175f40846aba1e2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21488:16253",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/5VN/yHO/erOLknXAJ7w0Ue7m/component_thumbnail_69.png?Expires=1655683200&Signature=X50dKfT8Sw8KKvrlTLofD~sEWa6nqhsSF3lKDfibA1lPD0-PuwJ4E4bnBbybr4MuUC~zKgn5QRl-avAmHBzyN6qZ0RGfB7vENlE32SF2DAFWfgIxDD4TyBzaMkGyuQya6GX7HcpgA0NRIlp7AJ7gF2uSChbCLxOzX~R78X8wQLXPQ-UUJZszV~2Gs~I58aWF~Prtlf5cBptRxAzRdJzdaIWv6AqrXV69Dw4tgGVq51lh6Uy-EP4IPNoQoe7GqLQngMxFNcM-gLFxkEUKUnwcae2bj32YHb-Bl4ht1t5bWbKdIVIztS49RREogXBsAOf1cnYAQsNQEwRfmrW3TIz~mw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Inactive, State=Open",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.854Z",
+                    "updated_at": "2022-05-09T18:36:02.854Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21488:16199"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "51124d956fbd4de1afd729a3d1818a0bf9daeffc",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21488:16200",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/KcD/gA5/Tqo8x9v0CcIXx7Vw/component_thumbnail_68.png?Expires=1655683200&Signature=M2lCrB9Vtik1fnWibccAj2YifqLfO~rDjy3ldjEgUiVL-XrTR9uRkkpPbyeDumjRvvzL2kBpitrQ3wbMK4ZOh4UU7AdTuAz6bTVGvrjbMh3TdBWIk-kPOxrPQhFDA52Tz99veWshPXJSNjwOliKogBxqvzr~kzelIfI8LbIU0xO7b26UkoljaroA-QGyAc5rm7UYy1iZceeA4oXrT3f4ZnQcGzu8QQQFEgli2ZPpL9BEcS~0x8LYHBCCB6sy9L4BI0-urjU-IS8NowLFu-ocXh7en32kE7w5z2hlebTvshQzb~zWClUqAdMCIEAYx2ymKeaG1BvD3UUY7JuKOSjbsA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Active, State=Open",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.849Z",
+                    "updated_at": "2022-05-09T18:36:02.849Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21488:16199"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b1ae1f3e06e54d71efeb980719c8d3bc692c282f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21488:16255",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Scl/LXs/umj5VMLUF0ByLVCQ/component_thumbnail_67.png?Expires=1655683200&Signature=VSyGQZ1yajkz856QS5nTX2VORMStea8QjK3pDidnW1lKHwCPXUPs6LjFRG5VHMwMW51CRJig~sE94mzRs6yBNLsQ7aPS2SQ2Vysvb9sIzq9CUkolmkvyUeyYeZcFBa8i0o3DZeaUh7tLebiejOjtlEMwWI1-bXGJ2fVUjqwV7fDIDGcXA4-Rj6m-aUs9ZjkZF03xL1MgB2-S9dCeyqzIM~KdYT0h9Fe0wGzO7ic-wji45cFEFBeTS0P1mHtNGsRFdIOeaWhpTPEgIuRmyV7PksnV0o6ax6PVKUEvS3gR~IeDn7GKfxzdahJCaqD0aJIDGInY4SrDEzrFPMNkSJ62aA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Inactive, State=Closed",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.843Z",
+                    "updated_at": "2022-05-09T18:36:02.843Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21488:16199"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "9c21549faaa95300ac6c914be79b21cb9e1652e2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21488:16198",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/du9/MB4/jl7w1YZMFNoNy2A2/component_thumbnail_66.png?Expires=1655683200&Signature=cbnsnzeHe5~OpzrqbNI1PwItvPKRvfu-J-tq-IRfM6ieO76bh9ErZfwLDowiT24k4mYxhh0dsRwNBBZR~pZcKSdRUDnqj403qnIsaZSBwylcgX5QN5L0VdgpT6n7b1LQV46zjYBgwAO9ViffHzAK8oY5exl1BO30Vl9kYvLvhlyC~8Y0Qh~hqHyjB9ZSZTD5EoQMmlnzJdxBqaa0TczPNgQ~5vVUqa80t5JHK07skiK11gJ78IZSHTTN6H5Es7zuvXaqb1zym6NMsEZF9Y1R5Y90xqxKIhfWNxRIVlYwKRRq06E72YEAlpgw72EAL4cJ~XV2CJ1CZzZ2zuYaDz6msw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=Active, State=Closed",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.838Z",
+                    "updated_at": "2022-05-09T18:36:02.838Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21488:16199"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a18e05f67adc50fc6080b51bf714fa35a4b3093c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21498:9732",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Q4A/bNZ/UYE0qPR4xzsblUk6/component_thumbnail_65.png?Expires=1655683200&Signature=FOvetTfM8g8xjIxfxQ5D1oTV9L~w5TiR0MTCl2yctHHZLb215iPqDacT6k91CcRA9nKCTK30X9SDeghtvUomG7BViHOYSFZgrcgmYd-58Ur164p6B9DiL4wcU2-WGEtuAp6X1pugI79QlPCyfiy~R5rglOjVI52ckVU5qcC5cWWLFRBNSLFMXo8fvuDYdIp1ui6Y6upOxSy2RSDICawYxS-BhPdBycIjLAKRtit2Kdn1izN7p~Js1WrspDQLPAQ3oj-nw~ouZn4hQ6Q4nEIwuTylZWTLALLIjdhtvGNlNG~jXhb-G3HI4lQWbGBwrRE4W54EMS9xakp-90tE4lUY-g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=3",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.833Z",
+                    "updated_at": "2022-05-09T18:36:02.833Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21498:9691"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "066c6205e3cc83e012a821b37a5dfb4fa27d8153",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21498:9876",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/e3A/LqB/5t7va2Hj4NtOOrQA/component_thumbnail_64.png?Expires=1655683200&Signature=eQstnbJ-Oyodoo~Q0pyu9-T8EaWVT-Bf~cgYxOJGdb6-Jma8Y1e-sCIhlB~DzUp~83kkWZKhU5L3-fZlwyQJw37hgLDRZ310iszKmIuRdlMn96LHho67W6vAMxEvcY63OJCkreR0uakEA861EWG8wFs2KSKYgLukrzQc7TfEko4REQ8SzNPzlRx~Z02m1pkn-lfc4NwB7RM32tCcrUyGy6iGUnOfOYT2eSM94AKtR4H00GFE~xbtnYhHJ0S87T6y9x9dC4Am7KACK~PMQCopL3nqjnigc8L-dj9D01MHjgm5ululuyi3sKEIOD3gWJTXrNSJoPoSfpFXZI-M2ZZWlg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=5",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.827Z",
+                    "updated_at": "2022-05-09T18:36:02.827Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21498:9691"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a797873a5e510e0c70367f941397605c3ad3ca7e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21498:9689",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/mZK/OYA/znMVgqaPRoruW5Ub/component_thumbnail_63.png?Expires=1655683200&Signature=WlcgzpB~PAcy8psvhFBGEEKexgY6BLhTKHcGSM3bOShG1EQYOsWk55r77JRBTw8ErFjMM4lkNUmacAJ3TlR8DT~81ksis0v3HdPxYV5RBKBX0GP9E3s5qxbXwXtkei4UZ7rnkvJCaTT0sc1qlA3jWSMwPLbPetDVtXdPkTPEJaZQ-DvLf1xxFS9ypmQgvpE6TTP-YqqZcxrDy6gm5ts2rrTkVlNIWeNOrY-pZPl-eXxJcMxTQVTVPA~vU46O2elqV30vEYTizG23CSEjlLfuC9kt9HK8uFQtvWQx0TJfu38Q0zU3kH59PomU9DpwWoh7ixuBHMNRk2d~ZPGyu2-A~A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=1",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.821Z",
+                    "updated_at": "2022-05-09T18:36:02.821Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21498:9691"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "1d92a5afeb2311191a204a693a9f38a4ae6645ec",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21498:9927",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/2xg/nan/sWI5Kmw4tGLlQTCn/component_thumbnail_62.png?Expires=1655683200&Signature=Cdrzv8nxExAOpr9FRaq0K54vwpduz3xxz7D-dAWGuHQymEG9Kf7wGQM1u29cHYJ-kV93mpbFj2xADWqAJFdfNOAf-6jLuJFaPWcjluudNGyMjGnA1WTYxbb24V1ocRAc-2p208kuAfy16zsWKhh8AZvpp2zo87MERiZTyzIRzRhiUQRiqE9DSGhrdg~hVDjaeI5tksIQ~nRfUom-lXQlvCFdLMNZsJt8yy4Wn3EaXMWRMVuVfG-aBaMCky3VktoUfRjFGljLUoCTjku1TeKoYtKji8x6WS-mtl5kDWD6RYKUT3~uTHJHPAiDLH3WSNqwbSrhH6U8MxXzQgNvUv7zuQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=6",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.815Z",
+                    "updated_at": "2022-05-09T18:36:02.815Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21498:9691"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "d853fe452d6ce06c8eefe74eca47cde4719c733b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21498:9794",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/wUi/Xhd/DABzpnULZbJ99ZYB/component_thumbnail_61.png?Expires=1655683200&Signature=cNQB4SKUAQqbaBJS9CYz3bMAPzBaZoJ-Z~iS86k5HWgCXb-xTam7ygcHj6bgbcdLEU8wDmzvtAfXX~ek~HFX6Qx6xA0rlXvIXJzb0RXeJGt3~zrvPfr7UP~t0G~GhcUQc9D8AkH2UFwUFCaWBiZPSl-pRYJxSuTGCQeoBefBrlGL1pKNKpfD-YuMLTnmIIldbVC0LDF9jDBqKcAuBzlI9R-3s7iuq91yYweWvaAgJ3TvAjCfXZ3v6vMY0SYOJ-PK~49dMg7fhfy2Y3t3pU1dffxGPk2cXavZ5FtYvjqg1GFPPzjlv6~Sij7h~sEJS25nGWWuHdamk1iwWhv-ZRNDfg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Items=4",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:02.809Z",
+                    "updated_at": "2022-05-09T18:36:02.809Z",
+                    "containing_frame": {
+                        "name": "Accordian",
+                        "nodeId": "21488:15456",
+                        "pageId": "19945:7462",
+                        "pageName": "✏️  Accordion (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "Accordian",
+                            "nodeId": "21498:9691"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "dd2bab338ba9b88ebe152ef0b6f9892a4a208c99",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9684",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/wfl/aSg/zruiDT2atcJzB1Al/component_thumbnail_35.png?Expires=1655683200&Signature=Waa92AKxRBMJMMpuDxtjWgaJ~g4DaMB~5xf5JhA9wmU434~8-aykQwDhq8RJjP9zkTpxUw1HmzVJmk2MtStsHejFPA2zAxc8-pXPoPdXUKCHnoE1Z4Ryskln9G7scwmjws5M02OAnoHybdMNwIGJ5-bADyMiLYMmWYbmFlUpcW35WsDxBh9IVSiwORm7GjTSccW91CEZCELwI5Yhm6fdIjwz8nqGrCAqffFx4dZ5gB7qRw0~ySr~UxlrIPVK7ZjybQxAEBGXH43UbJ~uCITfBIJNkVMljfgoh8wr0QLfy-SnSOvHPFEjS2XekwFkwW0P-RYM2E1LxcuXg3A0mGJr4Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=default, Icon=On, Responsive=True",
+                    "description": "button: primary/large/default/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.473Z",
+                    "updated_at": "2022-05-09T18:35:46.473Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e523189288b8670bebb2e5a13f760c10497d901e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8670",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/0Fo/aRE/Pm4OTeBVEGgDRbZK/component_thumbnail_34.png?Expires=1655683200&Signature=h0Bt2JsKITE~h-b8YXEaFwuEu99q6lUI5V2iWoKPa9ge2c9xNWXpfLa1PQuOmBPjkekYnXeKwoC6214yCj7ZTSRL6pMxELLumJ95l1X4Sayhtj-j9BTO76Oodtx8qRvZhTk8W30On-Zb0cQgihpnMBFlNrj4VTzqI5riggJuVCJjm99eEL1oQJdHLlmmOGoqiKJOmJlLqkPBSMP21wcCoPw5g24m7FHmPJ05dhxdzz4BaKeHdotcp5BVJKyH4U16Re0odvAfc-XHtNqyYVs3MjfuY5JhWat55d~YGpUXtm40O9qVGi9ep5nX9yOlIpdnPxX~Slv5EdHLkE-EyfiLQA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=active, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/active/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.468Z",
+                    "updated_at": "2022-05-09T18:35:46.468Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "151b9f3f41861837d55393b929e8159b1b3f5f7f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3304",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/nku/v6r/nlun8eplL1SYM77g/component_thumbnail_33.png?Expires=1655683200&Signature=TrPXu~fHbZyPZBVPvqfC2p8Hr4brVioueMANgGCp1GJWJa2dsPKu9IjuLqHCm1P2iCEAkqnd6GQQFDg9P4yd9bUXTmon~yS~2AXEzTq3xMHaAadwihoXTmX8PqgEy34~d5ZkI5SJ-FquBu2B7Q8-5tq042hwB~8OjUCXw6k5SnBu0dg0JgqkDCzsGpPN1vJ~AX07eC~wO1cp1rd582Fh0NZY2BV8DwLqNe34xDRr8Vwh0OSFUv6xo~hzI1enXMey8O949ilqNSIUf--5StQFbtxrLz4-o0Psb0WoimKyidLuDk6Olne25eIxR4ZpnDhaLZmVgNMCl9p15ivrVQFvww__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=active, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.463Z",
+                    "updated_at": "2022-05-09T18:35:46.463Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0138c732d9098addb3b471fab54781bad7415c23",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20525:4294",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/pfD/IgU/pCjTKEdDweINDBc9/component_thumbnail_32.png?Expires=1655683200&Signature=TpWgMgPt8kVQWseMnM8MQqzxBFSBF2D-FNWieUwBuoT-eUR8kVmuqaqXRyTdnK53SI60o-6O5zPxT16PcVEZ0l3-RzvIQItlXINn8ofqkKF9BIbygkLbbVisYY5UFW~88dhbAWfs~Oh0BOUMzOuEdh4mcdWWTLeEw4pnkHBYKrkLwkM6uNFYy58E8cBsNbD3CXlFEsd~GTY4qeG~V7H3yzGo8oaw~Mrdmmotz05TE1-kfIi~u-pFC61TBiurJt2G5coa7koRrijNsUTkJIaEFi8uQorQHW21N0zFsGpsTxZ-mCMlozkQy6r1DTmtf20SnbwzTqZdfSwny2Qz6aRm7w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=disabled, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/disabled/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.458Z",
+                    "updated_at": "2022-05-09T18:35:46.458Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "a96b597bb0acc9422ecd860b8be14d3c1fabbc83",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9662",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/y6u/SJO/30c51neqSDkBlHx5/component_thumbnail_31.png?Expires=1655683200&Signature=X4zGu3FFvVkYOo9gC-8J4wgOHebXZhuIBfthtD7COX-X~1stFdgB5~YTvNE8nM9r4ux~ONQwX24ezzQZnMgK9qVuFCjhnF-bjDaCk3r51MWA~7D0LORaFQrVnTeYVF-hL5Gt0nHL8VqvmIGbsJnIswwC1VQRLmSIPzx5cQHJBv4gO4mxlXGFCcHqGgJ8dkWK8yqWCkLwI1FBUrRKtaMfUE1AE6H4A3OiY2CsOmK4S1W0t1jvhsBTg5B8XHZUlAu5-ES7Xzjz8Y7xG8k6ycAvXGd4vkEOlmc~fOIKuUL1RQwOaEDNLL-JZ-iye760RnoFOhamAxGL-b2Qvm6vSQCg7g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=hover, Icon=Off, Responsive=True",
+                    "description": "button: primary/large/hover/no-icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.453Z",
+                    "updated_at": "2022-05-09T18:35:46.453Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "97584551a4711cf4ae5cf54c96deff4034ac0e6e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9692",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/LMx/Sr6/G0oFN1LByE2ugmkC/component_thumbnail_30.png?Expires=1655683200&Signature=ZX-mduG1nRB-w~3JHUKlLD4Be2CpF0oFXCSCajmkvPrCl2wf9Kx9QLhlRPtLur8kqJJRXmnURL9BlhhA9dIrB7I15a0mwiLU5h7Fora5wNWE6kZ4RzyUjEqga6oi3EHnvW2velMaUmziuRu0lavLiejDtm-2OrhWmLot5SXW9N6HKQtNNjwIzgLw9LHcaeUffTf0tMmhzwr9UYDLjceq991VQJtVMK0fNhwyxTkWE~l-6YcQsS96tsHd6UHa8gsAJZYHp5XhaJCM-3edpfzivJPstKugDoItfFkypTUx0wN~MLyciVs-sYknoYoZau9q0kgwD-dxj~81b0Lkk5RgkQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=disabled, Icon=On, Responsive=False",
+                    "description": "button: primary/large/disabled/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.447Z",
+                    "updated_at": "2022-05-09T18:35:46.447Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0b331ed7486285e16d845c2b910707308a36cfe2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9700",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ceA/ma8/vxVLbIgW7sBzSfcn/component_thumbnail_29.png?Expires=1655683200&Signature=DNNqak2gYgX5rKtHniPxlyu5CmtxCPSG4bfkBPeJhUDGTNkTvJnZf64c9xTHytUWq5vT8eX1753MOczmC64nDqOCnAK-S2tKEmBVPAn9VcBR7zb2oj8HsTu3g6-mWWO2TESsGxPR~fT15t9~skd4rKpDtRuW3Y-dqStqM-Ws9MRl664Sc6ijAqDwqZlRPC~oUr81N0oWdYPXPTtsGA~FxbUvQGrXxPplUOF7B7-~DbjnyxWWrXbB0dUjyitM9UY5fQoc8PbjAazJ7lheTRO~-jMVv0HcqcWoXtkRFkj2GJ2vSEweTJsyGJje3esWMwERDnPVDuJaDE70zHtKc0Cexw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=disabled, Icon=On, Responsive=False",
+                    "description": "button: primary/large/disabled/icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.442Z",
+                    "updated_at": "2022-05-09T18:35:46.442Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "793a517ceec8f14ccbf3efb5fb3b4088cdb78521",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9702",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/PuG/fbD/ODJrQ5dsEJPtTLxf/component_thumbnail_28.png?Expires=1655683200&Signature=Ii9au0Wcn8xGMSpzEhwTLWS06E6DFiUlEr0wqS92wlhwyPYMKP2HwqZ~cMJyHzCp1kQD7XGVHE27uFyQcSX7Aw55XdO3WplacdKdQOUyxo3r3-YTenXk19bba13bn1VI6lAIIuBd6YhFdVX9sUkutDOg1kA3MG9t9uCmPQYp2wqLZZ350F0ZlEh72PMhpgimGatNpnR8yIf0thvPRSiHMitFeu5ba3lWONQ6LhkcmuPcBg0NL-mqC4RwdNX33iY~c1Ywp6ZPEyRdcVm0YNiQIHm~ytu1gwseMeYTHFTHB~TF3IaBJ8EMyebhqwLv4w96cimBy3WN6h28SMULi~wBLg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary-inverse, Size=large, State=active, Icon=On, Responsive=True",
+                    "description": "button: primary/large/active/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.437Z",
+                    "updated_at": "2022-05-09T18:35:46.437Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7b7ffc8ac23a8bf793c2786b625571dfdc7529d2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8618",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/xRp/6cJ/xxm4ULv4jmthFt3F/component_thumbnail_27.png?Expires=1655683200&Signature=Uqp1PQz0N~tKUJo-1J9HM3zyhdO6dZL5VfrwweRNBeY2gzA4ryciqV6I~R9~dE~dVlysn3f0UwuelptE1Rh5wgyYlqWWu3blVYBMztckDpv~tLuSNZ-QCBAkily0vqFV358oeUS3xumPIReXzCdBIoZp~79sQ5Ia2wWAVk5CUy0vR9-QrnWp0Tv--lWEl-a9DFYXFFhd1iynDPLdBlNsPdFi-qhKf42cjc~1I12tbeVpFfP5x3HOS4tyukMsI96VBSXak3AC02T5S2U5--Ck3aDnA0CZh1u3UYUA5RwCCuyCCbLQ1oEhvy3vSP7~hE3bJUB~D7YcbYGTGL8Wz3adiw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=disabled, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.433Z",
+                    "updated_at": "2022-05-09T18:35:46.433Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "e992a2dfa4bbedcdf6ea9e0b01548d511bf96173",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9676",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/4AL/p9w/xmoQGrQFO8tSLYJ3/component_thumbnail_26.png?Expires=1655683200&Signature=grKrTlhXymjlnzS-6mVGqWqLhegP~2l9dhGTn8wdZcQPl5kcSIwHVwGVA-UDAwRadBy4c9hGpRcspQROt~xgqOIFSQUtz~2YcwOkgZgvRO-P0ojLPvy15CzWpGA~nxfIIRfVINK5IVvJV3UdP-VdmnLnmmGSHqwJWTBcgV9p~7YrcZNsKcrbFpl5wHrRDM07Z8Q6lDeKYn-2yn4bM63-X-cjiY82SajCGfoAFysojgt~n7QR45n7Oqq6KBMlYbfOmJi-Fv3v3wXsK4Nh4zPyeD~GVkiiPtTogJ-7NVpxjg1ow5j~TCz6NWawyfQQWl~CpRAu4lOxET3~6vLV6Qgr8g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=active, Icon=On, Responsive=True",
+                    "description": "button: primary/large/active/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.427Z",
+                    "updated_at": "2022-05-09T18:35:46.427Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "0376477b21782c4ec2618c088823259f9f9d602b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8620",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/gjG/IDv/POwCRf7HDR3tWCz0/component_thumbnail_25.png?Expires=1655683200&Signature=JALgJb~KqYh9FdmCAS3pDuPOKSqeFkmyeNPUq~~EHGjexcQySq7vYskhUrdpLtkW3pDeVGoP1fXTcd-fHKIzVaI6NWQjWbY5G0HUQEUmWwWgn9RpB0q9HtNz9A0AxDLtGZl~Ey82TVXDEifD-q-Ccdia63dEDPJqfecFAvBKAJEihAikitYkGqfPiuOhuHYubdjLJMfE2bG91m1YP0vIpMYNWyC20Bul~f4omChm051Bz8-RgA6lxgngImXoVU1n8jcbJb-0eBUXn6HiRI4JBLpazI-2arSA84yhYqMUa~iQlnoTQakgS1W59A6RdbG5yuK~2IV3M57HWoY9V9TO0g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=active, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.422Z",
+                    "updated_at": "2022-05-09T18:35:46.422Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "bc9da762463eb1f9b0d1bef7c8a258542fdd9904",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9710",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/nxZ/eHE/0EgkFaz4G6DP7ntZ/component_thumbnail_24.png?Expires=1655683200&Signature=Tk4E8hcBmKrC~RH3B~PYoPENzhXbZChWDD0fURbE9D-Cm0izfakN5HuvINHHEkJsSEphz5lJ-GFjppX5sd5FcQ61mEpNxJB6pxpbdxp2CRWZ-ClL0tp-vbYQvbV4p5X~iETgYPq3ltnrRtHYrc8cVq9cJW8M0txh47L9F6M8MXAzlqDnWPbbnLErcGIWMMWK7wSfUCaTokL10Biru0lq7gnTy2sMDTN68ehvzjankNKzyVVrJDwEiwOwZBH4Xw~-IX4huGl76Q1neDVicBRe3EFsPADuqrAaGdSWdPNfuK1maXQwOSdfvm8nd4htZ7ZQqdTBtVXbg5Fh-kL7ZGgsIw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=disabled, Icon=On, Responsive=True",
+                    "description": "button: primary/large/disabled/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.416Z",
+                    "updated_at": "2022-05-09T18:35:46.416Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "bdc9c8bd3a556308cf39d712b087211b10c0ed23",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:9688",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/p4L/PD2/xwr4bG6CcjNdE6l8/component_thumbnail_23.png?Expires=1655683200&Signature=QLBgXN7sJbFTJZD-193cuUsuCIVSXeYq1jk6otFSphN3~wWTEooQYRx6hCoO13Qimmok5Eo91tpvrw6tR6brXmSaY7z-2mPXo1EwrV2qirtelWGXQmh9rJzjkFviIiIEEwkxh47Oe8U-QVBqGqYuqCKIn6iaQr5rV7e92owBphZ5dh2YthRtPRgfu8b1xVPOJGYWSv9gPTSi0zD14QJYBhLsILOtDAYdvvd343V9FqnWkN0ZRhdXJ-hxPibaPJo8GqtScOreyszcM2qXxwDQW3jKHjeO3ubwQ83iP0i27WYdFkVFEw3uCdgZBqemNp62e3AxTQ-i4t~UQv05CYDHqQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary-inverse, Size=large, State=active, Icon=Off, Responsive=False",
+                    "description": "button: primary/large/active/no-icon/fixed (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.410Z",
+                    "updated_at": "2022-05-09T18:35:46.410Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "50ec850f6e3b42a05b6301e620859ea18c24bf17",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20014:12979",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Lai/Ban/qWvx9zT24eXjtCzl/component_thumbnail_22.png?Expires=1655683200&Signature=ZrAp9jvYFqB~Jdc1CQ03pTB6EvrCDS5W1o2PrRWsV4KGpkWtdPdLHHGWMj8eUiu3K1XSS-t1ol9lvA9ocx4axFn8Hs7e5qzexIgMPseyclxIFK4~40meiYq~yxlTlZEpZ4i-jmEqvk9FtgvZzi2ln-csjtuXlplWWeTWjaE~6F4mF5lfwTnQGl2lX2WNW~61H88aIen9yhj~k5MeMkuPHtDuVL7VGUrWspsFEjHyBb4wDMEW3caKvVOMmLRatuK6u8k1FXdsIhXaSt9pmNqf5XNvXcJrlhbGnZTCTH36rmxddxF4CXG3b9um-R8BhdWiNMdKDyQTLRHEYw-2OauVHQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=large, State=active, Icon=On, Responsive=True",
+                    "description": "button: primary/large/active/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.405Z",
+                    "updated_at": "2022-05-09T18:35:46.405Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "b01f5b5b9eb55c1ec55ffcc2726bffa972bd4a81",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8616",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Uhm/TK8/U83REdNvkLrQfHUA/component_thumbnail_21.png?Expires=1655683200&Signature=FXzJ4zTwr2cpQeUFR-CLNEFA5qu8xxh8d4bQINnjK1XuweKbBy6Plbm4xj~I8PIY0R5dBRSR6vQi4BW65JLvUr3mJ3FWz-HXcdpqGwUzueZde3gdx8hl4pHRXq3ERGWYSoRtb6KP~-8mHMC8x3hRsNga2xcDXAJAtnviC0vsUNpCxD~tEAb8bkqd83gN4pb0~28LNNmM1zlsRWW9Y8zjSMfDJ9CoRIpdaxYxGy8u9aprqodkhdJjeL9RktWWDdfTCeYxjk3SXyPc9kTFAiIiQsaylWAkUWL~nxLeHZxWH8dnAEdHXblhEU3CWqGAWVPCDAlT994i41EqvJ~YOZ~8jg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=default, Icon=On, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.399Z",
+                    "updated_at": "2022-05-09T18:35:46.399Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "746cea2dbbbbabfab040ea10ef41770ad580a38d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8658",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/J5G/S55/VJ8Ww32DKFUZMfCK/component_thumbnail_20.png?Expires=1655683200&Signature=ZPWWWWcROJveVSTcNtwfzurizBE9gK~Bmdb4xwQQLZp5CZjZZTVxIR7Bv~UQx1K5L7YUuEq6n7ZUtAWZWrS6vEhsFtOWkWTFEeb5v9KR0xVPmlhMc2ivUsjY6GDEXYrhQeNXNUnpWp4DpGYFkrbutRoLPZeEE9Kv5i4LFEWq-lyJxk3ZvO0WRZ-XmHucERMMVHqyUscQHpwp-oS~2ZM8lRtBbhV78Kmwh44Re84qj6ABSDQW-v1gCirLfh3ce3oImB~KYsPBQ4wH3vqohc-mU09n80xQ-C2j5Ljh1V01TruLSvG6J0~ysvT0euBHkqJRAosxmBhVtvXLceSbavWP5Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=large, State=active, Icon=On, Responsive=True",
+                    "description": "button: primary/large/active/icon/responsive (#CTA)",
+                    "created_at": "2022-05-09T18:35:46.394Z",
+                    "updated_at": "2022-05-09T18:35:46.394Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "7942c6a61b856c02d0c8916442001e82b183a0a0",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20328:3300",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/mMb/Afa/KZqCBAj3vLKnBYrt/component_thumbnail_19.png?Expires=1655683200&Signature=HTv4oVTQgDfvFU7XcjaGZQxuhVatGmdw4BNWLy45x74l3YKbx4XEiVak9G~XFJAasXKyi8B7RXBuYKCwaJ1KkFz2mo2fNY74UzSe4coJJwLiDUTE2vRMFYbt1WzsSAKxQKThOKE0-hLomUlhY9Ju0JtbLvM6aHNEHj89T1cuu2il1VrFB9L1DxMSZ3uEtgfWPH1sWLKP2QH79qL64uPL0T2kuVpaQnSyaMVFnDS5Cu9TRlWfqp4qozhCzGguQJk~VXq3x4Oxd42z69YVKBssO6ES9heJLdOmwsm04W~gQWAIAD4Yx5IY4KtZhWFaxQdPDrRw9gMV7Yfr4Hk~Xol6aA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=primary, Size=small, State=active, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.389Z",
+                    "updated_at": "2022-05-09T18:35:46.389Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "5807106c77cf54a2a441e06f74428ae270ed332d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8622",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/OiL/jXY/epJtqLD5BsmYZoHa/component_thumbnail_18.png?Expires=1655683200&Signature=al7w~seUnOW-Q2kN2lfUIcHO0Dvp1~gxfqzG2D9z4Qw3j3wJmJlm-qrJXibqihERGakm8PNCmX9Qe3AOwYZnX5Qnpmr62~o~vNRvzA25IaWtO9p9cZbyvLcGznNbCITfhWK-8n8XG8-H58M5LC4voE4tJN-Vh7vnT1YtszxrcVDLLZ7rweVq3W4q3VekOZ-kCGQfFL6xQX5mprh--aAenH~bX~PGOIeEKXtVB2e9tSXH6Dh-fip0H-Kdalo8lWWDOOb-HVDcRJDFAoCOk2icWkG13dPJmZhnkPXmoVL1oveHf5UQc5DfvZdqBERVBssmILA3mTHxH01dx1VxPzl9UQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=hover, Icon=Off, Responsive=False",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.383Z",
+                    "updated_at": "2022-05-09T18:35:46.383Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "154941a17e9ecdbfbd4fdcf3276103ba63a96027",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20637:8626",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Jwx/W9O/ApKMgnKNMQIZnNz3/component_thumbnail_17.png?Expires=1655683200&Signature=PBuwDxS4N~VnD-P69Glo-DQE7xeZ2EaOCO6iUnVvz6RAHaVMnxqyW5CMTfSmtY4yUE6x7uWcLB8tVDixklaoPPLYsh2DLLKtzouw6nsz93~T6V~5C8iBjuYASYonY5UUR~D~Ho3w~9g8nYBy1Cra2tcOgVZi3ZTKeXMyxyT3t2fjPmZuBwuu0CGqu~tDMBAI-lXj1d8Ms-R5eQYEPPm4RoCAkPaYvq-vZu7Ttmqe9KAZv5NVAPcvmK3KjKweQtklUDIWnGs4ESuxCujYIm7J50kc5xUo2HnnEhZ4rNDMGnVnU4CJ8lDjVvJclSOmdkZ-eHzc4SN6aXlEoleZQqTy9Q__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Type=secondary, Size=small, State=disabled, Icon=On, Responsive=True",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:46.378Z",
+                    "updated_at": "2022-05-09T18:35:46.378Z",
+                    "containing_frame": {
+                        "name": "Button",
+                        "nodeId": "21440:9989",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF",
+                        "containingStateGroup": {
+                            "name": "button",
+                            "nodeId": "20023:14789"
+                        }
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "8de2e424fb19f647e1fa93b6df656cf775527c55",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21556:12330",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/8BC/5VX/ty1R1u3e6rCVMOGU/component_thumbnail_63.png?Expires=1655683200&Signature=K0tAzAxUodXfYJeOGiPPQJsrHjTI3R7M4lmiQv9uqId47YWP2b-jbDFciBM-SEwXEyKHd-JvWUyzU43xxdsXGzNxHWq~P-f~awOJaBWGRpDMVVIkS9Fx5Mtzilcvlt06O8C4QtXPxW6YP0ytDWD6-fi7mXwmbHyHv8lldpR0049qJy9xXyWOyrcWv7pE9s-0iI7P3go5RbdvoHU9yiqMW7mTD050RwLbpebFjO~DqCEBbyC~aqoJK7ivA7WY9luRAN0ektOVBDRzEVTK~3kaMyj9fGhdBDKUbIxssHTuYwDrW7aOTfSiEuRnKVM~0Cmtu4egb4wwPrdjRGkzo13UeQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Component 2",
+                    "description": "",
+                    "created_at": "2022-05-09T18:34:51.160Z",
+                    "updated_at": "2022-05-09T18:34:51.160Z",
+                    "containing_frame": {
+                        "name": "Group 15",
+                        "nodeId": "21526:15292",
+                        "pageId": "20474:3363",
+                        "pageName": "Annotation Documentation",
+                        "backgroundColor": "rgba(0, 0, 0, 0)"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "dbd6a253582639bf0a6493841394ca16a6b8b27d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20815:8479",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/i48/iyD/jwvpvaoR8rKEJeyg/component_thumbnail_12.png?Expires=1655683200&Signature=G-AU7LpNDz7XZ0U0b13HwCiOmAYxdagWxvCCFG5l-E8XEnh3n6a9vArbASOexcoCvfFxiNoPQQ3IwTa3TzbBSXjziM9KGkjdKCIMhCsWzL2y0ckh3PjXNw5Ae5c69x5wnRwmHNntOiQNM30Y8ZGNF84gvVPxDklqc-VhpRkD2Y1lJlTrLQg5HWFNe-BGFVd5F1UhKqrSy2s9pvfoK4oCYgL1~XETVir8IWKiqZKDda6ApWji2soTJT97gUYywAw9y3TGXGqXN4NXFmLfyWZZlT-5wxNk6YU0lHqwC0PFfTqSsiYzeNv22~d1tp~vfvTQbAp2Cd9NOKx3erHR9nM8tA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "day/Frame 9",
+                    "description": "",
+                    "created_at": "2022-05-09T18:34:50.860Z",
+                    "updated_at": "2022-05-09T18:34:50.860Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "998fa166ac3acacad36db28e0c75e537296318d1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7335",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Kws/d7D/xML1ZGXxuIDJI7Tc/component_thumbnail_48.png?Expires=1655683200&Signature=Yb8~N7ZQ4cMxhDImpkC8DeCaO9Ipdhb113S17bcIheuD0qRWhvS0gYj7VDUgvwc~ZTZM-gm2yq7I4RK6Dn20UW9w2p~4NmHqeay2Ysrb19m2eZ-HvTisTBYikrmiyzCHeMkMyG0lCOOweD1ekbiuJVdb9KdOMCBo3M2n240IvfQ6ebe90bKZNSCN8GZdcmHFbHHl7fqa7qnathwSQmSLOg0XVR0cCqfUSKhNvQOnHCsfNYjbyBqxwa~oQepptJjaGttC59x7UlVIyv4iXCHh9HHJKZiARe0qDACGPf1L9wWLQPffo~HXiixfpBlom7R3Hpq5Qt1OPJKBlp~xp4YbmA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Frame 1",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:09.597Z",
+                    "updated_at": "2022-05-09T18:35:09.597Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "37742e7806d0f810872bc14d91bfced0fb3a5c63",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20813:7418",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/VEN/u5K/0W19jYsxg9FIucPH/component_thumbnail_101.png?Expires=1655683200&Signature=biW39qa9WbbTw7DftGpFQAKpPtlMv4kcI9mtDNCqNaTkmCs-Azm7Rc2NPpcOKIZuR6Crla8nZi1jv69JM3nlx~H7qTIAoUdaB9MwdfL05cKZX4KZ8kix~rbrDs00paK4NzDp9fsMe~E2UqxOs3SuWWPkIMhCy5nI89Qz5HPliCwywqutT6OhO3GIc~nm18aAqHao8vGzV4C6w3i4zrKSNlk2MchvL0n2y4b5e2k7BF9eLsRkpLoDO7d5Rf94DoY2IZQxYeJTnMLEqOgWcl8zgexrQB8ydUF8MXW1wVhlkEGzREM2VngSn99idLKnwukBt1~QtxrQsQ36RJ-2C27KtA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "day/Frame 3",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:00.688Z",
+                    "updated_at": "2022-05-09T18:35:00.688Z",
+                    "containing_frame": {
+                        "name": "Accordian States",
+                        "nodeId": "20817:8253",
+                        "pageId": "20629:6641",
+                        "pageName": "✏️  Calendar (WIP - Flo)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "94bfe35957aa7373da5a6f4de4b65d6d3a7c143f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20023:14116",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/6Z2/Pl9/vg1qQVCVWNi6N74A/component_thumbnail_93.png?Expires=1655683200&Signature=adocXufwrSMSjIcTvSCHr9314m92qNtM~9Zgj3IZft26WM8Xp-TuGEwxzJ0ETZle0c6MAxhvyQib2R7cD8TqRnXi-OJzdJSEHXb-DowTPijKB3ZSJcA6~szW-gbA4JiIdqPNhbGYbXvBl80Zwe~lbW~d1OA1IbKnl0MYDt3MhcfVm1qUpo~aacMxXwLTW8Lbg1M8AgBG80dBTxnYNKk9ZDZVHQMys9widpQBFwWJCngflrZRg7eAPrXGtnpzcAV5h3xmiaSjQEtJcvPZU8ZfYPRO7gw2y~IP7Z1IrvQE-wELxApJrjxpr8rt50fywUdd-AUP4IsrnIRvKj5mMhymBg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "button/structure/tertiary",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:00.652Z",
+                    "updated_at": "2022-05-09T18:35:00.652Z",
+                    "containing_frame": {
+                        "name": "Chevron",
+                        "nodeId": "21440:14883",
+                        "pageId": "1:6",
+                        "pageName": "✏️  CTAs (WIP)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "677d43369ffc33d3ec59d4cc217ad596c5278a8f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21356:7981",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/DPA/ieu/NkMn5cvFa9Fy3bhS/component_thumbnail_122.png?Expires=1655683200&Signature=Y2kl-GKOy5LF49sYNByMZ3a8mSaL81CMXtZgTW6RyPqYNIet92Zcjxmzovn3tSjB1voF4Jvx6En-g4RBCsTIQUCrZKCDQwr75T~bILjzf1OrO1ILxD7stPEEbq08dZbcagvS9rc7XqgDV2mN7EG-CRGzMd~WHYXXPVj6WnNnzDGPGpe9HENNor7InK4XiOsQ6mYSBHBJB2fHfLRP26k9JQbg4~aepBaMdysMGjfj2CGOoVbawOViK2B0i0oOPMApokjLaoPRSV1kDOPRF77bjagTyuw7Xa06kGAsSTDpq17~fqwFLaaB8ZRZL8T1-fdgv4uoEKQUzGJpr1mIuXV60g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Group 43",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:10.089Z",
+                    "updated_at": "2022-05-09T18:35:10.089Z",
+                    "containing_frame": {
+                        "name": "Grid",
+                        "nodeId": "21356:7922",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "rgba(0, 0, 0, 0)"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                },
+                {
+                    "key": "2e64ac34c250a09f9401dad741a8921c106d8670",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "23032:15352",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/SNX/uMO/tfTsBsiwxnDy1OZh/component_thumbnail_120.png?Expires=1655683200&Signature=K7LEiGHpXTtzTsJ68KkFOENZU2k2Hl4dU4~TNpuutoaGpOaey0H285xKbRHqYIhyuGjlAg2dpgaOiOig7eYka30aai5gN0bLTi5JsihKvDFxHj0gmoiIaaqA3JAbf3KiNo90frHI2H7OYdHcbbIz364npxbaNlCxaj0YtqBJa4w1bEvY9RhVrlMLXY8phW4naocUhnsSNbDWfFAJae74hn00JPWw1frUdWNMrPN70qqhANKot0AGszM5psCHpw9BoffoDWEWbviS1YEM6CRCbiQ9lH2Ty36c8-rNSU3nXHQ881VTUfOGZkSGduB~GH4DZK-ZcAEw9lXrlB-pMWISWg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "typography/heading/h1/large",
+                    "description": "",
+                    "created_at": "2022-05-09T18:35:10.076Z",
+                    "updated_at": "2022-05-09T18:35:10.076Z",
+                    "containing_frame": {
+                        "name": "Typography Styles",
+                        "nodeId": "20498:3413",
+                        "pageId": "725:8261",
+                        "pageName": "✅ Design Tokens (WIP - Documentation)",
+                        "backgroundColor": "#FFFFFF"
+                    },
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": "Jason Santos",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    }
+                }
+            ]
+        },
+        "i18n": null
+    }
+}

--- a/packages/cli/src/commands/styles/lib/__mocks__/publish.nodes.components.dt.json
+++ b/packages/cli/src/commands/styles/lib/__mocks__/publish.nodes.components.dt.json
@@ -1,0 +1,1322 @@
+{
+    "data": {
+        "name": "Radius Design Kit V2(WIP)",
+        "lastModified": "2022-06-06T17:51:32Z",
+        "thumbnailUrl": "https://s3-alpha-sig.figma.com/thumbnails/807606ff-5469-448d-8538-f1b9776194f5?Expires=1655683200&Signature=G9qouOWwVUxUD02XtyLbnv7T-DEI5OVqloWgsZxRh2jOc18ajILZu2UzD0~ON5mtmhK4yEfKTvdiT96okqoo3jOQ16nNbMpUXiYzqvkCM-itNfcA6BjVA9jL66GDsUwffAdao0fEbN1Yh9oY6fwmi0SPiTiIxK27xwv0iMA6eM9ObQzH7Pw-txcwfaau36cnD~GbYoDiBKHIXTmfBBjS00hng26Agb8NymbavVGpvj9pM3RuuPuE7OUNTPK1mbrLn27h6Xw7OO4QPYXUX-PP3qAR1oxywTChMUbo00rM83JMaftKxxYqBTaZG5aRlnV953A6Xr1MAZ~5Tf~Sxm~SIw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+        "version": "1953900395",
+        "role": "editor",
+        "editorType": "figma",
+        "linkAccess": "inherit",
+        "nodes": {
+            "19987:11387": {
+                "document": {
+                    "id": "19987:11387",
+                    "name": "Space=5-(20px-1.25rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11374",
+                            "name": "spacing/5-(20px-1.25rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": 71.0,
+                                "width": 20.0,
+                                "height": 20.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 0.0,
+                                        "g": 0.34509804844856262,
+                                        "b": 1.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": 71.0,
+                        "width": 20.0,
+                        "height": 20.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11387": {
+                        "key": "43c6f1013b72a69e8b0e13710fa06122cf574200",
+                        "name": "Space=5-(20px-1.25rem)",
+                        "description": "Spacer-token: spacer/5-(20px-1.25rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11384": {
+                "document": {
+                    "id": "19987:11384",
+                    "name": "Space=2-(8px-0.5rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11371",
+                            "name": "spacing/2-(8px-0.5rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": -61.0,
+                                "width": 8.0,
+                                "height": 8.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 1.0,
+                                        "g": 0.0,
+                                        "b": 0.65490198135375977,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": -61.0,
+                        "width": 8.0,
+                        "height": 8.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11384": {
+                        "key": "0254674d6fe4dcaf3be5d3e54e3f061d01ffe5dd",
+                        "name": "Space=2-(8px-0.5rem)",
+                        "description": "Spacer-token: spacer/2-(8px-0.5rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11388": {
+                "document": {
+                    "id": "19987:11388",
+                    "name": "Space=6-(24px-1.5rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11375",
+                            "name": "spacing/6-(24px-1.5rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": 123.0,
+                                "width": 24.0,
+                                "height": 24.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 0.0,
+                                        "g": 0.84705883264541626,
+                                        "b": 1.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": 123.0,
+                        "width": 24.0,
+                        "height": 24.0
+                    },
+                    "preserveRatio": true,
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11388": {
+                        "key": "25b4044cca28964a64f4dc0d306c91b603309c1e",
+                        "name": "Space=6-(24px-1.5rem)",
+                        "description": "Spacer-token: spacer/6-(24px-1.5rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11390": {
+                "document": {
+                    "id": "19987:11390",
+                    "name": "Space=8-(40px-2.5rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11377",
+                            "name": "spacing/8-(40px-2.5rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": 243.0,
+                                "width": 40.0,
+                                "height": 40.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 0.27058824896812439,
+                                        "g": 1.0,
+                                        "b": 0.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": 243.0,
+                        "width": 40.0,
+                        "height": 40.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11390": {
+                        "key": "3bffcccb258c8bb98880a53c2a9bc82a90644247",
+                        "name": "Space=8-(40px-2.5rem)",
+                        "description": "Spacer-token: spacer/8-(40px-2.5rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11392": {
+                "document": {
+                    "id": "19987:11392",
+                    "name": "Space=10-(64px-4rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11379",
+                            "name": "spacing/10-(64px-4rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": 395.0,
+                                "width": 64.0,
+                                "height": 64.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 1.0,
+                                        "g": 1.0,
+                                        "b": 0.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": 395.0,
+                        "width": 64.0,
+                        "height": 64.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11392": {
+                        "key": "1656a3627aab9c5921a50c4db15d9f537731f205",
+                        "name": "Space=10-(64px-4rem)",
+                        "description": "Spacer-token: spacer/10-(64px-4rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11394": {
+                "document": {
+                    "id": "19987:11394",
+                    "name": "Space=12-(128px-8rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11381",
+                            "name": "spacing/12-(128px-8rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": 619.0,
+                                "width": 152.0,
+                                "height": 152.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 1.0,
+                                        "g": 0.30588236451148987,
+                                        "b": 0.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": 619.0,
+                        "width": 128.0,
+                        "height": 128.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11394": {
+                        "key": "e709dc3744fdf0e51771bbdb8daff43578cb2550",
+                        "name": "Space=12-(128px-8rem)",
+                        "description": "Spacer-token: spacer/12-(128px-8rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11393": {
+                "document": {
+                    "id": "19987:11393",
+                    "name": "Space=11-(96px-6rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11380",
+                            "name": "spacing/11-(96px-6rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": 491.0,
+                                "width": 96.0,
+                                "height": 96.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 1.0,
+                                        "g": 0.65490198135375977,
+                                        "b": 0.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": 491.0,
+                        "width": 96.0,
+                        "height": 96.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11393": {
+                        "key": "fa07ea38d07d5845ecb001c1cb4c2a89c97c537b",
+                        "name": "Space=11-(96px-6rem)",
+                        "description": "Spacer-token: spacer/11-(96px-6rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11391": {
+                "document": {
+                    "id": "19987:11391",
+                    "name": "Space=9-(48px-3rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11378",
+                            "name": "spacing/9-(48px-3rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": 315.0,
+                                "width": 48.0,
+                                "height": 48.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 0.84705883264541626,
+                                        "g": 1.0,
+                                        "b": 0.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": 315.0,
+                        "width": 48.0,
+                        "height": 48.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11391": {
+                        "key": "f4b04d15b18bfcacde35c7172dcdb22a87ab143d",
+                        "name": "Space=9-(48px-3rem)",
+                        "description": "Spacer-token: spacer/9-(48px-3rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11389": {
+                "document": {
+                    "id": "19987:11389",
+                    "name": "Space=7-(32px-2rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11376",
+                            "name": "spacing/7-(32px-2rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": 179.0,
+                                "width": 32.0,
+                                "height": 32.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 0.0,
+                                        "g": 1.0,
+                                        "b": 0.30588236451148987,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": 179.0,
+                        "width": 32.0,
+                        "height": 32.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11389": {
+                        "key": "85f2eebcabd0010493b0c714e70a7581696e5516",
+                        "name": "Space=7-(32px-2rem)",
+                        "description": "Spacer-token: spacer/7-(32px-2rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11386": {
+                "document": {
+                    "id": "19987:11386",
+                    "name": "Space=4-(16px-1rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11373",
+                            "name": "spacing/4-(16px-1rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": 23.0,
+                                "width": 16.0,
+                                "height": 16.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 0.0,
+                                        "g": 0.078431375324726105,
+                                        "b": 1.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": 23.0,
+                        "width": 16.0,
+                        "height": 16.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11386": {
+                        "key": "48cd4c76e9c56f481404cfe0649f84fe890dc28a",
+                        "name": "Space=4-(16px-1rem)",
+                        "description": "Spacer-token: spacer/4-(16px-1rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11385": {
+                "document": {
+                    "id": "19987:11385",
+                    "name": "Space=3-(12px-0.75rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11372",
+                            "name": "spacing/3-(12px-0.75rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": -21.0,
+                                "width": 12.0,
+                                "height": 12.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 0.46274510025978088,
+                                        "g": 0.0,
+                                        "b": 1.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": -21.0,
+                        "width": 12.0,
+                        "height": 12.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11385": {
+                        "key": "6e5cce302084c4d715e5b348a24bc2e672c1882f",
+                        "name": "Space=3-(12px-0.75rem)",
+                        "description": "Spacer-token: spacer/3-(12px-0.75rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "19987:11383": {
+                "document": {
+                    "id": "19987:11383",
+                    "name": "Space=1-(4px-0.25rem)",
+                    "type": "COMPONENT",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [
+                        {
+                            "id": "19987:11370",
+                            "name": "spacing/1-(4px-0.25rem)",
+                            "type": "RECTANGLE",
+                            "blendMode": "PASS_THROUGH",
+                            "absoluteBoundingBox": {
+                                "x": 10194.0,
+                                "y": -97.0,
+                                "width": 4.0,
+                                "height": 4.0
+                            },
+                            "preserveRatio": true,
+                            "constraints": {
+                                "vertical": "SCALE",
+                                "horizontal": "SCALE"
+                            },
+                            "fills": [
+                                {
+                                    "opacity": 0.20000000298023224,
+                                    "blendMode": "NORMAL",
+                                    "type": "SOLID",
+                                    "color": {
+                                        "r": 1.0,
+                                        "g": 0.0,
+                                        "b": 0.0,
+                                        "a": 1.0
+                                    }
+                                }
+                            ],
+                            "strokes": [],
+                            "strokeWeight": 1.0,
+                            "strokeAlign": "INSIDE",
+                            "effects": []
+                        }
+                    ],
+                    "absoluteBoundingBox": {
+                        "x": 10194.0,
+                        "y": -97.0,
+                        "width": 4.0,
+                        "height": 4.0
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": false,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "visible": false,
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1.0,
+                                "g": 1.0,
+                                "b": 1.0,
+                                "a": 1.0
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1.0,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 0.0,
+                        "g": 0.0,
+                        "b": 0.0,
+                        "a": 0.0
+                    },
+                    "effects": []
+                },
+                "components": {
+                    "19987:11383": {
+                        "key": "c7699f9db7602e240ac09a2f15a79f39f08a5a9b",
+                        "name": "Space=1-(4px-0.25rem)",
+                        "description": "Spacer-token: spacer/1-(4px-0.25rem) (#Token)",
+                        "componentSetId": "20057:9044",
+                        "documentationLinks": []
+                    }
+                },
+                "componentSets": {
+                    "20057:9044": {
+                        "key": "5a4eb2412e88d062261b2912799b026551d1a5ba",
+                        "name": "spacer",
+                        "description": ""
+                    }
+                },
+                "schemaVersion": 0,
+                "styles": {}
+            }
+        }
+    }
+}

--- a/packages/cli/src/commands/styles/lib/__mocks__/publish.nodes.json
+++ b/packages/cli/src/commands/styles/lib/__mocks__/publish.nodes.json
@@ -1,1 +1,3551 @@
-{"data":{"name":"Radius Design Kit V2(WIP)","lastModified":"2022-05-19T18:59:32Z","thumbnailUrl":"https://s3-alpha-sig.figma.com/thumbnails/edbb5c45-3ed1-4dc0-a0d7-0e84a611c2c2?Expires=1653868800&Signature=Tj2~ydoGmDjOMEC6MrqWopXslcnorRWTNJVg2Xj2hbDIIsVyBXLB0-1TtbGW1-ANeWUUuKQP64sNP3ErYYB43~eLb2vIWWItEC09oVcbbB-SwTOLMSCFkMo6~6~p5LSaqIVQtbb381xRTjHbGzA2q2-DJOsu3uJuBYyHhcuxcYtx8XWr4KDAl~l8yMAA2Zcf6OY5FsCeuY9oiWJzFp-SHIbrZBcI3-Jf2yls3Jyho~4g~dtM4HJF3flhU1Hm6kM5zQYTM3okzoLw5ogh5og0QCCQ1pKp~BeECA~MnrwHV1JmvGjiTxn9R81rDtu~2~7OnUUaPotiO83oPBDI7zKnsA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","version":"1890938747","role":"editor","editorType":"figma","linkAccess":"inherit","nodes":{"21291:7794":{"document":{"id":"21291:7794","name":"Annotation Grid","type":"FRAME","blendMode":"PASS_THROUGH","children":[],"absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"clipsContent":true,"background":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","backgroundColor":{"r":1,"g":1,"b":1,"a":1},"layoutGrids":[{"pattern":"COLUMNS","sectionSize":-200,"visible":true,"color":{"r":1,"g":0,"b":0,"a":0.4000000059604645},"alignment":"STRETCH","gutterSize":0,"offset":150,"count":1},{"pattern":"ROWS","sectionSize":-220,"visible":true,"color":{"r":1,"g":0,"b":0,"a":0.4000000059604645},"alignment":"STRETCH","gutterSize":0,"offset":160,"count":1},{"pattern":"COLUMNS","sectionSize":230,"visible":true,"color":{"r":1,"g":0,"b":0,"a":0.10000000149011612},"alignment":"MIN","gutterSize":40,"offset":390,"count":16}],"effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20792:7357":{"document":{"id":"20792:7357","name":"elevation/light/100%","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.7686274647712708,"g":0.7686274647712708,"b":0.7686274647712708,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.10000000149011612},"blendMode":"NORMAL","offset":{"x":0,"y":16},"radius":24,"showShadowBehindNode":true},{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.05000000074505806},"blendMode":"NORMAL","offset":{"x":0,"y":0},"radius":1,"showShadowBehindNode":true}]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20792:7356":{"document":{"id":"20792:7356","name":"elevation/light/80%","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.7686274647712708,"g":0.7686274647712708,"b":0.7686274647712708,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.10000000149011612},"blendMode":"NORMAL","offset":{"x":0,"y":8},"radius":16,"showShadowBehindNode":true},{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.05000000074505806},"blendMode":"NORMAL","offset":{"x":0,"y":0},"radius":1,"showShadowBehindNode":true}]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20499:3480":{"document":{"id":"20499:3480","name":"labels/s","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":45,"height":18},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":12,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":18,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20499:3498":{"document":{"id":"20499:3498","name":"hint/xs","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":37,"height":15},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Regular","fontWeight":400,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":10,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":15,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20792:7348":{"document":{"id":"20792:7348","name":"elevation/light/20%","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.7686274647712708,"g":0.7686274647712708,"b":0.7686274647712708,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.10000000149011612},"blendMode":"NORMAL","offset":{"x":0,"y":1},"radius":3,"showShadowBehindNode":true},{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.05000000074505806},"blendMode":"NORMAL","offset":{"x":0,"y":0},"radius":1,"showShadowBehindNode":true}]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20474:3360":{"document":{"id":"20474:3360","name":"paragraph/m","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":59,"height":24},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Regular","fontWeight":400,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":16,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":24,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20474:3361":{"document":{"id":"20474:3361","name":"paragraph/s","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":44,"height":18},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Regular","fontWeight":400,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":12,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":18,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20519:3988":{"document":{"id":"20519:3988","name":"navigation/m","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":63,"height":16},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":16,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0.64,"lineHeightPx":16,"lineHeightPercent":85.33333587646484,"lineHeightPercentFontSize":100,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20472:3360":{"document":{"id":"20472:3360","name":"header/5xl","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":179,"height":60},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Riforma LL","fontPostScriptName":"RiformaLL-Bold","fontWeight":700,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":48,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":60,"lineHeightPercent":106.66666412353516,"lineHeightPercentFontSize":125,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20472:3361":{"document":{"id":"20472:3361","name":"header/4xl","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":153,"height":50},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Riforma LL","fontPostScriptName":"RiformaLL-Bold","fontWeight":700,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":40,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":50,"lineHeightPercent":106.66666412353516,"lineHeightPercentFontSize":125,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20472:3362":{"document":{"id":"20472:3362","name":"header/3xl","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":119,"height":40},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Bold","fontWeight":700,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":32,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":40,"lineHeightPercent":106.66666412353516,"lineHeightPercentFontSize":125,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20472:3363":{"document":{"id":"20472:3363","name":"header/2xl","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":107,"height":35},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Riforma LL","fontPostScriptName":"RiformaLL-Bold","fontWeight":700,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":28,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":35,"lineHeightPercent":106.66666412353516,"lineHeightPercentFontSize":125,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20472:3364":{"document":{"id":"20472:3364","name":"header/xl","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":90,"height":30},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Bold","fontWeight":700,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":24,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":30,"lineHeightPercent":106.66666412353516,"lineHeightPercentFontSize":125,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20519:3939":{"document":{"id":"20519:3939","name":"inline/m/active","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":59,"height":24},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","textDecoration":"UNDERLINE","fontSize":16,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":24,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20519:3940":{"document":{"id":"20519:3940","name":"inline/s/default","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":45,"height":18},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":12,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":18,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"21287:7661":{"document":{"id":"21287:7661","name":"- annotations/Annotation S","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":53,"height":16},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Overpass Mono","fontPostScriptName":"OverpassMono-Light","fontWeight":300,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":13,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":-0.65,"lineHeightPx":15.600000381469727,"lineHeightPercent":102.40000915527344,"lineHeightPercentFontSize":120.00000762939453,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"21287:7662":{"document":{"id":"21287:7662","name":"- annotations/Annotation L","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":121,"height":30},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Overpass Mono","fontPostScriptName":"OverpassMono-Regular","fontWeight":400,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":30,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":-1.5,"lineHeightPx":30,"lineHeightPercent":85.33333587646484,"lineHeightPercentFontSize":100,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20521:4154":{"document":{"id":"20521:4154","name":"labels/m","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":60,"height":24},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":16,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":24,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"21287:7660":{"document":{"id":"21287:7660","name":"- annotations/Annotation M","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":67,"height":21},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Overpass Mono","fontPostScriptName":"OverpassMono-Regular","fontWeight":400,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":16,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":-0.48,"lineHeightPx":20.799999237060547,"lineHeightPercent":110.93333435058594,"lineHeightPercentFontSize":130,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"21291:7423":{"document":{"id":"21291:7423","name":"- annotations/Annotation XL","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":191,"height":48},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Overpass Mono","fontPostScriptName":"OverpassMono-SemiBold","fontWeight":600,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":46,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":-1.38,"lineHeightPx":48.16199493408203,"lineHeightPercent":89.343994140625,"lineHeightPercentFontSize":104.69999694824219,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"21440:14880":{"document":{"id":"21440:14880","name":"- annotations/Annotation XXL","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":397,"height":101},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Overpass Mono","fontPostScriptName":"OverpassMono-SemiBold","fontWeight":600,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":96,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":-2.88,"lineHeightPx":100.51199340820312,"lineHeightPercent":89.343994140625,"lineHeightPercentFontSize":104.69999694824219,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10971":{"document":{"id":"20008:10971","name":"background/2","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.9458333253860474,"g":0.9458333253860474,"b":0.9458333253860474,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20029:15095":{"document":{"id":"20029:15095","name":"XL Desktop (1920px)","type":"FRAME","blendMode":"PASS_THROUGH","children":[],"absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"clipsContent":true,"background":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","backgroundColor":{"r":1,"g":1,"b":1,"a":1},"layoutGrids":[{"pattern":"COLUMNS","sectionSize":-688,"visible":true,"color":{"r":0,"g":0.6392157077789307,"b":1,"a":0.05000000074505806},"alignment":"STRETCH","gutterSize":32,"offset":394,"count":1},{"pattern":"COLUMNS","sectionSize":-86.66666412353516,"visible":true,"color":{"r":0,"g":0.6399999856948853,"b":1,"a":0.10000000149011612},"alignment":"STRETCH","gutterSize":32,"offset":394,"count":12}],"effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10974":{"document":{"id":"20008:10974","name":"text/disabled","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.612500011920929,"g":0.612500011920929,"b":0.612500011920929,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"21291:7667":{"document":{"id":"21291:7667","name":"background/- annotation","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.5041666626930237,"g":0.5041666626930237,"b":0.5041666626930237,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10975":{"document":{"id":"20008:10975","name":"text/inversed","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20003:10942":{"document":{"id":"20003:10942","name":"brand/primary/light","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.9166666865348816,"g":0.32944366335868835,"b":0.20625001192092896,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10963":{"document":{"id":"20008:10963","name":"UI/Grayscale/secondary","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.5083333253860474,"g":0.5062152743339539,"b":0.5062152743339539,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20668:7336":{"document":{"id":"20668:7336","name":"text/link","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.0117647061124444,"g":0.4000000059604645,"b":0.8392156958580017,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20472:3365":{"document":{"id":"20472:3365","name":"header/l","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":75,"height":25},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Bold","fontWeight":700,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":20,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":25,"lineHeightPercent":106.66666412353516,"lineHeightPercentFontSize":125,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20003:11700":{"document":{"id":"20003:11700","name":"brand/primary/dark","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.7166666388511658,"g":0.23184168338775635,"b":0.12541669607162476,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10976":{"document":{"id":"20008:10976","name":"text/error","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.8156862854957581,"g":0.25882354378700256,"b":0.10588235408067703,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20792:7350":{"document":{"id":"20792:7350","name":"elevation/light/60%","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.7686274647712708,"g":0.7686274647712708,"b":0.7686274647712708,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.10000000149011612},"blendMode":"NORMAL","offset":{"x":0,"y":4},"radius":8,"showShadowBehindNode":true},{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.05000000074505806},"blendMode":"NORMAL","offset":{"x":0,"y":0},"radius":1,"showShadowBehindNode":true}]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20792:7349":{"document":{"id":"20792:7349","name":"elevation/light/40%","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.7686274647712708,"g":0.7686274647712708,"b":0.7686274647712708,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.10000000149011612},"blendMode":"NORMAL","offset":{"x":0,"y":2},"radius":4,"showShadowBehindNode":true},{"type":"DROP_SHADOW","visible":true,"color":{"r":0.1882352977991104,"g":0.1921568661928177,"b":0.20000000298023224,"a":0.05000000074505806},"blendMode":"NORMAL","offset":{"x":0,"y":0},"radius":1,"showShadowBehindNode":true}]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10977":{"document":{"id":"20008:10977","name":"text/success","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.07450980693101883,"g":0.501960813999176,"b":0,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10965":{"document":{"id":"20008:10965","name":"UI/Grayscale/quaternary","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20127:7569":{"document":{"id":"20127:7569","name":"UI/alert/dark","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.6958333253860474,"g":0.39398765563964844,"b":0,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10973":{"document":{"id":"20008:10973","name":"text/secondary","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.4588235318660736,"g":0.4588235318660736,"b":0.4588235318660736,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20668:7241":{"document":{"id":"20668:7241","name":"sub-navigation/s","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":48,"height":12},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":12,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0.48,"lineHeightPx":12,"lineHeightPercent":85.33333587646484,"lineHeightPercentFontSize":100,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10972":{"document":{"id":"20008:10972","name":"text/primary","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.14901961386203766,"g":0.14901961386203766,"b":0.14901961386203766,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20003:11701":{"document":{"id":"20003:11701","name":"brand/primary/darker","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.637499988079071,"g":0.199060320854187,"b":0.10359376668930054,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20003:11702":{"document":{"id":"20003:11702","name":"brand/secondary/main","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.14901961386203766,"g":0.14901961386203766,"b":0.14901961386203766,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20003:11703":{"document":{"id":"20003:11703","name":"brand/secondary/light","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.24166665971279144,"g":0.24166665971279144,"b":0.24166665971279144,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20519:3941":{"document":{"id":"20519:3941","name":"inline/s/hover","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":45,"height":18},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","textDecoration":"UNDERLINE","fontSize":12,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":18,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20519:3942":{"document":{"id":"20519:3942","name":"inline/s/active","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":45,"height":18},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","textDecoration":"UNDERLINE","fontSize":12,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":18,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20003:11705":{"document":{"id":"20003:11705","name":"brand/secondary/dark","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.10000000149011612,"g":0.09916666895151138,"b":0.09916666895151138,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20003:11706":{"document":{"id":"20003:11706","name":"brand/secondary/darker","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.05416666716337204,"g":0.05416666716337204,"b":0.05416666716337204,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10962":{"document":{"id":"20008:10962","name":"UI/Grayscale/primary","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.14901961386203766,"g":0.14901961386203766,"b":0.14901961386203766,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10968":{"document":{"id":"20008:10968","name":"UI/success/default","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.07450980693101883,"g":0.501960813999176,"b":0,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10967":{"document":{"id":"20008:10967","name":"UI/error/default","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.8374999761581421,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20127:7564":{"document":{"id":"20127:7564","name":"UI/error/light","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.9291666746139526,"g":0.10065972805023193,"b":0.10065972805023193,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10970":{"document":{"id":"20008:10970","name":"background/1","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20127:7565":{"document":{"id":"20127:7565","name":"UI/error/dark","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.6708333492279053,"g":0.0642881989479065,"b":0.0642881989479065,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20127:7567":{"document":{"id":"20127:7567","name":"UI/success/dark","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.06353407353162766,"g":0.36666667461395264,"b":0.010694444179534912,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20127:7568":{"document":{"id":"20127:7568","name":"UI/alert/light","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.9372549057006836,"g":0.5960784554481506,"b":0.15294118225574493,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10964":{"document":{"id":"20008:10964","name":"UI/Grayscale/tertiary","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.9291666746139526,"g":0.9291666746139526,"b":0.9291666746139526,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20003:10941":{"document":{"id":"20003:10941","name":"brand/primary/main","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.8313725590705872,"g":0.2705882489681244,"b":0.15294118225574493,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20519:3926":{"document":{"id":"20519:3926","name":"inline/m/default","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":59,"height":24},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","fontSize":16,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":24,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20519:3927":{"document":{"id":"20519:3927","name":"inline/m/hover","type":"TEXT","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":59,"height":24},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0,"g":0,"b":0,"a":1}}],"strokes":[],"strokeWeight":0,"strokeAlign":"INSIDE","effects":[],"characters":"Rag 123","style":{"fontFamily":"Roboto","fontPostScriptName":"Roboto-Medium","fontWeight":500,"textAutoResize":"WIDTH_AND_HEIGHT","textDecoration":"UNDERLINE","fontSize":16,"textAlignHorizontal":"LEFT","textAlignVertical":"TOP","letterSpacing":0,"lineHeightPx":24,"lineHeightPercent":128,"lineHeightPercentFontSize":150,"lineHeightUnit":"FONT_SIZE_%"},"layoutVersion":3,"characterStyleOverrides":[],"styleOverrideTable":{},"lineTypes":["NONE"],"lineIndentations":[0]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20029:15096":{"document":{"id":"20029:15096","name":"Large Desktop (1440px)","type":"FRAME","blendMode":"PASS_THROUGH","children":[],"absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"clipsContent":true,"background":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","backgroundColor":{"r":1,"g":1,"b":1,"a":1},"layoutGrids":[{"pattern":"COLUMNS","sectionSize":-208,"visible":true,"color":{"r":0,"g":0.6392157077789307,"b":1,"a":0.05000000074505806},"alignment":"STRETCH","gutterSize":32,"offset":154,"count":1},{"pattern":"COLUMNS","sectionSize":-46.66666793823242,"visible":true,"color":{"r":0,"g":0.6399999856948853,"b":1,"a":0.10000000149011612},"alignment":"STRETCH","gutterSize":32,"offset":154,"count":12}],"effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20029:15097":{"document":{"id":"20029:15097","name":"Tablet (768px)","type":"FRAME","blendMode":"PASS_THROUGH","children":[],"absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"clipsContent":true,"background":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","backgroundColor":{"r":1,"g":1,"b":1,"a":1},"layoutGrids":[{"pattern":"COLUMNS","sectionSize":36,"visible":true,"color":{"r":0,"g":0.6392157077789307,"b":1,"a":0.05000000074505806},"alignment":"STRETCH","gutterSize":32,"offset":32,"count":1},{"pattern":"COLUMNS","sectionSize":-23.5,"visible":true,"color":{"r":0,"g":0.6399999856948853,"b":1,"a":0.10000000149011612},"alignment":"STRETCH","gutterSize":32,"offset":32,"count":8}],"effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20127:7566":{"document":{"id":"20127:7566","name":"UI/success/light","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.20450440049171448,"g":0.6875,"b":0.12031251192092896,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10969":{"document":{"id":"20008:10969","name":"UI/alert/default","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.8588235378265381,"g":0.48627451062202454,"b":0,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20029:15098":{"document":{"id":"20029:15098","name":"Mobile (360px)","type":"FRAME","blendMode":"PASS_THROUGH","children":[],"absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"clipsContent":true,"background":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":1,"g":1,"b":1,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","backgroundColor":{"r":1,"g":1,"b":1,"a":1},"layoutGrids":[{"pattern":"COLUMNS","sectionSize":52,"visible":true,"color":{"r":0,"g":0.6392157077789307,"b":1,"a":0.05000000074505806},"alignment":"STRETCH","gutterSize":24,"offset":24,"count":1},{"pattern":"COLUMNS","sectionSize":-5,"visible":true,"color":{"r":0,"g":0.6399999856948853,"b":1,"a":0.10000000149011612},"alignment":"STRETCH","gutterSize":24,"offset":24,"count":4}],"effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}},"20008:10966":{"document":{"id":"20008:10966","name":"UI/Grayscale/disabled","type":"RECTANGLE","blendMode":"PASS_THROUGH","absoluteBoundingBox":{"x":0,"y":0,"width":100,"height":100},"constraints":{"vertical":"TOP","horizontal":"LEFT"},"fills":[{"blendMode":"NORMAL","type":"SOLID","color":{"r":0.8708333373069763,"g":0.8708333373069763,"b":0.8708333373069763,"a":1}}],"strokes":[],"strokeWeight":1,"strokeAlign":"INSIDE","effects":[]},"components":{},"componentSets":{},"schemaVersion":0,"styles":{}}}}}
+{
+    "data": {
+        "name": "Radius Design Kit V2(WIP)",
+        "lastModified": "2022-05-19T18:59:32Z",
+        "thumbnailUrl": "https://s3-alpha-sig.figma.com/thumbnails/edbb5c45-3ed1-4dc0-a0d7-0e84a611c2c2?Expires=1653868800&Signature=Tj2~ydoGmDjOMEC6MrqWopXslcnorRWTNJVg2Xj2hbDIIsVyBXLB0-1TtbGW1-ANeWUUuKQP64sNP3ErYYB43~eLb2vIWWItEC09oVcbbB-SwTOLMSCFkMo6~6~p5LSaqIVQtbb381xRTjHbGzA2q2-DJOsu3uJuBYyHhcuxcYtx8XWr4KDAl~l8yMAA2Zcf6OY5FsCeuY9oiWJzFp-SHIbrZBcI3-Jf2yls3Jyho~4g~dtM4HJF3flhU1Hm6kM5zQYTM3okzoLw5ogh5og0QCCQ1pKp~BeECA~MnrwHV1JmvGjiTxn9R81rDtu~2~7OnUUaPotiO83oPBDI7zKnsA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+        "version": "1890938747",
+        "role": "editor",
+        "editorType": "figma",
+        "linkAccess": "inherit",
+        "nodes": {
+            "21291:7794": {
+                "document": {
+                    "id": "21291:7794",
+                    "name": "Annotation Grid",
+                    "type": "FRAME",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [],
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": true,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 1,
+                        "g": 1,
+                        "b": 1,
+                        "a": 1
+                    },
+                    "layoutGrids": [
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": -200,
+                            "visible": true,
+                            "color": {
+                                "r": 1,
+                                "g": 0,
+                                "b": 0,
+                                "a": 0.4000000059604645
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 0,
+                            "offset": 150,
+                            "count": 1
+                        },
+                        {
+                            "pattern": "ROWS",
+                            "sectionSize": -220,
+                            "visible": true,
+                            "color": {
+                                "r": 1,
+                                "g": 0,
+                                "b": 0,
+                                "a": 0.4000000059604645
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 0,
+                            "offset": 160,
+                            "count": 1
+                        },
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": 230,
+                            "visible": true,
+                            "color": {
+                                "r": 1,
+                                "g": 0,
+                                "b": 0,
+                                "a": 0.10000000149011612
+                            },
+                            "alignment": "MIN",
+                            "gutterSize": 40,
+                            "offset": 390,
+                            "count": 16
+                        }
+                    ],
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20792:7357": {
+                "document": {
+                    "id": "20792:7357",
+                    "name": "elevation/light/100%",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.7686274647712708,
+                                "g": 0.7686274647712708,
+                                "b": 0.7686274647712708,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": [
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.10000000149011612
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 16
+                            },
+                            "radius": 24,
+                            "showShadowBehindNode": true
+                        },
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.05000000074505806
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "radius": 1,
+                            "showShadowBehindNode": true
+                        }
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20792:7356": {
+                "document": {
+                    "id": "20792:7356",
+                    "name": "elevation/light/80%",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.7686274647712708,
+                                "g": 0.7686274647712708,
+                                "b": 0.7686274647712708,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": [
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.10000000149011612
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 8
+                            },
+                            "radius": 16,
+                            "showShadowBehindNode": true
+                        },
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.05000000074505806
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "radius": 1,
+                            "showShadowBehindNode": true
+                        }
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20499:3480": {
+                "document": {
+                    "id": "20499:3480",
+                    "name": "labels/s",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 45,
+                        "height": 18
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 12,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 18,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20499:3498": {
+                "document": {
+                    "id": "20499:3498",
+                    "name": "hint/xs",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 37,
+                        "height": 15
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Regular",
+                        "fontWeight": 400,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 10,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 15,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20792:7348": {
+                "document": {
+                    "id": "20792:7348",
+                    "name": "elevation/light/20%",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.7686274647712708,
+                                "g": 0.7686274647712708,
+                                "b": 0.7686274647712708,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": [
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.10000000149011612
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 1
+                            },
+                            "radius": 3,
+                            "showShadowBehindNode": true
+                        },
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.05000000074505806
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "radius": 1,
+                            "showShadowBehindNode": true
+                        }
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20474:3360": {
+                "document": {
+                    "id": "20474:3360",
+                    "name": "paragraph/m",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 59,
+                        "height": 24
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Regular",
+                        "fontWeight": 400,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 16,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 24,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20474:3361": {
+                "document": {
+                    "id": "20474:3361",
+                    "name": "paragraph/s",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 44,
+                        "height": 18
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Regular",
+                        "fontWeight": 400,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 12,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 18,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20519:3988": {
+                "document": {
+                    "id": "20519:3988",
+                    "name": "navigation/m",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 63,
+                        "height": 16
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 16,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0.64,
+                        "lineHeightPx": 16,
+                        "lineHeightPercent": 85.33333587646484,
+                        "lineHeightPercentFontSize": 100,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20472:3360": {
+                "document": {
+                    "id": "20472:3360",
+                    "name": "header/5xl",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 179,
+                        "height": 60
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Riforma LL",
+                        "fontPostScriptName": "RiformaLL-Bold",
+                        "fontWeight": 700,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 48,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 60,
+                        "lineHeightPercent": 106.66666412353516,
+                        "lineHeightPercentFontSize": 125,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20472:3361": {
+                "document": {
+                    "id": "20472:3361",
+                    "name": "header/4xl",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 153,
+                        "height": 50
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Riforma LL",
+                        "fontPostScriptName": "RiformaLL-Bold",
+                        "fontWeight": 700,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 40,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 50,
+                        "lineHeightPercent": 106.66666412353516,
+                        "lineHeightPercentFontSize": 125,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20472:3362": {
+                "document": {
+                    "id": "20472:3362",
+                    "name": "header/3xl",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 119,
+                        "height": 40
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Bold",
+                        "fontWeight": 700,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 32,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 40,
+                        "lineHeightPercent": 106.66666412353516,
+                        "lineHeightPercentFontSize": 125,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20472:3363": {
+                "document": {
+                    "id": "20472:3363",
+                    "name": "header/2xl",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 107,
+                        "height": 35
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Riforma LL",
+                        "fontPostScriptName": "RiformaLL-Bold",
+                        "fontWeight": 700,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 28,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 35,
+                        "lineHeightPercent": 106.66666412353516,
+                        "lineHeightPercentFontSize": 125,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20472:3364": {
+                "document": {
+                    "id": "20472:3364",
+                    "name": "header/xl",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 90,
+                        "height": 30
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Bold",
+                        "fontWeight": 700,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 24,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 30,
+                        "lineHeightPercent": 106.66666412353516,
+                        "lineHeightPercentFontSize": 125,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20519:3939": {
+                "document": {
+                    "id": "20519:3939",
+                    "name": "inline/m/active",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 59,
+                        "height": 24
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "textDecoration": "UNDERLINE",
+                        "fontSize": 16,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 24,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20519:3940": {
+                "document": {
+                    "id": "20519:3940",
+                    "name": "inline/s/default",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 45,
+                        "height": 18
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 12,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 18,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "21287:7661": {
+                "document": {
+                    "id": "21287:7661",
+                    "name": "- annotations/Annotation S",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 53,
+                        "height": 16
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Overpass Mono",
+                        "fontPostScriptName": "OverpassMono-Light",
+                        "fontWeight": 300,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 13,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": -0.65,
+                        "lineHeightPx": 15.600000381469727,
+                        "lineHeightPercent": 102.40000915527344,
+                        "lineHeightPercentFontSize": 120.00000762939453,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "21287:7662": {
+                "document": {
+                    "id": "21287:7662",
+                    "name": "- annotations/Annotation L",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 121,
+                        "height": 30
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Overpass Mono",
+                        "fontPostScriptName": "OverpassMono-Regular",
+                        "fontWeight": 400,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 30,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": -1.5,
+                        "lineHeightPx": 30,
+                        "lineHeightPercent": 85.33333587646484,
+                        "lineHeightPercentFontSize": 100,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20521:4154": {
+                "document": {
+                    "id": "20521:4154",
+                    "name": "labels/m",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 60,
+                        "height": 24
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 16,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 24,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "21287:7660": {
+                "document": {
+                    "id": "21287:7660",
+                    "name": "- annotations/Annotation M",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 67,
+                        "height": 21
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Overpass Mono",
+                        "fontPostScriptName": "OverpassMono-Regular",
+                        "fontWeight": 400,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 16,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": -0.48,
+                        "lineHeightPx": 20.799999237060547,
+                        "lineHeightPercent": 110.93333435058594,
+                        "lineHeightPercentFontSize": 130,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "21291:7423": {
+                "document": {
+                    "id": "21291:7423",
+                    "name": "- annotations/Annotation XL",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 191,
+                        "height": 48
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Overpass Mono",
+                        "fontPostScriptName": "OverpassMono-SemiBold",
+                        "fontWeight": 600,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 46,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": -1.38,
+                        "lineHeightPx": 48.16199493408203,
+                        "lineHeightPercent": 89.343994140625,
+                        "lineHeightPercentFontSize": 104.69999694824219,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "21440:14880": {
+                "document": {
+                    "id": "21440:14880",
+                    "name": "- annotations/Annotation XXL",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 397,
+                        "height": 101
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Overpass Mono",
+                        "fontPostScriptName": "OverpassMono-SemiBold",
+                        "fontWeight": 600,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 96,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": -2.88,
+                        "lineHeightPx": 100.51199340820312,
+                        "lineHeightPercent": 89.343994140625,
+                        "lineHeightPercentFontSize": 104.69999694824219,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10971": {
+                "document": {
+                    "id": "20008:10971",
+                    "name": "background/2",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.9458333253860474,
+                                "g": 0.9458333253860474,
+                                "b": 0.9458333253860474,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20029:15095": {
+                "document": {
+                    "id": "20029:15095",
+                    "name": "XL Desktop (1920px)",
+                    "type": "FRAME",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [],
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": true,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 1,
+                        "g": 1,
+                        "b": 1,
+                        "a": 1
+                    },
+                    "layoutGrids": [
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": -688,
+                            "visible": true,
+                            "color": {
+                                "r": 0,
+                                "g": 0.6392157077789307,
+                                "b": 1,
+                                "a": 0.05000000074505806
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 32,
+                            "offset": 394,
+                            "count": 1
+                        },
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": -86.66666412353516,
+                            "visible": true,
+                            "color": {
+                                "r": 0,
+                                "g": 0.6399999856948853,
+                                "b": 1,
+                                "a": 0.10000000149011612
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 32,
+                            "offset": 394,
+                            "count": 12
+                        }
+                    ],
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10974": {
+                "document": {
+                    "id": "20008:10974",
+                    "name": "text/disabled",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.612500011920929,
+                                "g": 0.612500011920929,
+                                "b": 0.612500011920929,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "21291:7667": {
+                "document": {
+                    "id": "21291:7667",
+                    "name": "background/- annotation",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.5041666626930237,
+                                "g": 0.5041666626930237,
+                                "b": 0.5041666626930237,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10975": {
+                "document": {
+                    "id": "20008:10975",
+                    "name": "text/inversed",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20003:10942": {
+                "document": {
+                    "id": "20003:10942",
+                    "name": "brand/primary/light",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.9166666865348816,
+                                "g": 0.32944366335868835,
+                                "b": 0.20625001192092896,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10963": {
+                "document": {
+                    "id": "20008:10963",
+                    "name": "UI/Grayscale/secondary",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.5083333253860474,
+                                "g": 0.5062152743339539,
+                                "b": 0.5062152743339539,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20668:7336": {
+                "document": {
+                    "id": "20668:7336",
+                    "name": "text/link",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.0117647061124444,
+                                "g": 0.4000000059604645,
+                                "b": 0.8392156958580017,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20472:3365": {
+                "document": {
+                    "id": "20472:3365",
+                    "name": "header/l",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 75,
+                        "height": 25
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Bold",
+                        "fontWeight": 700,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 20,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 25,
+                        "lineHeightPercent": 106.66666412353516,
+                        "lineHeightPercentFontSize": 125,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20003:11700": {
+                "document": {
+                    "id": "20003:11700",
+                    "name": "brand/primary/dark",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.7166666388511658,
+                                "g": 0.23184168338775635,
+                                "b": 0.12541669607162476,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10976": {
+                "document": {
+                    "id": "20008:10976",
+                    "name": "text/error",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.8156862854957581,
+                                "g": 0.25882354378700256,
+                                "b": 0.10588235408067703,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20792:7350": {
+                "document": {
+                    "id": "20792:7350",
+                    "name": "elevation/light/60%",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.7686274647712708,
+                                "g": 0.7686274647712708,
+                                "b": 0.7686274647712708,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": [
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.10000000149011612
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 4
+                            },
+                            "radius": 8,
+                            "showShadowBehindNode": true
+                        },
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.05000000074505806
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "radius": 1,
+                            "showShadowBehindNode": true
+                        }
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20792:7349": {
+                "document": {
+                    "id": "20792:7349",
+                    "name": "elevation/light/40%",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.7686274647712708,
+                                "g": 0.7686274647712708,
+                                "b": 0.7686274647712708,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": [
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.10000000149011612
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 2
+                            },
+                            "radius": 4,
+                            "showShadowBehindNode": true
+                        },
+                        {
+                            "type": "DROP_SHADOW",
+                            "visible": true,
+                            "color": {
+                                "r": 0.1882352977991104,
+                                "g": 0.1921568661928177,
+                                "b": 0.20000000298023224,
+                                "a": 0.05000000074505806
+                            },
+                            "blendMode": "NORMAL",
+                            "offset": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "radius": 1,
+                            "showShadowBehindNode": true
+                        }
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10977": {
+                "document": {
+                    "id": "20008:10977",
+                    "name": "text/success",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.07450980693101883,
+                                "g": 0.501960813999176,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10965": {
+                "document": {
+                    "id": "20008:10965",
+                    "name": "UI/Grayscale/quaternary",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20127:7569": {
+                "document": {
+                    "id": "20127:7569",
+                    "name": "UI/alert/dark",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.6958333253860474,
+                                "g": 0.39398765563964844,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10973": {
+                "document": {
+                    "id": "20008:10973",
+                    "name": "text/secondary",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.4588235318660736,
+                                "g": 0.4588235318660736,
+                                "b": 0.4588235318660736,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20668:7241": {
+                "document": {
+                    "id": "20668:7241",
+                    "name": "sub-navigation/s",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 48,
+                        "height": 12
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 12,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0.48,
+                        "lineHeightPx": 12,
+                        "lineHeightPercent": 85.33333587646484,
+                        "lineHeightPercentFontSize": 100,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10972": {
+                "document": {
+                    "id": "20008:10972",
+                    "name": "text/primary",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.14901961386203766,
+                                "g": 0.14901961386203766,
+                                "b": 0.14901961386203766,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20003:11701": {
+                "document": {
+                    "id": "20003:11701",
+                    "name": "brand/primary/darker",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.637499988079071,
+                                "g": 0.199060320854187,
+                                "b": 0.10359376668930054,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20003:11702": {
+                "document": {
+                    "id": "20003:11702",
+                    "name": "brand/secondary/main",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.14901961386203766,
+                                "g": 0.14901961386203766,
+                                "b": 0.14901961386203766,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20003:11703": {
+                "document": {
+                    "id": "20003:11703",
+                    "name": "brand/secondary/light",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.24166665971279144,
+                                "g": 0.24166665971279144,
+                                "b": 0.24166665971279144,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20519:3941": {
+                "document": {
+                    "id": "20519:3941",
+                    "name": "inline/s/hover",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 45,
+                        "height": 18
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "textDecoration": "UNDERLINE",
+                        "fontSize": 12,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 18,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20519:3942": {
+                "document": {
+                    "id": "20519:3942",
+                    "name": "inline/s/active",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 45,
+                        "height": 18
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "textDecoration": "UNDERLINE",
+                        "fontSize": 12,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 18,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20003:11705": {
+                "document": {
+                    "id": "20003:11705",
+                    "name": "brand/secondary/dark",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.10000000149011612,
+                                "g": 0.09916666895151138,
+                                "b": 0.09916666895151138,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20003:11706": {
+                "document": {
+                    "id": "20003:11706",
+                    "name": "brand/secondary/darker",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.05416666716337204,
+                                "g": 0.05416666716337204,
+                                "b": 0.05416666716337204,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10962": {
+                "document": {
+                    "id": "20008:10962",
+                    "name": "UI/Grayscale/primary",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.14901961386203766,
+                                "g": 0.14901961386203766,
+                                "b": 0.14901961386203766,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10968": {
+                "document": {
+                    "id": "20008:10968",
+                    "name": "UI/success/default",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.07450980693101883,
+                                "g": 0.501960813999176,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10967": {
+                "document": {
+                    "id": "20008:10967",
+                    "name": "UI/error/default",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.8374999761581421,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20127:7564": {
+                "document": {
+                    "id": "20127:7564",
+                    "name": "UI/error/light",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.9291666746139526,
+                                "g": 0.10065972805023193,
+                                "b": 0.10065972805023193,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10970": {
+                "document": {
+                    "id": "20008:10970",
+                    "name": "background/1",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20127:7565": {
+                "document": {
+                    "id": "20127:7565",
+                    "name": "UI/error/dark",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.6708333492279053,
+                                "g": 0.0642881989479065,
+                                "b": 0.0642881989479065,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20127:7567": {
+                "document": {
+                    "id": "20127:7567",
+                    "name": "UI/success/dark",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.06353407353162766,
+                                "g": 0.36666667461395264,
+                                "b": 0.010694444179534912,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20127:7568": {
+                "document": {
+                    "id": "20127:7568",
+                    "name": "UI/alert/light",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.9372549057006836,
+                                "g": 0.5960784554481506,
+                                "b": 0.15294118225574493,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10964": {
+                "document": {
+                    "id": "20008:10964",
+                    "name": "UI/Grayscale/tertiary",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.9291666746139526,
+                                "g": 0.9291666746139526,
+                                "b": 0.9291666746139526,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20003:10941": {
+                "document": {
+                    "id": "20003:10941",
+                    "name": "brand/primary/main",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.8313725590705872,
+                                "g": 0.2705882489681244,
+                                "b": 0.15294118225574493,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20519:3926": {
+                "document": {
+                    "id": "20519:3926",
+                    "name": "inline/m/default",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 59,
+                        "height": 24
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "fontSize": 16,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 24,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20519:3927": {
+                "document": {
+                    "id": "20519:3927",
+                    "name": "inline/m/hover",
+                    "type": "TEXT",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 59,
+                        "height": 24
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0,
+                                "g": 0,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 0,
+                    "strokeAlign": "INSIDE",
+                    "effects": [],
+                    "characters": "Rag 123",
+                    "style": {
+                        "fontFamily": "Roboto",
+                        "fontPostScriptName": "Roboto-Medium",
+                        "fontWeight": 500,
+                        "textAutoResize": "WIDTH_AND_HEIGHT",
+                        "textDecoration": "UNDERLINE",
+                        "fontSize": 16,
+                        "textAlignHorizontal": "LEFT",
+                        "textAlignVertical": "TOP",
+                        "letterSpacing": 0,
+                        "lineHeightPx": 24,
+                        "lineHeightPercent": 128,
+                        "lineHeightPercentFontSize": 150,
+                        "lineHeightUnit": "FONT_SIZE_%"
+                    },
+                    "layoutVersion": 3,
+                    "characterStyleOverrides": [],
+                    "styleOverrideTable": {},
+                    "lineTypes": [
+                        "NONE"
+                    ],
+                    "lineIndentations": [
+                        0
+                    ]
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20029:15096": {
+                "document": {
+                    "id": "20029:15096",
+                    "name": "Large Desktop (1440px)",
+                    "type": "FRAME",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [],
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": true,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 1,
+                        "g": 1,
+                        "b": 1,
+                        "a": 1
+                    },
+                    "layoutGrids": [
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": -208,
+                            "visible": true,
+                            "color": {
+                                "r": 0,
+                                "g": 0.6392157077789307,
+                                "b": 1,
+                                "a": 0.05000000074505806
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 32,
+                            "offset": 154,
+                            "count": 1
+                        },
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": -46.66666793823242,
+                            "visible": true,
+                            "color": {
+                                "r": 0,
+                                "g": 0.6399999856948853,
+                                "b": 1,
+                                "a": 0.10000000149011612
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 32,
+                            "offset": 154,
+                            "count": 12
+                        }
+                    ],
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20029:15097": {
+                "document": {
+                    "id": "20029:15097",
+                    "name": "Tablet (768px)",
+                    "type": "FRAME",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [],
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": true,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 1,
+                        "g": 1,
+                        "b": 1,
+                        "a": 1
+                    },
+                    "layoutGrids": [
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": 36,
+                            "visible": true,
+                            "color": {
+                                "r": 0,
+                                "g": 0.6392157077789307,
+                                "b": 1,
+                                "a": 0.05000000074505806
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 32,
+                            "offset": 32,
+                            "count": 1
+                        },
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": -23.5,
+                            "visible": true,
+                            "color": {
+                                "r": 0,
+                                "g": 0.6399999856948853,
+                                "b": 1,
+                                "a": 0.10000000149011612
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 32,
+                            "offset": 32,
+                            "count": 8
+                        }
+                    ],
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20127:7566": {
+                "document": {
+                    "id": "20127:7566",
+                    "name": "UI/success/light",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.20450440049171448,
+                                "g": 0.6875,
+                                "b": 0.12031251192092896,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10969": {
+                "document": {
+                    "id": "20008:10969",
+                    "name": "UI/alert/default",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.8588235378265381,
+                                "g": 0.48627451062202454,
+                                "b": 0,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20029:15098": {
+                "document": {
+                    "id": "20029:15098",
+                    "name": "Mobile (360px)",
+                    "type": "FRAME",
+                    "blendMode": "PASS_THROUGH",
+                    "children": [],
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "clipsContent": true,
+                    "background": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 1,
+                                "g": 1,
+                                "b": 1,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                        "r": 1,
+                        "g": 1,
+                        "b": 1,
+                        "a": 1
+                    },
+                    "layoutGrids": [
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": 52,
+                            "visible": true,
+                            "color": {
+                                "r": 0,
+                                "g": 0.6392157077789307,
+                                "b": 1,
+                                "a": 0.05000000074505806
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 24,
+                            "offset": 24,
+                            "count": 1
+                        },
+                        {
+                            "pattern": "COLUMNS",
+                            "sectionSize": -5,
+                            "visible": true,
+                            "color": {
+                                "r": 0,
+                                "g": 0.6399999856948853,
+                                "b": 1,
+                                "a": 0.10000000149011612
+                            },
+                            "alignment": "STRETCH",
+                            "gutterSize": 24,
+                            "offset": 24,
+                            "count": 4
+                        }
+                    ],
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            },
+            "20008:10966": {
+                "document": {
+                    "id": "20008:10966",
+                    "name": "UI/Grayscale/disabled",
+                    "type": "RECTANGLE",
+                    "blendMode": "PASS_THROUGH",
+                    "absoluteBoundingBox": {
+                        "x": 0,
+                        "y": 0,
+                        "width": 100,
+                        "height": 100
+                    },
+                    "constraints": {
+                        "vertical": "TOP",
+                        "horizontal": "LEFT"
+                    },
+                    "fills": [
+                        {
+                            "blendMode": "NORMAL",
+                            "type": "SOLID",
+                            "color": {
+                                "r": 0.8708333373069763,
+                                "g": 0.8708333373069763,
+                                "b": 0.8708333373069763,
+                                "a": 1
+                            }
+                        }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "effects": []
+                },
+                "components": {},
+                "componentSets": {},
+                "schemaVersion": 0,
+                "styles": {}
+            }
+        }
+    }
+}

--- a/packages/cli/src/commands/styles/lib/__mocks__/publish.styles.json
+++ b/packages/cli/src/commands/styles/lib/__mocks__/publish.styles.json
@@ -1,1 +1,1133 @@
-{"data":{"error":false,"status":200,"meta":{"styles":[{"key":"257d2e53f5b342bafeb497a294e38c1ce4e4c298","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"21291:7794","style_type":"GRID","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/eCZ/jqo/PDaWSnIvQhr7vZ7r/style_thumbnail_35.png?Expires=1653868800&Signature=XTNOUGJladC4F2DZtcvdS8FRkXgJk41McVUUMKSBGuvcLEi4sXk6KdFhU3EjQ4ikvTs4~xDjXPphsWfaukk-FZ1gftRLWMTgnEzmBmtnwzzB4yCnBMTNsdcEOPbYVEnGnvFJfd2PvA2aRk0pCAUDpTw4QMMEvxpbwq5aGjpei4Hpmbqj9jSIOPUQ0Y~B1M76i0k~4wdFiAEiwXG2oCgggGOuRI2W682-C1MuI8oLwGplBXf8l01G2C~mjCv8EZlF0Xp5ti3~SbJwWEunWEKPrD4moT93Nuyp6-~iblGIw6Fz-PppsVsy7xmzHxoYrjFY7VHGsWKHfRklU~C0FeFciQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"Annotation Grid","description":"","created_at":"2022-05-09T18:36:06.798Z","updated_at":"2022-05-09T18:36:06.798Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~|"},{"key":"002402f1847b52b00967ce1494b93505c4443704","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20792:7357","style_type":"EFFECT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/6Qy/CJV/NvnbRNLv1kW84uys/style_thumbnail_34.png?Expires=1653868800&Signature=Zx3T0FPEp2NRc9i6b4a~NiTNsQ0YpMKpsxvtJ21R9wIqbQPfFIRD6iOjIaVq4sCR0QS0DOBlPHgiz~poOBawSOtFMCe~GPwSPAa-Wp~6pRpj5DY89e9R00TUwYjjA8y2Qn3kZVYcU4wXOqFeIQHeHd3mYlPDf5ELhoGFiATQ4K2nElYCRlXx2tegsRJ-FB3iLNvrs-Ym7e5w1XsgeCCbjCDdZM2wUC3DBmqRWc6V75hPX-5aoYldm1V09AdJ23PmVbxfXITVDPhpKu6f4NsMGZ~9MGxYp7--b45BCXzmaLvB7gzPl45OpIR7neznErBKinaCjtBPLCFQq472O-82eQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"elevation/light/100%","description":"Elevation & Shadows Token: --elevation-light-100%\n(#Token, #100%)","created_at":"2022-05-09T18:36:06.790Z","updated_at":"2022-05-09T18:36:06.790Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~wY"},{"key":"686c7f2cc60333d4738d29d1331ec75dbc66bd70","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20792:7356","style_type":"EFFECT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/Tsb/gnW/xLQOTgNqw4AqR89W/style_thumbnail_33.png?Expires=1653868800&Signature=Nb9LsjMQ9CE~EFlp0H1NaQz9ogZcJ-pU5syx4j~b0rulgCFR3IAx1Jc-L3FhW5yLLK6paAestEDdYrb-0mATjR4HWg4IMFLOrAMTiLFy-JQdZA9HJP55vzTFaHp01BeofblVxObHC1DoVnWnXpPFUCMxTLybOClx9TwwCaYK6mEn5CbfEpWK7sfIMicT0Cz2Ok-ySUCf2zQoiezKF4Md6YQ3q0BHvGP9JwR~skQELgXP~VzX69rhyZa4cykoiD8c7~RnS4EomSNQMgZu8f-6O0T3kzUv22cdwjszGhhnr6Nd8I~wzzZ1v2ySRrgjPfqDSwTJPOZnLNIRdiTqwDq~~g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"elevation/light/80%","description":"Elevation & Shadows Token: --elevation-light-80%\n(#Token, #80%)","created_at":"2022-05-09T18:36:06.784Z","updated_at":"2022-05-09T18:36:06.784Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~wX"},{"key":"82a866634cc3cd71193b462a15c51e0618df6079","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20499:3480","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/3pk/FVp/9HaqCIyiNJXBKTkH/style_thumbnail_32.png?Expires=1653868800&Signature=Qs2qyu0rVFfJH7g~mxHShczLR5MyJ6~oguUMjMOUgGwhQczS7r92CwNCcRNHu8koW-DnMNfR8cBCJnbS0qDpddmOoSqRS-vBq2LKag9wnanq3StyCiE1vqa9vPxheO3JJU2D0BINtdEooBfadSffp9v3ZcCMQDSnUtOr4gJAtw26EFuZLZiX~SqNIbNU2mrH5QBBES2lT2dGXvnwwD8e6s3cap0zT40MaaN29VMmkRr~pSdGcSNqyxB-amO5qwLQuJRO~ZAP~E2q3Q8MG5lbQtgK01e2e9dV7Pk0xaTKKaNCIcFUn7Rx89MZbZC1GPL2RmBDpJAN8oe~U3xCtj11pQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"labels/s","description":"","created_at":"2022-05-09T18:36:06.778Z","updated_at":"2022-05-09T18:36:06.778Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~quO"},{"key":"a2df7c0f65f0c1f453ee0daad6fd39e82d3500ba","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20499:3498","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/bLu/bAS/Rxpxec23xkwOWZiO/style_thumbnail_31.png?Expires=1653868800&Signature=dcrLu5Vx1JOz2mf4Bx1wxz-Hfd8BwmtI~YjjV72VmpZL4rCQiXN1G95hDa2Wm1zRgfaJYnmbjOimW8-rna8zPkYsuq0~oMkY46ABnycyLseLz2Q1e7siV0aCYJzO4WBP3i6QsRuMTotSXxF3kgYwdtwfDeJtsJNc3enS~tpxoSO~6DkpZJJ4mq0a3IpOZvrBaHKqcGGYIkM7vYCJkXoW6C08I6anq~pD-Ydf1o9XSaJDWfGgHNusSzxUG8KEBam0wvc0JR9aF6wiOe-AbryRtZ5sWx6ooWQw-3YY16RZNBGyLlZdZHGqmnAcVuglr381qOrSdWdvP42qVI-2dCxjzg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"hint/xs","description":"","created_at":"2022-05-09T18:36:06.772Z","updated_at":"2022-05-09T18:36:06.772Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~qw"},{"key":"84d8252f0c4d2188a7d4c12802f0d6017cd2a120","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20792:7348","style_type":"EFFECT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/p5B/0bW/1p4pIuNc36XWENhn/style_thumbnail_30.png?Expires=1653868800&Signature=VrS9UgnQkcW42CzL21s~EPl30PVyw6py7buKOv8AIphUGdd~fOEQB9nNs1GrWau-QlhAkoujUkockW4Z4PRUE9azSP3G9wV06Qxk9qHJOJXIYzdaai7-gI~ONDf-c93pByPj6S7XpOuJqM5iduruPuUuOqYkCesQfGb2Iwe0YiQIOvaVHCbRlmBLEm5xPjpqfTypjExKQALNK9s~4IQ3UY2xg4whEHNb1RSbG~KsqezK5MJGl9cHg8ckYWTBxM-oDSa46y7zAhlU28GYGDBHV9T9tA13w8rdJxiX9NE72V-M64MuWetH7n7dWh6ekzm0q4NkLCCP2rzuzPw-isxsEw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"elevation/light/20%","description":"Elevation & Shadows Token: --elevation-light-20%\n(#Token, #20%)","created_at":"2022-05-09T18:36:06.767Z","updated_at":"2022-05-09T18:36:06.767Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~wU"},{"key":"255951ceef11c2eaff33378a2b605fa926ae69c0","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20474:3360","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/akq/RU0/tlorP8eRJzQ4XYvU/style_thumbnail_29.png?Expires=1653868800&Signature=THvXJjQV-KIZCeqiXfUMEfE1vFadig8JDsNX8QpZeBejlRUs7Y3IUlyn3Wu~NRO1iLGwFC3REkLKCQyu268a6jnJUJt6VQfygHqly6MRqsK4jkb5VsNfGqxLG9QUUJF9OVnfPE-lHd~r6oPcWP6mNKaSJ3Prd-x-fdcFRlv2ceGbk~0DRIOly5yKPR3aNpAc0mPiygXrxKRqqShQ7eWh4rvDygBewJzZsgYaXTnnT2lgmYlVRVyEipf-5HLAvtkL8mn-mV1FasswkpIE3Hjp2W2x01afVufseF0B-sUarv3RAWkXkSVeEGtcx5nqHczi3mffr2kvL38savUIGHRv7w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"paragraph/m","description":"","created_at":"2022-05-09T18:36:06.761Z","updated_at":"2022-05-09T18:36:06.761Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~qt"},{"key":"883829dbe6487e0da67e96f89bcd2794dabf58c6","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20474:3361","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/x6x/h7H/LPTt5jCMEWvWhBBt/style_thumbnail_28.png?Expires=1653868800&Signature=GYf6gPn~YmfVGMN~ihbSCQrVLk4be7Pp5tk9Ohd-pErLb53-yV1cwPdM6Zp5r96Wr4omOz8nBSuoQdSIT83nqMUs52afa6ZE36eJwNiruQRdhrliUR9jI6Sg-FVEgye53ns1Uvj9GrL8WrvgQoy05NPFeoagMTYgeZIl6DPkXHcomkX4Ytfiv4pt2RE4fEsqR3LB2qrxVaj9WDIwOYJZ6jZTOYBX0w6PCggmGCpqiGOPlaKfRMrDWixzzHUPDMza2pcF6jWgbsdQj24hNV6~txx~EzohsYkHQ78~SDRijF3h4yG5Gf0MURl6suKIEDIaF2FKJXj-ZTPm4e~T07C3Aw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"paragraph/s","description":"","created_at":"2022-05-09T18:36:06.755Z","updated_at":"2022-05-09T18:36:06.755Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~qu"},{"key":"3e19202910d331f355018d61d5245d15ad3e61fa","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20519:3988","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/wru/fls/5Re3D0nXPcgTe4a5/style_thumbnail_27.png?Expires=1653868800&Signature=O8HSkwxjPhfaUwixLXiakWmfxoCQsVf3JPxzvsMp1AlriQdpZcDob24EFCxNCMpizSIj0ACDlCEtEGEAmcWbGcCJq~2Gr1bTKemZXMyy9LA4Blnx6l6unFxdNOCH~-aQuPGBCMdug~AoNoSiLyJzYZkxGBOjkaGCL5DHrKawb-5oaFGC7KMwsZZdwuv-FtmenOvK1NDWkVbhB7WSYoQsnAvuDsSi3QSGirJNGyZc2b5lymTN1HQWCl8vTuaqVKa45lQXsHr3~E9gsQN2Bq3GJEy3v-RGnQMJduycOq5unL-aEqg6h2iDvRxyPq5uuKEPXMJG5are1NiBVHCMsAcsYA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"navigation/m","description":"","created_at":"2022-05-09T18:36:06.750Z","updated_at":"2022-05-09T18:36:06.750Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~Q"},{"key":"ddb12189b15f6d1e6dbba3ab088d870ec3066e8e","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20472:3360","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/DUg/45X/KiyS2CI0pIydOC6F/style_thumbnail_26.png?Expires=1653868800&Signature=X3ABpN3ySOZBCplw6yW5VBFvFIh52CWuqXJv3UJ~xiXpsFwM7VOgyLUM75xRv2q01bNDam3wQAZZpQvTsXFjxx0192RE6EDFP1-Iy3h4ZCqKERsDCn9uRle~8OlsTyuKf3ZSkz1UYtJ74bzDBUYS-6dhRwCRK5Zn~kC1Y-0TlAGtdskjXaOs51sqZzyd5vPkrC2ZBReGCqSLhRW8NTJhVVCfCSN~ZsT~qZTilHvMCfwqi0eqdw3UovtuIUgHXVOrdiQJOhONDuvq9SgeDrrd5i13HQWgzT9OFjyX9S~Pexc9oQewYNlqpidvT~5I1sF9NSka~wfKe~MKJT4LmhgLmg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"header/5xl","description":"","created_at":"2022-05-09T18:36:06.745Z","updated_at":"2022-05-09T18:36:06.745Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~ql"},{"key":"643a2f079c1ff445d0c7904f5b9a4ddf73f1d891","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20472:3361","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/sZf/K0r/akH2H1HGYATugFO2/style_thumbnail_25.png?Expires=1653868800&Signature=WzJBxFab115mM9vOhCBsMvoQqtYMM-y9Jbanh1qZ9I1u-lVxEsU2wUxAm5pI8-WKR9SNdL7ZY4fWgWfgUYD6IyQkAygF9YV7-9oA2Dfr9Zg4Ut0sXgkA0mZEO8Gl5TicVi-x0W8TFtlVroaen4hRRwzsOcmlu5QWBIoVCnZM90~4a2dCdX7H5WHqblT5ECKeKwVYPOA8S06btWtwYvCma0COLUZKM2YP4aPv5x2Xd8P~4I8IrwW4RcPjmVQNtjoefdvJfYBeLzk6IOaw4211cnPiaqy5bq0G5mK8PgzG~pj2iVD5E68rwSYw8Xq-uBuNC50VLQ7hZa3cjOI891sufQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"header/4xl","description":"","created_at":"2022-05-09T18:36:06.740Z","updated_at":"2022-05-09T18:36:06.740Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~qm"},{"key":"796182139ad95fe65630898b351054ac68310772","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20472:3362","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/Mij/bbs/X9IeMTuM0Cr1EZrL/style_thumbnail_24.png?Expires=1653868800&Signature=N~Q34WVYETnvzv4FDZ8DfSTE5mQNBR8eYuNYGnzeNV3J6valmlxLp4MPuqX1~lcV-RlvTCDXcZHenbWezXaX5m4p9dVjQE944Zw47wd2jKY5z3TvHFLivmL60cJHAXxOdgkvOyPXcv7r1CsIRHacW~trrH6hjGsEpckewcBPwOMCFme-xXs1xCK3STqFNIL8LpsMmXwQx6eRTDa4pdLoFnIQJtIyaFyQmAZBbeySM40du~Iak4Gz3ItNg2wEur0nSCuXFkEbOTqgRQ8YbZFzMQihu3IyhHuq0Z5yi1GYXyw1oUBnVYAzBLdy7bpVqX0fPg8ugwFy1b9tTuhBRkHatA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"header/3xl","description":"","created_at":"2022-05-09T18:36:06.735Z","updated_at":"2022-05-09T18:36:06.735Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~qn"},{"key":"6a01cde1036049784471d5fda778883b94e98a77","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20472:3363","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/gDF/m79/gKPj6MyR0ytYSDWn/style_thumbnail_23.png?Expires=1653868800&Signature=RvSe2ioQTEaMRuhW-iH~yahZD62arpErVF5T8HXfWfTFoLCHJOmTQwJrn-J5kTjr4WufzpqUSlGLSnqZ3AXZKxzjRNYHSZjOJq8b7mKdt~rWlR2zVbwQhifxyN61QE9SlfKQEHjLU4d-ZG93ZsprXW~v5HQfCzboPllhC43LH4SdAkl6DJQHEuQf6r-1RQjYGXvsWLsFLN3bsfes8BNrst7upObcjMFx8m-Y5nQj~uIwgvXzHVaBMFaIDwDJ7fq9Fd9r4KM9ILxHcRZsSrY4gppOLTAVGVx3A8yE14DTqJVKYsi~A~voBrRc1w7SS8xTDGuQvOt1cGKVwDvrSldM7g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"header/2xl","description":"","created_at":"2022-05-09T18:36:06.729Z","updated_at":"2022-05-09T18:36:06.729Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~qo"},{"key":"b690cbc53e8d99e62336d62bc9160e07181740f2","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20472:3364","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/6FL/fjF/9piwfCLOcBVEFptE/style_thumbnail_22.png?Expires=1653868800&Signature=RwQwKzTq52JPG~9n3VSEBka-t2FsYh1qcOBCZ74RwuVSL-krKMMDK2rbOjweftDDTskdbBlBhpIUa69DknuH-AEAgIYaVEFy8EuGy4FkcTnCJ46nm7W84sDB-6w4hU89si5Jz6ufWsTqxvCY6JDDcdO27Q9oH1Z3dnbgz0gL8nkA7fsHKvW2Vsb8I2DViFMiSqVTTnc2LGTfxvl2vJ6e9XzEtzN95LEgzRXKv367Ci4lyABwIA~SSd59zJJjJAfndJHoqslFpDqQRIiafsHQoO-OqSIMJhr4ZgJNKiG0NduGFEBqaSwPThrK8Uf7UlC507C19W8zhU6OWMkQEsC9QA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"header/xl","description":"","created_at":"2022-05-09T18:36:06.724Z","updated_at":"2022-05-09T18:36:06.724Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~qp"},{"key":"f021a110bc7e1d4bd448468a7ed795576784e561","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20519:3939","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/lCH/HJq/b9oYLFENrKsA2Zw9/style_thumbnail_21.png?Expires=1653868800&Signature=DtolbWW3htCnLSnfKZ72Mh5fIFjVLuOrKh76ZNvfjlSgtknAZkSm~byhLRljwNw2Ro6XJ9BOcdgbiNZ4bmM1P0qCTNnGr8jFnnLcEAH4RiJs5ZO4a6TnKIfLbqjeNECYVwrqb1lVjXA-tjchPL0iZyfYTIGnGX26A7GWjJVaA1K2~Zj68m2pMIy8cz1~lOG2surSsRB5mubEDWMlkzGvPqnvQJU3UWzy49EcFHHwI6hfpBIrDp1GLcqA~A0T~mpc4jQdK0wuz5zaRFUGIQwF9Ik8MnwNHg6kXcQTydRoZvFTXdtF47YOVZqn2TKQpS3~mLFtmczFfQ3c1EVK-nsxPA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"inline/m/active","description":"","created_at":"2022-05-09T18:36:06.719Z","updated_at":"2022-05-09T18:36:06.719Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q}"},{"key":"368e7108ef7ff5ce2ece6c6db2c80cddaad0d731","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20519:3940","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/OyV/RWL/1cWJh0hPk6yNPrFm/style_thumbnail_20.png?Expires=1653868800&Signature=c12mtO6HMxqEbRRuEit~UKXCuBzXU04DaJiU3nLsHBY0Irqxcfdhr34MRi6WycMvESq7klCGglOi2g8lHawvZMLy1O0ESJZVhC6B6qlQj6r7T~EDGerieoZp3kY9ELO6Gnw0Rv3OuLhcwxzDvjkTwTQCQ8jJzrtWk35Gzs4IRpdTveUObF8Q7I4LcgsNLD0aQCiPQc16GS-K-3VvO-vzKIe-Rx~W4zecRjnum~ubEhRjPN5AuPx3odS0cP-NZKSPey0VK1CTVjCGmLu2~oWZ2A4mzx-FCdOE4D-itN0EAXVptYG6Sv2TlRswpyIfDMZquXKcxSkXyoGe40X6A7d0Vw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"inline/s/default","description":"","created_at":"2022-05-09T18:36:06.713Z","updated_at":"2022-05-09T18:36:06.713Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~"},{"key":"cd3d8d595500ce21c7824db2c8a1da1b4d300f1c","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"21287:7661","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/Cyp/Cn8/7XrvcCWX7tSzNnmJ/style_thumbnail_19.png?Expires=1653868800&Signature=gwxjIJSio-0mzRQoStbGkc0CQjc084aOGdS1s9X2w8Xaf~1dUcHWC7piNCwTwf9RUWXJmzbDuToK~NVk3V74uYhbDuOQJNwZThpwAAEUof3ova~5mjnMA~p1esmLvJ4zxU8wTSU-02wddgu0freR4JLYLCY6wrNT-IM9-JTpUEKhU9mDomx0JdjmOgjox9UDUCdN-TVh70MyznxJmp~9Qf-YWBoGxhX3WJooHgnP7iZ0Uj40IC4Id4gl6kvQCtNOYLq9JThYOIwd3IVQGzQD8ZlghsTNNqD4rMoPPoEiajblOqd866jN7bO2sd24jzClo-GegJNQ3cCAoWKErEiasA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"- annotations/Annotation S","description":"","created_at":"2022-05-09T18:36:06.708Z","updated_at":"2022-05-09T18:36:06.708Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~RO"},{"key":"6cb98feb81542192b424e5e05019701c7878a985","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"21287:7662","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/id6/Dgb/TAvWjQ1cf5o63hKb/style_thumbnail_18.png?Expires=1653868800&Signature=PMIK4FVsMetV20ci-cWzFYJiTObP-QVLQblDaA-ZKsszeS01X-fpsTbEcOYZLkvrPPrYXA1916sEtiQnBLfs42diukj8JDF~o6iWXHVCcyRUvhWDRKAt7j-O3o6-lcA7wOu-nRxr5gcPHBsDKgb8OXwqaMSF0WEtYVEVqcma2VTTcgDA24hTtiAeCEevI3XoBKoJukyxpnviDk48i5SytCh6hY7G3DhskDuYr5JGr6QB5DGC6xON9ps~FJNPXmFKWCTMMLS-xLIj2cueS8bErcziOKkQNQMkvFPJYeYFNKxByy~wIfZUuO7d0pvpqw0j3AlN6Hxf1Guk1ttfS9bOmw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"- annotations/Annotation L","description":"","created_at":"2022-05-09T18:36:06.703Z","updated_at":"2022-05-09T18:36:06.703Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~SO"},{"key":"d69043021a6f3cecd9b580fb59435d5a624cc68d","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20521:4154","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/hXe/JS4/TpEoKtzZrBPcViGB/style_thumbnail_17.png?Expires=1653868800&Signature=eWVD71f2ACJWXBsbl62SgfSD45DoWHwMXrnmeNdF9f0qWORF~qzZovqDNuARfuzrFexSjnzGDuEZBlr6yVs4xRbeXMG5FBIcwHLu8Ja0lTj-WivnP2eYR0~x0XRTBRV6DqRtPQecx~xk7zqbPLXhzUhEYhawpmQEOfJiZ9kz5VLOJgFo8KTcuaXdfO3t4ATqKOOiaNtPmzXIeMuK2dnkDfQ~K-g7L1f8-0Gg0SBrYokq4uq91na4dWkhfBnVb5gA4IH4~Qs0pStBN4~vgDyTUTpKomPUuVU7nszePHDIgiXHcUsmUJSjfBo9Vjn7~OCuzuf~xMHVlHP4SZlqUj-xgA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"labels/m","description":"","created_at":"2022-05-09T18:36:06.698Z","updated_at":"2022-05-09T18:36:06.698Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~qu7"},{"key":"0021faefe5985d3784e751588729bb25061baf46","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"21287:7660","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/EzL/nD2/wyJYGbXLgw0nHLiI/style_thumbnail_16.png?Expires=1653868800&Signature=GC89Rl4vQL-tdVYYBWZCiGbCo8n8W9JGvBb6MbhIIg1KQyPl~CyqooI1HsHb1mefBTRyqzOc1dk-Yr61yolGyzc5ycJaDu4hFfqe8wK9tL~1ys5cr0UM0NBOHjx0~GWBF7jt3knz3sQLLVU-lvHMB5cULomLG4qvRxzE5xg-PcioKt0qKDHEbGJtIr7bYi5iOmA14yQaRZDo7GwmHHZiqMTOlp5GBhxdQDX1FXdQls836IQ4s2G6-yOk9udsr~JptdLGXCzRa6r1~tGg-8W1y55bwVva8sZKiff6~~IzA7RHpFbJJ4yqoNu6EwY2gOBzFHfCNb5r5gaA5frYKSFauw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"- annotations/Annotation M","description":"","created_at":"2022-05-09T18:36:06.693Z","updated_at":"2022-05-09T18:36:06.693Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~QO"},{"key":"64d5eb8c7ec8db18203a0f17917b0ee690214d2a","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"21291:7423","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/9rK/c12/rYImSieW9E50RU8j/style_thumbnail_15.png?Expires=1653868800&Signature=ORb822ZCjnB6w5zyj7qYGoSb8EZGYBY~aqAj4mktNHN46nXx1KaqBjjICifOEEJMZtBDIYfyZFp-1fXwLRqJ5MalMyJHesqrb1aBsVC4rpWojpLG7Nkp~j0LSDqveuzYGWK8wFmzdjoG-SbxXkxM0CLnQJp8kw-R8SQpT9jWTVR5W~fhFeEW0NvlOJzIVL1Jx-kamw2T~S~oIJErYxVE13C6nRKepPgBtPOiEJ3EiBwI~CLJXsW9zyK0CJn3Mo-dAnJQBfAmrpK1AumuZwlKjg7-MrfzmVYdGIE~O83YWLOr2RV4SPPKSMr0YQsQ5fZqfbW~biEu14Am81R3bm1UNg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"- annotations/Annotation XL","description":"","created_at":"2022-05-09T18:36:06.687Z","updated_at":"2022-05-09T18:36:06.687Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~Sf"},{"key":"345f2b5d0aff165a9e488eea44bbf78f5952dde5","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"21440:14880","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/aCs/6Wi/foGtkU9O9PZYcK1q/style_thumbnail_14.png?Expires=1653868800&Signature=aRYyMRbnumqAD4stMkS9FaQk37vVVe43lo9cmJyI6I53lZitY-UwrppwUMW3uX6-pvIr9AsNhhdC7F6gujRYr2MipJ-jVWYVPfy5mKNd9U4-6IuS90fnjkSWz4XnafaJJfbNvVmG7mQvLSo9BI8UPa5lYR9ht35QGM~OGOZSmWkDjpdEdGgtOhel4BaJ6JeUoVVDcAvsxxg4IlBo6A7feOs7-p8--u4kr1-VLwkD18DPSXg6Bi8OuW~JwIQO8m87czvGtVds3V1mZ28a3TGIHjd~6hdrmFvGzZAmPTEiuZqQuuzv89Gt7az0x8hDntnL86HMshyjLsWKhu3G-3gIag__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"- annotations/Annotation XXL","description":"","created_at":"2022-05-09T18:36:06.681Z","updated_at":"2022-05-09T18:36:06.681Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~Sg"},{"key":"f9b164d248ace903e06565a46e043f59d051e049","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10971","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/F6D/Yul/Kz923k10gfx20QxL/style_thumbnail_13.png?Expires=1653868800&Signature=GNAxo63ilXJ98Mcyc2cO7QVpEZGnN8kbJfP4kz~8L6qNQ10P1tr3f9GCBoTTxNyny82C8XQvdK0M9zopNlaZbJbIVneZxLlKhfh-aYALC5XqRcfAVy3WrEQwJ7YzmZmqrneP2O1WS1WeeKqdhhv8x1xj9XMJnNrLQ2bsLd8aXE2JJq0~CEjje2cPlZc4YoCHGNI3uBW9XHR9sOzKctiU804kxW1SCJTp8vj5vzc3K7yNmWUYrdhcCK5AJBTdksveKGNJ1qUilFGRXFS0Sv6pdwhI134WjX7RP2kPIxWwB6A68PwwsTLchPnt2qfGh~gU7F7pYUrQEplAV7li~2eK4g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"background/2","description":"Colour Styles: --background-2-colour (#Token)","created_at":"2022-05-09T18:36:06.675Z","updated_at":"2022-05-09T18:36:06.675Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"\\"},{"key":"06a067cbf75e3fda25c50b3dd842a3fcb3db3d22","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20029:15095","style_type":"GRID","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/zEV/gnn/QaY9lNmDFVcxE4U3/style_thumbnail_12.png?Expires=1653868800&Signature=I4pXbj8IjoBciDg9d2lKif2R0wx8fb~vR81itpuIN9pnB3B24~7mwZ2C-3EgiHDPlvSIjZuweMk2FhzHpNuFwtKwH-UTHDh4iR59~auo1ZsCsl5Ud-WEVqB6stYWS1Xf8zkct8Xfz0cR0AWOMnf64FZrqVfdJlM8AcIs0P6jZVXAXIpTMRZ2odjDmTq2sUdU8tf20CNnHWZ2W7Tfsk37ByfntKRJ-zr~-ij72orx9CpYFCcMwi~Rwytxunuclc29w22MU7RHYNMYfYN2RsYCb4H~nOHPBBIP8kDj0vEPcqioiSkPpoNzZXhCRdZJhAhN8Tdmckcp062P9LO-CoIqpA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"XL Desktop (1920px)","description":"Grid Token: --xl-large-desktop-1920px-12-columns (#Token, #extra-large, #grid)","created_at":"2022-05-09T18:36:06.670Z","updated_at":"2022-05-09T18:36:06.670Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~x"},{"key":"9665200a30f37b84b5686d07b8d23ae26f634df2","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10974","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/JAA/eUI/A7uOLd6PZYnzeVKO/style_thumbnail_11.png?Expires=1653868800&Signature=TLi9hIxpuF6Z7dl5EGKSJJqvifm8R1F52Kp~PW-CjwtD9dJ9fwC3pRjzncf~15C1D~ogZ2LIWByokq6z8YrnV-7QuUZJhRJEDsyObSZTxGnk~XBruBjRG64z7ar1P7PA9OFctW7dJsa9F9q~5LlCV4uB~EYGEr6oaXrDfixuyqPrS4Gb6bOyJnQKSmhNMqyU6dwje8pfX~5n5b6BX-VDoMJ2zpOgLZa-tqQUl1uPcjd~tF0bTzpKBi55GAnbCvtCfA2KQfHKWv-1KvXMKQff79KVo0nMS~o4RJlO4qD09BrBzA6JaCPWxNaA377PwILSMuxCVQlxbXxDAvQBEYijKg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"text/disabled","description":"Colour Styles: --text-disabled-colour  (#Token)","created_at":"2022-05-09T18:36:06.664Z","updated_at":"2022-05-09T18:36:06.664Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"_"},{"key":"3fedd2719778ce41e38a0f58ecb209a3a3006d40","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"21291:7667","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/fNd/vsc/VrmfRXkEteNnSttL/style_thumbnail_10.png?Expires=1653868800&Signature=M-DS7HnPCf4VlXDwgkz-2yDb6B8ZMSEEvnAFzQQatwD8cxKCKdbI2B-KYog13bhsEsHo14UaSM60NldXnXOHWKN0hxeqtAdOy2Nyrmiiczjo-yQUznYANLS4rArUCzNgBwAseseytZRibaJ4b7jFIqYq8-0VQFipa7BeCOi7CuIvp4E0328BFQRNWRD7xyYGeyELo5JYWmJYjQNTv3iXn0U4A4XM~~88g7-FlQ8wlZi3byZ390RDAjxCHbEnfnXP7RldDCP9uEYWCFs2tiemATCZ01JnHGw2SBA4K5yOGsD8VTIrvFrt9kpCPeUNMHzds8pM0ipGmVVPm6bo9jyrLA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"background/- annotation","description":"","created_at":"2022-05-09T18:36:06.659Z","updated_at":"2022-05-09T18:36:06.659Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"\\O"},{"key":"11ee8ffd6a463a26d1db2b4c07a11fdc7bd47607","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10975","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/PUU/ThC/kzZcKHooGWIaNVyY/style_thumbnail_9.png?Expires=1653868800&Signature=BFa32YNdR95KU~HNSVPIJc6RsAkJaOUF80vjqYkUpSEw3faLOzPM3CbLUXR2WIa41BXGqYbDqFSYmL0pIsH5g-ne7wUpzeZsM6Despg1lxtxRmiF-WAg2KNKqpxNvoKVxyrum5Agi4co8RGEaslYLqFHUnCHi-rizFFKMv69jfklJHrnfvIYP6Ig~zrMIchxl43O85IMXp4YAT5DvWe8DgV2uVCl5E94mF0ccSqxoMpOR9N51bEa1r8-QRaz3LRBnO4F~JUxz29hjVgZTM07qn7f87r5X3ZfQOaBINPB8N-bLWtmXhIk-YMN-8Kx2hxFx1hQWGDCDv9muXzGSyUGNQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"text/inversed","description":"Colour Styles: --text-inversed-colour  (#Token)","created_at":"2022-05-09T18:36:06.653Z","updated_at":"2022-05-09T18:36:06.653Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"`"},{"key":"c2f61245ce67fef858727d77a065f08e0e3aaf66","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20003:10942","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/r6Y/0MD/NRzUiO5qBn1wHHCD/style_thumbnail_8.png?Expires=1653868800&Signature=dIAdX-P7oClS8K93fONogICJ1bn3YlQbDhXhUn0eE0LJxORlgN47hRcsF2FvttDXevjphYOb98gaD7fvanwoWFx~kFdogV7OS60Yc~r2ltTE2KWzxSZCWbuO2DvbMR9uom-qOw-UXVuzeJeuH~UID5mpOS154jiGdqQwreW2bA9oNTES6iwByLXWmcXqYELJybtKOlzI4-mQp2av~e8VAQwWF5Uzh4HEN4kghpB3rq~0DcS4VnUU8aD60DDI-1yBt8hAqDEDgALgJ~9FEo0G1Eo1MD2ORBE96p2XwT~k9THbZd9H6QI0juGPh0ou5dakTyuP9BA81j4Ap3zxwdKLSg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"brand/primary/light","description":"Colour Styles: brand/primary/light (#Token)","created_at":"2022-05-09T18:36:06.648Z","updated_at":"2022-05-09T18:36:06.648Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"J"},{"key":"8cdc6d36a7823ce891d1e0eac329c22839ccc449","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10963","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/g0h/y8I/mfWv3Jr45f24Oue2/style_thumbnail_7.png?Expires=1653868800&Signature=FVxJVAjju4ckHtf3iE56QDtl9NnH~3~LcXQ8oDRQUKQ4QS7wyoyFpX0MRIusH6GWILN587zLklyqB17RFmdLHqZqXQfeXuBQPl5fQWIMDwj2v4EUlT41JUFVIQzpMrqVoSpDvzkIOeRps3h3x8DUDvZ6cOPGIyvM2h57f8trJDvwhv4GI2uCiPzy4LXnkjjOo37hH7vBAu6PEPtLaLGXyLlfKlgC1dH6XAsFQILHZVPrH-w6rACJ24nuiUYZtcJ0cssVqPaGklKdZcHQOPWPj1StkbjRmvXwy9i0loffJygXuFoR2cW6NC5EKEWkZB149dWvAhzYF4bJ~vMPE3DJ5w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/Grayscale/secondary","description":"Colour Styles: ui/secondary (#Token)","created_at":"2022-05-09T18:36:06.643Z","updated_at":"2022-05-09T18:36:06.643Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"T"},{"key":"c443d4526f555a5357e6a0adaa83f73a509b5096","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20668:7336","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/yri/IFm/4szUDIj4s0nqsyCc/style_thumbnail_6.png?Expires=1653868800&Signature=ACagn53Ootg9jAfWqzibw4gPfD34pzdQ-EJXutPx60qOBYH5PiVQwPKwe-DbU2xkU1iDUivhzCrpsf9PEOl8apu3ivlVWOHPKTdtzBi2ApVx5mPNcHdA-PcE--UZIJ5ex25P8zGctk~~R9SJ1IgOpL8rrygvm~w2WHLccRMYGvi0Lb3gbt-5E0Z80O33XGNSlxlITQFteGwA5W0HpCL9ePw2rpuuBaLrxjSjPQpzwvJYynxu-op0nqR5UF9Bzsc4loja6ptyHysMUkCD8u9js5-N1gy-FW12Gm~hZT29YeAGa7hls9S4srJVVuDM2WM4OsCm9lQZJOZLua~B4RrNYw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"text/link","description":"Colour Styles: --text-link-colour  (#Token)","created_at":"2022-05-09T18:36:06.638Z","updated_at":"2022-05-09T18:36:06.638Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"k"},{"key":"5f0c854e55a71f8bc96195595582bd5b3638ca0e","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20472:3365","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/QEX/RdC/K5NkKzOdseHo6PmR/style_thumbnail_5.png?Expires=1653868800&Signature=dPD4qUlKlKW5U6JflkfCnGAh35EVTD6OnkCAq10rsWZYk2mpY0MPb~RKZr9rGir9Q3SImHyP-VaRajYPK6rXKcxXnRO8Fcy21Ccf2eKum7NLPoXgbCPYtq7SwOiNkZX8QzF7HSbIJwhEieA~9Z8xEXNHpLy0nPPIqq-VWnx3~dw2p7fMDTXCQ-z5kuwOEY4fO0WvOIFSaVXf9oWDY6oo731bYer-M6Im8QuGSia0m1Vt5vPdhdswWm9kWkWFoID4y1AAiuKtfNPjlNPvJOhz8Q9kooWKZe7En~hu5P6G5i8WKTzRPScmCSSRlReGQslggfKrMU4PPKY85ZTo2TEjTQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"header/l","description":"","created_at":"2022-05-09T18:36:06.632Z","updated_at":"2022-05-09T18:36:06.632Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~qq"},{"key":"91821670c1e11f4e729ad2be6b24582132f4cd83","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20003:11700","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/bTH/Cql/WYNi3XYcB56Lw3T5/style_thumbnail_4.png?Expires=1653868800&Signature=CYCwNSEh9HEV-mtOAtBL9kfwSuFu33RzH3CwU9bxxOyvgiDi7u~iz2K53XizJV3mqlxh0lA8H6Dzw7RzU9XNojQbrej1A~TvUWxO9XlwZ0k17NdohLJxb-bANhzF-5-JGENhJUZbrSBEv0xJnxk9mCnU4VXkSmaZh-3hD5YcMtawbMAPHKcVqg9Oo50N4nt~yASzkGwUIj0Fm8MCNF0mDcq69xJt4wTS0urOYmHCLYF4rOsd7cOoKVDICJHyYoHItb1648O3uhAzbHP7lmER19j5FbMbmcXY3rnbcWKKj2tt2lj1i2faeju3RiqY8r-Dh1nboSFNUeus0Ilvh0EzRg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"brand/primary/dark","description":"Colour Styles: brand/primary/dark (#Token)","created_at":"2022-05-09T18:36:06.627Z","updated_at":"2022-05-09T18:36:06.627Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"K"},{"key":"6c6ef9b8a12aac499427ac682e601499c438b274","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10976","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/sdk/oQS/wfwmpAilX7m043SE/style_thumbnail_3.png?Expires=1653868800&Signature=FBU3afI2ROwusmGKZDQiEkf2AyXfwvLOSeP86aw4aNiSOYuZOyzX1tfG8eW9qHrB4APMf7cVIBr0~px3YdhXETBBGc30Qad6XQ7r7WziQIDGMzH9GG085x8xFDdQp~nre9BA2P1iID2gNg-xpOHjd6s1iFU3-TwPcBJGJ4iubQQSTT7tJ9qJPeNdfxTHCZwcELIGfUX25PEWikBHIlKsrfoNoMGavQZPHCNVfdBvLYlOYXldvuFZHXkOBzWkMQhaMdL3U3ZC1vn0zYNK1l7BPc~iULujk5d9PKAjh1sXIh6afS978d1UM7qMubZ4xv6GuCNXKk0cbUPBPGwu8G-3LQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"text/error","description":"Colour Styles: --text-error-colour (#Token)","created_at":"2022-05-09T18:36:06.621Z","updated_at":"2022-05-09T18:36:06.621Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"a"},{"key":"74fba58789de53c151206f867ef2396f66bcfb58","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20792:7350","style_type":"EFFECT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/A9q/071/7pHIQGk2UiUHFdlc/style_thumbnail_2.png?Expires=1653868800&Signature=R-lV7jJF1NIHILayaDZJKD~jEViL~W0XSfKfawLU~vvgj7DItBh3HLreM2xBHuO9-Avl8TX8c8hpGtBD4LzyyCnQ5yJGRVDWQ1rB45VP2r1Et2fuICZ0dVLWr9-SmRv7YrLf1bguYvxiVuvaUsLNd12SrfaDILYyPrp~Muq3ibwkDT8xssGQQ8DY1WAPwXWzGXaBpQnUhA1ga0Fom3lHJB-r25dKV8RuQbhhCb9hcH7RY8Pi7vCG9xji9mP8VSqFBDTAjriNM5l8eveWOmuGK-Ah1webkUW-YGAe1tyHTD7pfXkc3wcKmDJ1ReYs8759uT5krq2fF0~XQx4cafeH~w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"elevation/light/60%","description":"Elevation & Shadows Token: --elevation-light-60%\n(#Token, #60%)","created_at":"2022-05-09T18:36:06.616Z","updated_at":"2022-05-09T18:36:06.616Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~wW"},{"key":"fce66bd9067fcf7553be0f7d563e58d48f0ecdd7","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20792:7349","style_type":"EFFECT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/2dz/kyI/Vh4jEvifD8Kr6QG7/style_thumbnail_1.png?Expires=1653868800&Signature=XR4G5x8Cr1f7rCW6ArzU6wUKiswec5u-9sYwi9abJ9OqgdMGSrXpHoOnBVGubsQFRto5Q4-SFySzOdf2J-407M76ueX4dPTUh9kvFsy4t2MoKFSQzAtJRcxmUQAQ2SU4kn2Z95fM-3icsv5CUPk~gxQEf9~G7JcAe7JZuJNUkY0WzDhbU6736d0eipLugelAjL4TwU4qg1~0vKSQE4whOh8UOBmgQkfMVOdjzVyylZUFFCW~zk-52RfnLfV5Llm65UCwQnT~35LAldCmiMyNuddXYLVyTHgFqN1SEQ3swC1xb2ibv7fskd1KkT0NvvqdfPAEHtW4VSUyFayYyGKDhg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"elevation/light/40%","description":"Elevation & Shadows Token: --elevation-light-40%\n(#Token, #40%)","created_at":"2022-05-09T18:36:06.611Z","updated_at":"2022-05-09T18:36:06.611Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~wV"},{"key":"c7bbbab40d232a7b2e245291cfa51c34da18d923","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10977","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/yFB/xsr/Yf6RjN5kYS6q6k3E/style_thumbnail_0.png?Expires=1653868800&Signature=fdifqP9NVMC45xwMVc6uDo39m-8-UzY8BuQNkGpXi~RGmVzwTYihv3KVTBVKC4YOOc20U-P6nQhVQ56LCSj51ViFs8NTveQS50yaA7mCvV-TVQzzv-IpAosZ53tE8Lco3JXgzStOZJN5fEC5W8SKhJJCNVTrEaeC76iHW8IXMksmiIjLqcflkBSN~jQLfAW42FO-sl83TohChzzzmLaV76GMDTZAqr0DGRHbKeoN5PZr5WPXc14rNQG3cAkny0E9lOuOoy8XnfaxcaMgU0t8M2GzSHN4ebjsupsLsqdQWvNJGGkb5m6~YxpeQIamx-RAqXDHXjwiwAwlmVCx4s4X3g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"text/success","description":"Colour Styles: --text-success-colour  (#Token)","created_at":"2022-05-09T18:36:06.606Z","updated_at":"2022-05-09T18:36:06.606Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"b"},{"key":"cd4245890bf7287b8dea254bf85391682d6be154","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10965","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/XiG/3CV/4zlrlWjACV6fnVqT/style_thumbnail_29.png?Expires=1653868800&Signature=CfGX~XWnGlGQSeNbAcboqmB0iJL6H3G-mC~vznYjdsxkNiUFjFlNJNd10CgXaB6K6UYa77BemkZPLQsp0PqgTGxMplrC28Zh71ZH46jSk8t4ievf7iCUZqYqjwCrRhlQ1F1XRhzfO42yMSd2tEGP~v-RO1KRJlglmp9yKLANrWnNZK4S9ophGgrHa6jJX6e88lzbC3DHLjZxN~WFk5fTd4XrAi4A2yUgEciRypxlCZvdRQx1xIUjJHI6yLiQ2t90kWuM03bP3G9g48vBp2SYM2SF~CdVwZVISRlToxv2PuqDmzBgkkLbI-aLJ-jlZqMXI6XbgTZ2vW~LrQ3Ij14t2A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/Grayscale/quaternary","description":"Colour Styles: ui/quaternary (#Token)","created_at":"2022-05-09T18:36:03.588Z","updated_at":"2022-05-09T18:36:03.588Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"WC"},{"key":"304add5ac09540eb1818e3c42037898ae94610d7","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20127:7569","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/urm/veq/hF3nsMrNrNy43SoP/style_thumbnail_28.png?Expires=1653868800&Signature=QP-7AY3ffLEgTTu5xgT6~UEAirqLyfUanCvhKWxkamyWkoc2ublgrkHx06OLuSgmB7AIz-ew7hrA98HsL~MQZ3dop7SCYVzM8iLve5F~ivX77AOiZbAuzi~2TXxnx5oQGBd1AhKTn1H0VNLrbgUpH3Vq1X4TQaM3hHrYvOfo84M7hwvDAFUDPQNbo8GHSg7mIeo20RlGpLPWmt9A253VpJu8amMe-e7ped3GGBlxeqrjlyg-HEDbbgtHbCg7jLp-sw03UXvTlEha-G9UgLWbThNXk5IKg3wWNwmyrkVF2lJ7dtTfapgjSE9HiPnCq9E4rw0UyEoddhGH0fJp-eod4g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/alert/dark","description":"Colour Styles: ui/alert/dark (#Token)","created_at":"2022-05-09T18:36:03.583Z","updated_at":"2022-05-09T18:36:03.583Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"i"},{"key":"9bb1e967a769984f9b0f311da626f3216597f81c","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10973","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/Hk0/Rh9/sNwncEjTDPdDfeui/style_thumbnail_27.png?Expires=1653868800&Signature=aYPg-weMQ32EktZ8jfDpGCVo5L7IUlkPsvAZvXYFxnERFJZz8xO8K7WHetoji2CcaIWOujTxDg6ftEr7AQ5ay75mSeikNX~x5iYKtxhsE-xUJBT4PmU~e8TfU79Q1CBpNLoaEnp8~WyAk6n6pKWY4mZOaWO28MveOVsjIVSYYEjvv~kSdXp-vt2vs65xROP6whIwgzXAbU19lhBTfXLl96b6WqemODDhRtKmmpNgDcGGZBJK-fYroLBcayOUzhkpZtqym~4EizqzW40AyFjat3hDLY0IGyUH~lZ4rEXaghhGF1vl3noyvFbOI4JViWB87iEkAKG9ly4pw~Z~WQxz7w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"text/secondary","description":"Colour Styles: --text-secondary-colour  (#Token)","created_at":"2022-05-09T18:36:03.578Z","updated_at":"2022-05-09T18:36:03.578Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"^"},{"key":"f14ce4ab6e60abea77dd2ae94d4e61c14ece0913","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20668:7241","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/ZDY/atB/O0YaJ18kzylipxlI/style_thumbnail_26.png?Expires=1653868800&Signature=e3IU7viuv~oEzyI9dWOREWwffghjYp~IiZrgIUXCLX4k3bSZP9w2OPw3FkbXAQTtzF5n~Tg5ICPYND943m2R8K35cBn94icfochhtkxrDdsKUJoN42jt1v394DYrUvPL93y-00VngSPrHb5BD5UZTqIyZnoRBbbkWMNs2XMrm6tEtWHk7zdYY0UhIakNWysH~uu03hzOwtyWIOgiD~2Yq0JKAoFFdEs1oXgZtx4qqmtH6V30ty~ODAf3XxDQXaPoSaCWAma6ieW3SBtY9nKxUGyRCgfP2HHkNTwcfBwTHnA7FDCjtbneIlyPrLie9GJL416SI~Z5k7dbUfPUzNovxA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"sub-navigation/s","description":"","created_at":"2022-05-09T18:36:03.573Z","updated_at":"2022-05-09T18:36:03.573Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~Q7"},{"key":"cea073fdd51415613e23a22ba7bd9e5733d61b6a","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10972","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/xd6/fBR/LeHImTgs8z0Jnkev/style_thumbnail_25.png?Expires=1653868800&Signature=eBf-8UX4XaxfQs3z9U7ZAVzPeYjsYFcruqubfzx9jcYQ5gjsIdL0ZXE0tLlEFBAjyJQX3nkRFqdcGPp33yjy8OiptuW2PRltvzlY3ymoiMiW3O573YXstf--9owckreYenRNvRac2fVcpjeb-cmd0xea968IbAGkKDkU1CNW7Hd6-lo607GphlcnDLR3ULXXHBG91J4v9lxCCas7S658sMPtZR3F-N6ST2Np8JJzgaOq5nz2RZBCf999A1XqdS~Dj2kv-6JqeF4FjveeIWIF9TL4zVgzyqmW1q9cGiuyOUon4gwq2cT7ZwxMkYlsw6WW7sF7ECSh1j-nnVG~gT1jOg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"text/primary","description":"Colour Styles: --text-primary-colour (#Token)","created_at":"2022-05-09T18:36:03.567Z","updated_at":"2022-05-09T18:36:03.567Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"]"},{"key":"56d496b6ba2c65284c304d805e36d2a3d3bc7806","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20003:11701","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/sQ3/iLW/IaHS58qFJViWFweK/style_thumbnail_24.png?Expires=1653868800&Signature=W8wsFoWxhiMDHxwPO0vCoFeaWmJP3a5WDGt2tHT5QjfEeS7kmJz1siLI2XgcAEXtg7YU7NcGJXuu89wZgruzPcjNtklHppoIRJthwLApQPL5hmDuVBr2UpeJPeueRRV3BTok-XZKbWh9xRP7OW7p4wS0YkyQiQrOYiMnoL9M-vaCYoiVM1vKe7kepJR0W~9wpSrkownyCeuD99phzaIjfQc7uCMBVFwZwfV2ajLkddjiaEOPLr5ehuUYzIhXM7bnMq4rhXz2UrBfwmmBnoOZ5d-OYx1O-iPhXi5OLI1Py-CeeWNegteK6W-wa-nnztMuH4OSliCrdGGGLjekscWPTQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"brand/primary/darker","description":"Colour Styles: brand/primary/darker (#Token)","created_at":"2022-05-09T18:36:03.562Z","updated_at":"2022-05-09T18:36:03.562Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"L"},{"key":"576115fb858c1c4b706cd36251f31a159fe6c704","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20003:11702","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/9eA/e5v/0H4LmrdUbvood1Sr/style_thumbnail_23.png?Expires=1653868800&Signature=NpJNlcruup3ozpg1vAvZRez97JwT-e5hgnMOkLfdqh-4SkAjzgDR1uaOvEhj~YkOj3EJrIbboUTtfU2z3ZaBwdYoptK1G9txoIopDzaWSlk1M9VpExveWDgZiD1dTQc~VlPfriODeecWX6bS5FpToveg~FDDFVRG5oYTjAwU1N5kdJWlUM-TIbOWmZvO0GJ3jevwLDW9IBcAMfW0IsVvIaXbhOmS~Pm5Emm2wf5xZspHR~T7g9OUgRxnsK83a2VM5G-qIX9MF7~98g30IWHmhPxO369cOsGm7SVbQ5jETtAfz-wwnmfF6s5rF65gOsgBJMkjvtCGhJN5UMcvz6Kh6w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"brand/secondary/main","description":"Colour Styles: --brand-secondary-main-colour (#Token)","created_at":"2022-05-09T18:36:03.557Z","updated_at":"2022-05-09T18:36:03.557Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"M"},{"key":"e480c3ad3eee62952ebd89ff18205f317d4f2567","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20003:11703","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/7Mn/ui8/BJeUAT5t1Eo3dI8L/style_thumbnail_22.png?Expires=1653868800&Signature=epNLzesI4l954uVZQca24LZpUEfL-g56xzGN0gWcivpFWV7roTylML23ADvfsSkQCavOpRG-iNxZ5LQEqM4fBHzziz5tSAM7mxPDgOAT-0a-9GU0duffGIA3Cr6imyGszXRWA4y8ajfu6FpYfiNwfUcN~jT91MI2Pnpp0d9gKpJdvjtUcsGdttf71XN6h8ZAB4m25VZtxfzchx13tfd-C9jvxtttlc2u2dAbKjxeFHlx-lfH6cnqRBD9pQUzTVB8eQaNxBwzYSIq1IWqfyyuEuSXG5olzkBUea04YnNgn7ES4x9sLedOZdsy7rqYSbX29nNd0q61~piaKODQPAFgtw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"brand/secondary/light","description":"Colour Styles: --brand-secondary-light-colour (#Token)","created_at":"2022-05-09T18:36:03.553Z","updated_at":"2022-05-09T18:36:03.553Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"N"},{"key":"b44508ef97101e0055de683d37cb42f29305100e","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20519:3941","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/05o/mW9/T838aKNtpN8rcu3O/style_thumbnail_21.png?Expires=1653868800&Signature=AGjH-4Bal9q7aiKgce6fHpJAvTLUQ3U2HCVrrWFMvSwY3hjuV05TpnjQA9peWAx1nhbjS3rgChSr6ZEddaG-QVNCYTxKaPfULEd5QZ~Fp3MYgjsnftfYZiew1Y0Yo1SElt7Ca2mMazWaW6tcPBA2woP7J3cFySciwyVZ7BKCDOIhTZsze6TlP3U622nW3Cs95qClEHddAtC6yCycmp4FnPLoUMkHhqIXpP6PwbeSC7iTLPIGeHDwEH6qYbQS~~j3uS4NsAsVXFbC2j9o41CfW-Ky0OyWulhtAcn5BFdTrHR5chZTwJvBIGDBBK8R6q3~CjU6ZircEIs9Z0XhlvNR9A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"inline/s/hover","description":"","created_at":"2022-05-09T18:36:03.548Z","updated_at":"2022-05-09T18:36:03.548Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~O"},{"key":"1bf51ad2358aecfc54a7f794bb3ff1a714987cdd","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20519:3942","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/EIU/gPi/PAUjFU0Hw8Xgwqok/style_thumbnail_20.png?Expires=1653868800&Signature=GzhcDRg1HgswwT16B6E6kwtJYf3lKe-ThZgP5w1Q~FzfOiHDZcfHX~sdi-VjSMrwounhSb-MWzW2wWh4JGaEo0blosJJ-GI0GLwj8Cm4otfONTjDETCHMDSq98qPZ4so7rgWTOdHx0OmOkXDtj-Trhk6DQVcL3qbgZ0jO7a7tRd-UR6Ugn5ip-Rqe0TuuWumHkO3~ccjlVMjBrXs30PUQt5r0M9lZe7Ge6CJiewEKi9qiyTWmXNF4Y8s7LX9badQWyxfT-Yfy2KbNvbu1Kge~to58nNRIR2gD0Rve1e2esOfD3gm-GeT3mRqGY-zM9Qv~Lje1CMXSiybMPNRtYYHgg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"inline/s/active","description":"","created_at":"2022-05-09T18:36:03.543Z","updated_at":"2022-05-09T18:36:03.543Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q~P"},{"key":"072abb33e90400aab1115402bb2492c96a3b1a77","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20003:11705","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/Jfj/w88/4GoPc1yZU4JgkodQ/style_thumbnail_19.png?Expires=1653868800&Signature=EVklVsxC57eVROJF-YSc34p3Pm6fmm1ed0UT6r~atE78K7A3HvTPDe6tigavb9aFRXJjMC-YBpDBIPmb1a-tAtBzoedJoGwEijV2T1sV3v-wormyol1FTUsGkvnzOMuHeWE3qEl2KywUoEVti63pPzzmGhYydkovh4Ebp-fDNCn17FeBeXO~pjPfGo7B2xpHvrPvBhWTJ54-2Ku2yNllgAm37-AB10Bn6LNWNGrNC80JaicZK7xINjviy~zFxMkp1uNfNx6~WHflWYzT7rdlMKh8DwDjcbvmE63zVmEjLL70wdUklFYAtKhIPZS15HrmQ97rJ10yEBECiGsF6qb9Qg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"brand/secondary/dark","description":"Colour Styles: --brand-secondary-dark-colour (#Token)","created_at":"2022-05-09T18:36:03.537Z","updated_at":"2022-05-09T18:36:03.537Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"P"},{"key":"af84dc2f21b0dabf3a16fb621ada69bb048947ee","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20003:11706","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/cnB/OEz/MhchYNCMccgj9ybh/style_thumbnail_18.png?Expires=1653868800&Signature=XyG2bG9oUYQMQ22xTYaukp1OXyS1odU-aZf1P6NYe~OfTmJVpmBvHednQVjNj0mVcCSvPgEyR-7UvXWtFRrJyqX4B5ENEYkNYa3KYWipkHXrqIV2lp9q97QhX5~lj1PIGx-mpkjc8C5v0J-KPrAVHQq~punTNvXeV~YaQC0i7tF2gEECtcJE25uctdeIi67Fnim2uva-~iLjsCp04YbXdIUmckje6hLEhr2A41fvm8wfcy~veOFA-Zlzi9nHN7bjTuYjfauuqEq1TSwqrLMAfFrHN-K5tt6a33g1L4I7rGt4Tlp0ZX8Vrs9lNtBkzGeHkEZisOtMXpP9MtcxzewBGA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"brand/secondary/darker","description":"Colour Styles: --brand-secondary-darker-colour (#Token)","created_at":"2022-05-09T18:36:03.532Z","updated_at":"2022-05-09T18:36:03.532Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"Q"},{"key":"631a242ba99e9d34b6a465ba2617a8baee9ff6f9","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10962","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/Cb4/6VZ/4JGEU1BamDK7CHh5/style_thumbnail_17.png?Expires=1653868800&Signature=IJn~e8NvYVY2usKCy6KGFnuqJBFfwDNBMPV5SSmLgG4wSw7Qj0IUS7mutl1481D0h8iW62ODOL1jJX3Vgbm0~0ciJXJSFoTn24otOQdEfkv-zuZiWv4icJ559k3vnJZ0t4h9S1P0VsvyFyfL4nyTGShkJdZqZefhAqv4JqBeprty012kkqJo4g4An2BgJ6-0fkgnmQO7XO~7RmAWJazoLD8wpl~iJYgYQ7IMYoXh6eLi3yaInybwEiIhPnZTqePirXpxlgfWkIleBC3KEhrtfh6V2FcRK4r1M56XqmT~YAwqb7JEBWFaukPQ5iWmhrIgRxL9Q29Kzy73YL0md8iRPQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/Grayscale/primary","description":"Colour Styles: ui/primary (#Token)","created_at":"2022-05-09T18:36:03.526Z","updated_at":"2022-05-09T18:36:03.526Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"W7"},{"key":"b909c949fafd6f4b43fbf1e54e1cf993c78001c1","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10968","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/47W/2Od/PrbzCwgDonpC6GH7/style_thumbnail_16.png?Expires=1653868800&Signature=DnHD0nNmca3t1ftbpc-tc5Nbx1r6Y3qMo1cj4wyiimnN264ItmoMGPejYzwh3gBzA-10EpLJ~fSS~Ytx-ELZIgXylOLzxW67ABq7tVQ6RLLZH1Ri3Kh5GOXCIYmx4CMWtPRizuUZiAENaWwwbgK7-G~8QVH2KZTSUmJo7OBIfZ34SdUHVaeX3ykOTOXaxj0v0HUdtf5He~Tf3DKt7CMPaqY3q4XFCcN5HR7SMiJoj56SaVlgcXfmQ6FGMrm0nfNhUBGxoxo1AILa5nT77bVmY-DlWGd6M7hMc7P0gylXqJxt6YpYcDTHE0tCUd7tj0vMdSTNa015EtDLXXe1zMsMkg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/success/default","description":"Colour Styles: ui/success/default (#Token)","created_at":"2022-05-09T18:36:03.521Z","updated_at":"2022-05-09T18:36:03.521Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"WO"},{"key":"288bb1a54a106381689c4a3d0ead7371a991105f","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10967","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/9Pz/xRF/z0wGiH3aNVoNHk96/style_thumbnail_15.png?Expires=1653868800&Signature=grYFx~HqQBuhr15KADnaNOmnMbzjFQupu4UWYC3tMbdnvkMsSwZPgVbQth0eJJmZcEyOytQ-dAPfA0FrlfHOHwucgi8-KkVI9r~TbgLATTQduRoo50TYgxFAWpCq615~0jYcVD-XCAUJ3ZjAB93or-hCR7QouUjT8DZ5PO-NLCP5HUY~gAjWKPganpjjOugxortYyrW9s5jyExlUxhQps9VrgLVA~gnlt0D2paCxZsusZn5yqrX1CvdZLP~BY4PeK7XzjBc2s~y500mbbJkpjZzYtIzXRKZMVAvM2VPFJwkUrqziCJkO~DwIVAFtTMkKgB4l3CYxxH~GDCYQtSLXZQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/error/default","description":"Colour Styles: --ui-error-default-color (#Token)","created_at":"2022-05-09T18:36:03.516Z","updated_at":"2022-05-09T18:36:03.516Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"X"},{"key":"0a0aba446af46b81639cbdaf5d8e5b586d9c83cd","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20127:7564","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/O36/WjK/DVLAGH9bARus5wYI/style_thumbnail_14.png?Expires=1653868800&Signature=TLdOmSddZv-IEV6h9K1vlOIVCk~nBdSqC7HYDvBPngO7tw9g1FWckkoDlOKTRfJW3agggq0EIhC3WajIbqvTHLZGOE6p7mj8aRvNlQ19WbqbBPsiSSMEqn~DAeQ1gQGGEWV4NMzvljIg3PJ27qR~KDlzivWHCC0kyHy4PiW390MtwKxjJ-6H8I9wZq45Ejab2Y6XxsaXxbCRzzDj8w0eBsL8jzbU~~pj-E2-0w17H199cvRsCv6EZ4h4lbwL0-IQCw8-mBEeSHdO5R68e8ppJgg6uke23qg2P4AYi0V8QwuGrXy0bngOHRNRmP0l~uMV-sM3rXs4rUVcZ3-xZVQ4~A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/error/light","description":"Colour Styles: --ui-error-light-color (#Token)","created_at":"2022-05-09T18:36:03.510Z","updated_at":"2022-05-09T18:36:03.510Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"d"},{"key":"c510581b70f968a40556cddd9ec3829efe91ec11","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10970","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/yQW/TCw/UYZN5MtSPtWoDRUN/style_thumbnail_13.png?Expires=1653868800&Signature=SfJ0MJBE-j9Krn2CXBStQ~we8pKKVMm1gmawU1XCzundSqpnjgiXrOKYSzjeuzsp24--zrSRynA704RGIRvMyh77OMqXJw8ZAd9sPa8fIpyshWXOWzK6yCwlrniC-~DilXKEPAg045ZECDXaDoAvC7SO21m4ErUC27vqfXfBuuyVvVfWsq6kq2vkeVXek8rh7HOPhMCuvgNCxJhKCTjNKll3AanOExcrYpvqCFb95TNBbvGuMpkib9QB7mpsP9Wlp4PVPTxFJDoUE6fOPuXl5T-jpK6ie9ehO-6-yhz7dhlRWchIXd0k-hcREWicgSYPMipdnfNXV7R6ZWGo-bkwBg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"background/1","description":"Colour Styles: --background-1-colour (#Token)","created_at":"2022-05-09T18:36:03.504Z","updated_at":"2022-05-09T18:36:03.504Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"["},{"key":"0adb2bb91a54e4e7fa163676c0779b7033af967f","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20127:7565","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/8Nx/m5c/eOkMkhiu3dT0AC0R/style_thumbnail_12.png?Expires=1653868800&Signature=T~0xWGXDaAS2frF-TV1ujN0Rd9-3L8UbF2mtDg5vkBbI5R888GX3~3eVyaZGnQrkROmJqeguQnTILvgfBSkPtaNhEob-lSQidJvlslXiTZuiMzaStREOzhmOzTyupcCM~-kD1lBvtTSaI4gMXHpNkpPTIEY~vIcYLjqfWW4a5frabWRRwbtByd6ZLtYhb-u6zkMu9TGjP63zK5l3nTVbRpdTJuuEZcFlgik2OnFuEAZFea6MDhlG1SD~KDfFRS0fAkPaB~wsxEV6iKLMiUSjso56xNI9RdBr3sHIV1v3XJwPx4Mv8LWwquWZv5SvD6tfdCDgYwWWOCB-I4WSuDeccQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/error/dark","description":"Colour Styles: --ui-error-dark-color (#Token)","created_at":"2022-05-09T18:36:03.498Z","updated_at":"2022-05-09T18:36:03.498Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"e"},{"key":"076435ccf252656be6b3b8e3c2e74ad4f35153af","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20127:7567","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/Piw/IUp/5mzjRum3l9Or7mH5/style_thumbnail_11.png?Expires=1653868800&Signature=fYhxaltyCyYh4Aso~CrGzHTxTtFjsMuM5zCLIbaV2lbmGcI61A6e2YoCJHMiUIYspKHkL908T3V1hajCKrpLopA~6GSE6B2tBGY7Llnf6mWLm2Dtond8f~X86hV27BgbvPPDqZPsufXuBw-ktwxdNqb6XAD43uupwVkECIGqlKrCoRnKg~E1qmERNE6NqISSb~9MR8yav2BN9kq9PcywBqc82nVqFoK-ROb18J27Oocg-P0ZVtzUkRQwQL4HIePUP6IUjJjdORnBnhyvWuy3RGvYnoFinTOwNT6dmR-m0JgEMFdOj0lLpKROKAJfmAKljSM0tBFaX5BKE4zOWAiiwQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/success/dark","description":"Colour Styles: ui/success/dark (#Token)","created_at":"2022-05-09T18:36:03.493Z","updated_at":"2022-05-09T18:36:03.493Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"Wr"},{"key":"fa55f423c9266499c422d52053b9cc8ea01aae2f","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20127:7568","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/TdZ/4rr/O4hGkR18KmA9VSZt/style_thumbnail_10.png?Expires=1653868800&Signature=a3~1LflWbwRdrbUWiIOiOk~gQ2H4LBhIHFP5LsMiSIlUV8iW7A-EKh8wH-VrAbCThU75rYOsk-qg8QVXB4pGSl~kxIPjRduKpAO4KLnRRDC7UETKUGLTF6DY9a6dgPJCJ35pTUcdzGQ-4r5GhRIBeTlF-2nUfZkOhZjhL9rqyuVKBT57RGCLvqX8mjkcKX1uda47-ByxRgwdnnhCsPiz-VrOhw~E-3UWb4MKyQucq87VDo-9YU-hRThAng6KNRWGUffFMMOZlBGT9SuEcynxb65VUF8PkMjg0FXYHusYL5R7pDPmvzA-0-73VQq9rg1sI7ZkdnDyjwPEDPbglEo9IQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/alert/light","description":"Colour Styles: ui/alert/light (#Token)","created_at":"2022-05-09T18:36:03.488Z","updated_at":"2022-05-09T18:36:03.488Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"h"},{"key":"47afbb4e9d4d9a02e54abd3d3139cf20c1dda89e","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10964","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/wKB/bk4/7ttwj2gvUT4xzras/style_thumbnail_9.png?Expires=1653868800&Signature=I8sWtz0wgZQuKdfBQsp8aAXpx4GaYxJcr4dTc1CXFsEfL3ghYCO6ojMJLKsbxIXMRu5I0ytLQhbbHonyixRG2leNFX7HX3g2nykJpotx33KJvWpaGN8XK6pKzm09qz0BPo2jJ6zD22pukzqhHouoG5MDniuURBxezPpg1iM54NC6RECNClP97M7i7HPv58evx4FnJFcO5smVTD7i1FQktJMFiTPZY-WTQHxYZ0HwzQT3ZsZPxqVO8HfZeSoHQOqtRof4JeU~gFx0lmWfDdgttLf5cVpg8gihJWvsegvgJXKcjdJOGbUlNGyZjSanHey2VOAKQiJXjTdcmCyYAp-WPA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/Grayscale/tertiary","description":"Colour Styles: ui/tertiary (#Token)","created_at":"2022-05-09T18:36:03.482Z","updated_at":"2022-05-09T18:36:03.482Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"U"},{"key":"89c6479821813ffd4246ced68c735a521652f2b5","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20003:10941","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/Y8f/kWQ/7nyQPbznQl19yALp/style_thumbnail_8.png?Expires=1653868800&Signature=RFl2WousRv8NQn301jn9s5WgGff0uMMZdjJ-QOEaF3OR4M97LlaIvUNY0-GPjxoMFbmRb~5r~27-hPIs-NLaV1DlhG-qheDkVdKjff5BBoW6D3BXJ9I0i~JozXtvHyt4HmnWXJ31CkwnUgwUvuXdkAzNH15nK1TRnc~m64rnxxsUb3K5O327EiCKuG4HQkZxCcvkQKhoJbWPjxgOr9DqxfGJhVgCGUhk89FRIHqU6pD2EclYRNU2knNks-LBAOZenf8g-39mGIfBhpzUkdknZMectThpSg1JBU2Ywnf2zLnixilcTrQtLcBxFS-W7Ty3CkpYjPu6K~udU3ovsa08Wg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"brand/primary/main","description":"Colour Styles: brand/primary/main (#Token)","created_at":"2022-05-09T18:36:03.477Z","updated_at":"2022-05-09T18:36:03.477Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"I"},{"key":"fbce4a9e33801e2ef1ba8039b2113c686277b78b","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20519:3926","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/yxb/qYc/aBRE9Ac0iW2TbIT4/style_thumbnail_7.png?Expires=1653868800&Signature=gzMup0Q-9DZkWEBHk4wNK6Gm7F3ZA4RdIdxlRHOTFjt~LoP0z7ZEgH~CtA-n3Tsz7iSnqlT8rN2k6UOyqApsTCaUKs1XOcOW1PhhV13heqJhcxHmDSNPUOeZ5S~442POuzYEGyPZQdDQ5YfxDboQpp6PVZaCzeD3z8k~uMyAT7K~uBrHGRFlo761yMSm6o4HZc~fKJeRuOFbIgq95GpXISQeB~KjR~5ALg29joOWn6~QCVyhVOid3GUU5T59i0Gr1qSoon0XSWkZc~35XI3uWpFyIq8pcyUPUf~j2WkNwhQ7VISPtZeRp0Div8Tmeb-beGkFiBQvVfZGwEfaApXN8w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"inline/m/default","description":"","created_at":"2022-05-09T18:36:03.472Z","updated_at":"2022-05-09T18:36:03.472Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q{"},{"key":"30391beffefd13e8c0c224fc3732183ef79cad2d","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20519:3927","style_type":"TEXT","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/eJi/GSE/ILSTTQkwcVGBVzUt/style_thumbnail_6.png?Expires=1653868800&Signature=eZoW0hIatB-Aruq60EIqob1fMhrMmk3iVFiYR~G0NvwDLdM5DhGQX3mSHQS0XxlrJaIZaWmeJJcqxiR3iwaZCxEShByCq5Ep9-gS9f9hn7hu4CJhSoUYt-7Zxh~c5eaECXlXO6H8TtRiRrnoxbWXpZvndSQ5EzD8zGXeYrypQiKQX87LNwKc8Ku6HTfLp8IQEG2hT7fR0yNoZQI3OEuf7hq6V0GBcBWXXSu2-DVOHkUHH~WCzIVvLZ0fEv1eREoShTgXIcxPKzn33xe1nQjx0Z7xkZVa8w4DwkMPcSqJ7yZo9ts7FiVDgjtDUA~lHE3WYzp6t-BG5h~9FCON0aKybA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"inline/m/hover","description":"","created_at":"2022-05-09T18:36:03.466Z","updated_at":"2022-05-09T18:36:03.466Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~q|"},{"key":"40c6ede7fc447275e33fb9b6afc600e2972693d2","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20029:15096","style_type":"GRID","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/Rle/LKQ/E5tc4MbBJsEcqmUk/style_thumbnail_5.png?Expires=1653868800&Signature=fWRsm5szvmRpZxCXuV9B2GUrEYdmH0hMA8KATr4zaN-z8fca~s1L99l2jj9YewZoddMlUattO9zm0SskU~FVKEscqAe1-4126FY28yQlzEF2~bnUaUqlN6i-F7MPUa8HQOfMTyUUEf3mHGJFgzfO5xAwBh9S09npPqFF3KVui3cyLlXZCiEO98DK1o4-s6s2kfu7Eujqys968Ff1-rZN93TztET1UxbMjqrr0Kqdm9Bw5bc2z9ZcqDiOGn~FsEv8JWiTwyhARGKykIBHmIS332oMOq76hsPOOD2JNRNoVdl7PAzQ2Uuj5yGVnXkSErb~cMlE3SSPDe6LPQ-w96osGw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"Large Desktop (1440px)","description":"Grid Token: --l-desktop-1440px-12-columns (#Token, #large, #grid)","created_at":"2022-05-09T18:36:03.461Z","updated_at":"2022-05-09T18:36:03.461Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~y"},{"key":"d357173388a0b2e95a1ab88b1c09e76074a6fbe2","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20029:15097","style_type":"GRID","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/T8J/Py3/CjSO0EzabWPfxfFv/style_thumbnail_4.png?Expires=1653868800&Signature=SH7OQhE~9-E2i8F2sUvAtXhg8rxXioKefr1Y1To3K4HfqNtJ4AePXzrXHN4J-c1GUEle2GYcLPbyS8KAw6jcFa7IfypHQOfimQD6Cwh8zCpbHqwhP1yZ1rc7P0DIRxrIeNNVLAHzVBNNW-nQ-xzar-Chr08~oHdxul8VysGbpIpyZJGAAddwsog21uyz3Y2Li5Ute1gLpujfdE7eAlDZ9qMK5gEN5IjEoe6p~QsCQe18kKMEXAele-r4yLLqRoxGtXXfX~b6w~dDSRctb057g4q1wqRyAxjRgR1eP2yvsxYsl80dJz~jhOXznV2nEIsqHiUzGpGYZO3tWFAYKXn1Zw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"Tablet (768px)","description":"Grid Token: --m-tablet-768px-8-columns (#Token, #medium, #grid)","created_at":"2022-05-09T18:36:03.455Z","updated_at":"2022-05-09T18:36:03.455Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~z"},{"key":"caa8e9b0cae7cbb0bc56d4ef2df86a162d8fbd7b","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20127:7566","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/lty/tNe/JDUDu7NkkEYcZChn/style_thumbnail_3.png?Expires=1653868800&Signature=abgVUZ16ZrGmQAucpfb92-7D0eQAH~rAph0SpD8TFoGBsXv9nP94kHOCm6E4~pFN5dYXnGpGU2WFqkWYZKwTDRW-Gpbza8A8KcQI873Gq5E4SqSYsape-iZHc-oafvp7U~YtpZIQvvZTIIucZqKZqrOdm6BQsgy5QhApNXms5vRPSnd~Om1acwDdlCMQBIrpbAY8pLi7MBfTN4PxBJk1debDT9QOZIivHhC9gqGDTMo-CdLusE2YtPX0bpy7DsM-WDLStBrRvfAenBbvanOq6kLK9jbH873zU4Nuceq09hvCubcJhrF3t2lH4J1pJKMzs6laJxcIvmvoDPoiptkotQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/success/light","description":"Colour Styles: ui/success/light (#Token)","created_at":"2022-05-09T18:36:03.450Z","updated_at":"2022-05-09T18:36:03.450Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"Wf"},{"key":"e0db952545244f354d49f08bec2860002e22fd6d","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10969","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/5er/8FU/3M1CyQRaGHy4Jx0A/style_thumbnail_2.png?Expires=1653868800&Signature=fwcRgvA9dH~sy-08mMGyblgFtAjeBAIV6YnlhlppW1VUQMqcgTtoo-Oe4-qoF7S6BUo9oNwDWDhOCits8R4RU5dA49Ze6DU1Xdizyybz9aKFWAkJNfGGpZ~ZqnilW4G1690t0holPlU1rBTdPZbGDPzNEoqFEPDa6UGiFAZ7wVW0tt~ia-MeiA5JpPoi8JQ4EkdeN5GYtTEN3vOCwkD5hOgmaaBZMNdGevJmR66OMzwGxWDHd9XVHmWKxiXwbV1htButVS0pg0qA~phLSvcTgBLQPeULj44YoVcEDoenbykm7rudl8FjVpE9WYGzMPj8z2jmE8~scNm0E9yGymDTRg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/alert/default","description":"Colour Styles: ui/alert/default (#Token)","created_at":"2022-05-09T18:36:03.444Z","updated_at":"2022-05-09T18:36:03.444Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"Z"},{"key":"18290da001f3b038eeaa3f1e941761c6812c07be","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20029:15098","style_type":"GRID","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/y0Q/c6C/baJphLvh4J62vYpn/style_thumbnail_1.png?Expires=1653868800&Signature=bMp-dv-rYXFwt1NTaSu4eqaGCK~oeJbydeL631iLy8gl7q2JqZRgr8Ju4me9RSjRGeyE6nBJ7atfJDjEXWwXTmqe3zuWvg~asENwGBpbBUOdTaf3u~qlq1GvZ8VPo1yhA7ugLQWc8TT-WQmpqwkuUOQubBexoJdPV~ZEIob4ExLDoGi8MH~rh~OV3hYVj32p~QyaLd7gxqUGkCxtN1WzD1jlJkycHDiv4LKLBxrjgLc5qY8e5BCoSdNi4HhrUJ7pzlIio0rG690DKYKtUV5RU1jh84xTy07rCoQkyYO5~euwWtg3T9AVb~GW14183AywwirErwvoVpxEykeLp4u1ww__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"Mobile (360px)","description":"Grid Token: --s-mobile-360px-4-columns (#Token, #small, #grid)","created_at":"2022-05-09T18:36:03.438Z","updated_at":"2022-05-09T18:36:03.438Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"!~~{"},{"key":"b495cd185b76fdfb8dd9b058c795baea5d0488e9","file_key":"TJzz7ZB6pJvpLhjI5DWG3F","node_id":"20008:10966","style_type":"FILL","thumbnail_url":"https://s3-alpha-sig.figma.com/checkpoints/eSK/vpa/yhyCltrzTfEro5ZD/style_thumbnail_0.png?Expires=1653868800&Signature=QTvRThliNnD2ZbEMbsPdcI9Ajv6041KUSSncOwYfIyqbNNisBovakHWkecU9xH0CexXMyzwO6UZ4CW6wpjl1xjgJ429bn4On4vIVBkP5wtvqXUxAGwqDWKQWo5Dbev2ylsz1OfbzuaHwdOCfdQ89DRmFAbTV72OO4a-CVnyegZSkVC7fL7JNqiUdJK-Bx8kT6l3W5M~PWHQO7xMmto0KVI4YgHOcbFDb3TsKb6F06im~5rNdhnCPoVf0YbDuutb2fBqOZyNz1-l0vtbaxbJeVC7D47jg8bCil0LUox-v3s33QXbnSpzKau1-Azz3SHBmL78t1f~hOPf6ZKlfLtmfUg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA","name":"UI/Grayscale/disabled","description":"Colour Styles: ui/disabled (#Token)","created_at":"2022-05-09T18:36:03.431Z","updated_at":"2022-05-09T18:36:03.431Z","user":{"id":"716290236385945493","handle":" ","img_url":"https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"},"sort_position":"W"}]},"i18n":null}}
+{
+    "data": {
+        "error": false,
+        "status": 200,
+        "meta": {
+            "styles": [
+                {
+                    "key": "257d2e53f5b342bafeb497a294e38c1ce4e4c298",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21291:7794",
+                    "style_type": "GRID",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/eCZ/jqo/PDaWSnIvQhr7vZ7r/style_thumbnail_35.png?Expires=1653868800&Signature=XTNOUGJladC4F2DZtcvdS8FRkXgJk41McVUUMKSBGuvcLEi4sXk6KdFhU3EjQ4ikvTs4~xDjXPphsWfaukk-FZ1gftRLWMTgnEzmBmtnwzzB4yCnBMTNsdcEOPbYVEnGnvFJfd2PvA2aRk0pCAUDpTw4QMMEvxpbwq5aGjpei4Hpmbqj9jSIOPUQ0Y~B1M76i0k~4wdFiAEiwXG2oCgggGOuRI2W682-C1MuI8oLwGplBXf8l01G2C~mjCv8EZlF0Xp5ti3~SbJwWEunWEKPrD4moT93Nuyp6-~iblGIw6Fz-PppsVsy7xmzHxoYrjFY7VHGsWKHfRklU~C0FeFciQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Annotation Grid",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.798Z",
+                    "updated_at": "2022-05-09T18:36:06.798Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~|"
+                },
+                {
+                    "key": "002402f1847b52b00967ce1494b93505c4443704",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20792:7357",
+                    "style_type": "EFFECT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/6Qy/CJV/NvnbRNLv1kW84uys/style_thumbnail_34.png?Expires=1653868800&Signature=Zx3T0FPEp2NRc9i6b4a~NiTNsQ0YpMKpsxvtJ21R9wIqbQPfFIRD6iOjIaVq4sCR0QS0DOBlPHgiz~poOBawSOtFMCe~GPwSPAa-Wp~6pRpj5DY89e9R00TUwYjjA8y2Qn3kZVYcU4wXOqFeIQHeHd3mYlPDf5ELhoGFiATQ4K2nElYCRlXx2tegsRJ-FB3iLNvrs-Ym7e5w1XsgeCCbjCDdZM2wUC3DBmqRWc6V75hPX-5aoYldm1V09AdJ23PmVbxfXITVDPhpKu6f4NsMGZ~9MGxYp7--b45BCXzmaLvB7gzPl45OpIR7neznErBKinaCjtBPLCFQq472O-82eQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "elevation/light/100%",
+                    "description": "Elevation & Shadows Token: --elevation-light-100%\n(#Token, #100%)",
+                    "created_at": "2022-05-09T18:36:06.790Z",
+                    "updated_at": "2022-05-09T18:36:06.790Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~wY"
+                },
+                {
+                    "key": "686c7f2cc60333d4738d29d1331ec75dbc66bd70",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20792:7356",
+                    "style_type": "EFFECT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Tsb/gnW/xLQOTgNqw4AqR89W/style_thumbnail_33.png?Expires=1653868800&Signature=Nb9LsjMQ9CE~EFlp0H1NaQz9ogZcJ-pU5syx4j~b0rulgCFR3IAx1Jc-L3FhW5yLLK6paAestEDdYrb-0mATjR4HWg4IMFLOrAMTiLFy-JQdZA9HJP55vzTFaHp01BeofblVxObHC1DoVnWnXpPFUCMxTLybOClx9TwwCaYK6mEn5CbfEpWK7sfIMicT0Cz2Ok-ySUCf2zQoiezKF4Md6YQ3q0BHvGP9JwR~skQELgXP~VzX69rhyZa4cykoiD8c7~RnS4EomSNQMgZu8f-6O0T3kzUv22cdwjszGhhnr6Nd8I~wzzZ1v2ySRrgjPfqDSwTJPOZnLNIRdiTqwDq~~g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "elevation/light/80%",
+                    "description": "Elevation & Shadows Token: --elevation-light-80%\n(#Token, #80%)",
+                    "created_at": "2022-05-09T18:36:06.784Z",
+                    "updated_at": "2022-05-09T18:36:06.784Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~wX"
+                },
+                {
+                    "key": "82a866634cc3cd71193b462a15c51e0618df6079",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20499:3480",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/3pk/FVp/9HaqCIyiNJXBKTkH/style_thumbnail_32.png?Expires=1653868800&Signature=Qs2qyu0rVFfJH7g~mxHShczLR5MyJ6~oguUMjMOUgGwhQczS7r92CwNCcRNHu8koW-DnMNfR8cBCJnbS0qDpddmOoSqRS-vBq2LKag9wnanq3StyCiE1vqa9vPxheO3JJU2D0BINtdEooBfadSffp9v3ZcCMQDSnUtOr4gJAtw26EFuZLZiX~SqNIbNU2mrH5QBBES2lT2dGXvnwwD8e6s3cap0zT40MaaN29VMmkRr~pSdGcSNqyxB-amO5qwLQuJRO~ZAP~E2q3Q8MG5lbQtgK01e2e9dV7Pk0xaTKKaNCIcFUn7Rx89MZbZC1GPL2RmBDpJAN8oe~U3xCtj11pQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "labels/s",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.778Z",
+                    "updated_at": "2022-05-09T18:36:06.778Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~quO"
+                },
+                {
+                    "key": "a2df7c0f65f0c1f453ee0daad6fd39e82d3500ba",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20499:3498",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/bLu/bAS/Rxpxec23xkwOWZiO/style_thumbnail_31.png?Expires=1653868800&Signature=dcrLu5Vx1JOz2mf4Bx1wxz-Hfd8BwmtI~YjjV72VmpZL4rCQiXN1G95hDa2Wm1zRgfaJYnmbjOimW8-rna8zPkYsuq0~oMkY46ABnycyLseLz2Q1e7siV0aCYJzO4WBP3i6QsRuMTotSXxF3kgYwdtwfDeJtsJNc3enS~tpxoSO~6DkpZJJ4mq0a3IpOZvrBaHKqcGGYIkM7vYCJkXoW6C08I6anq~pD-Ydf1o9XSaJDWfGgHNusSzxUG8KEBam0wvc0JR9aF6wiOe-AbryRtZ5sWx6ooWQw-3YY16RZNBGyLlZdZHGqmnAcVuglr381qOrSdWdvP42qVI-2dCxjzg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "hint/xs",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.772Z",
+                    "updated_at": "2022-05-09T18:36:06.772Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~qw"
+                },
+                {
+                    "key": "84d8252f0c4d2188a7d4c12802f0d6017cd2a120",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20792:7348",
+                    "style_type": "EFFECT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/p5B/0bW/1p4pIuNc36XWENhn/style_thumbnail_30.png?Expires=1653868800&Signature=VrS9UgnQkcW42CzL21s~EPl30PVyw6py7buKOv8AIphUGdd~fOEQB9nNs1GrWau-QlhAkoujUkockW4Z4PRUE9azSP3G9wV06Qxk9qHJOJXIYzdaai7-gI~ONDf-c93pByPj6S7XpOuJqM5iduruPuUuOqYkCesQfGb2Iwe0YiQIOvaVHCbRlmBLEm5xPjpqfTypjExKQALNK9s~4IQ3UY2xg4whEHNb1RSbG~KsqezK5MJGl9cHg8ckYWTBxM-oDSa46y7zAhlU28GYGDBHV9T9tA13w8rdJxiX9NE72V-M64MuWetH7n7dWh6ekzm0q4NkLCCP2rzuzPw-isxsEw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "elevation/light/20%",
+                    "description": "Elevation & Shadows Token: --elevation-light-20%\n(#Token, #20%)",
+                    "created_at": "2022-05-09T18:36:06.767Z",
+                    "updated_at": "2022-05-09T18:36:06.767Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~wU"
+                },
+                {
+                    "key": "255951ceef11c2eaff33378a2b605fa926ae69c0",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20474:3360",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/akq/RU0/tlorP8eRJzQ4XYvU/style_thumbnail_29.png?Expires=1653868800&Signature=THvXJjQV-KIZCeqiXfUMEfE1vFadig8JDsNX8QpZeBejlRUs7Y3IUlyn3Wu~NRO1iLGwFC3REkLKCQyu268a6jnJUJt6VQfygHqly6MRqsK4jkb5VsNfGqxLG9QUUJF9OVnfPE-lHd~r6oPcWP6mNKaSJ3Prd-x-fdcFRlv2ceGbk~0DRIOly5yKPR3aNpAc0mPiygXrxKRqqShQ7eWh4rvDygBewJzZsgYaXTnnT2lgmYlVRVyEipf-5HLAvtkL8mn-mV1FasswkpIE3Hjp2W2x01afVufseF0B-sUarv3RAWkXkSVeEGtcx5nqHczi3mffr2kvL38savUIGHRv7w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "paragraph/m",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.761Z",
+                    "updated_at": "2022-05-09T18:36:06.761Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~qt"
+                },
+                {
+                    "key": "883829dbe6487e0da67e96f89bcd2794dabf58c6",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20474:3361",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/x6x/h7H/LPTt5jCMEWvWhBBt/style_thumbnail_28.png?Expires=1653868800&Signature=GYf6gPn~YmfVGMN~ihbSCQrVLk4be7Pp5tk9Ohd-pErLb53-yV1cwPdM6Zp5r96Wr4omOz8nBSuoQdSIT83nqMUs52afa6ZE36eJwNiruQRdhrliUR9jI6Sg-FVEgye53ns1Uvj9GrL8WrvgQoy05NPFeoagMTYgeZIl6DPkXHcomkX4Ytfiv4pt2RE4fEsqR3LB2qrxVaj9WDIwOYJZ6jZTOYBX0w6PCggmGCpqiGOPlaKfRMrDWixzzHUPDMza2pcF6jWgbsdQj24hNV6~txx~EzohsYkHQ78~SDRijF3h4yG5Gf0MURl6suKIEDIaF2FKJXj-ZTPm4e~T07C3Aw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "paragraph/s",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.755Z",
+                    "updated_at": "2022-05-09T18:36:06.755Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~qu"
+                },
+                {
+                    "key": "3e19202910d331f355018d61d5245d15ad3e61fa",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20519:3988",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/wru/fls/5Re3D0nXPcgTe4a5/style_thumbnail_27.png?Expires=1653868800&Signature=O8HSkwxjPhfaUwixLXiakWmfxoCQsVf3JPxzvsMp1AlriQdpZcDob24EFCxNCMpizSIj0ACDlCEtEGEAmcWbGcCJq~2Gr1bTKemZXMyy9LA4Blnx6l6unFxdNOCH~-aQuPGBCMdug~AoNoSiLyJzYZkxGBOjkaGCL5DHrKawb-5oaFGC7KMwsZZdwuv-FtmenOvK1NDWkVbhB7WSYoQsnAvuDsSi3QSGirJNGyZc2b5lymTN1HQWCl8vTuaqVKa45lQXsHr3~E9gsQN2Bq3GJEy3v-RGnQMJduycOq5unL-aEqg6h2iDvRxyPq5uuKEPXMJG5are1NiBVHCMsAcsYA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "navigation/m",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.750Z",
+                    "updated_at": "2022-05-09T18:36:06.750Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~Q"
+                },
+                {
+                    "key": "ddb12189b15f6d1e6dbba3ab088d870ec3066e8e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20472:3360",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/DUg/45X/KiyS2CI0pIydOC6F/style_thumbnail_26.png?Expires=1653868800&Signature=X3ABpN3ySOZBCplw6yW5VBFvFIh52CWuqXJv3UJ~xiXpsFwM7VOgyLUM75xRv2q01bNDam3wQAZZpQvTsXFjxx0192RE6EDFP1-Iy3h4ZCqKERsDCn9uRle~8OlsTyuKf3ZSkz1UYtJ74bzDBUYS-6dhRwCRK5Zn~kC1Y-0TlAGtdskjXaOs51sqZzyd5vPkrC2ZBReGCqSLhRW8NTJhVVCfCSN~ZsT~qZTilHvMCfwqi0eqdw3UovtuIUgHXVOrdiQJOhONDuvq9SgeDrrd5i13HQWgzT9OFjyX9S~Pexc9oQewYNlqpidvT~5I1sF9NSka~wfKe~MKJT4LmhgLmg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "header/5xl",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.745Z",
+                    "updated_at": "2022-05-09T18:36:06.745Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~ql"
+                },
+                {
+                    "key": "643a2f079c1ff445d0c7904f5b9a4ddf73f1d891",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20472:3361",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/sZf/K0r/akH2H1HGYATugFO2/style_thumbnail_25.png?Expires=1653868800&Signature=WzJBxFab115mM9vOhCBsMvoQqtYMM-y9Jbanh1qZ9I1u-lVxEsU2wUxAm5pI8-WKR9SNdL7ZY4fWgWfgUYD6IyQkAygF9YV7-9oA2Dfr9Zg4Ut0sXgkA0mZEO8Gl5TicVi-x0W8TFtlVroaen4hRRwzsOcmlu5QWBIoVCnZM90~4a2dCdX7H5WHqblT5ECKeKwVYPOA8S06btWtwYvCma0COLUZKM2YP4aPv5x2Xd8P~4I8IrwW4RcPjmVQNtjoefdvJfYBeLzk6IOaw4211cnPiaqy5bq0G5mK8PgzG~pj2iVD5E68rwSYw8Xq-uBuNC50VLQ7hZa3cjOI891sufQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "header/4xl",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.740Z",
+                    "updated_at": "2022-05-09T18:36:06.740Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~qm"
+                },
+                {
+                    "key": "796182139ad95fe65630898b351054ac68310772",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20472:3362",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Mij/bbs/X9IeMTuM0Cr1EZrL/style_thumbnail_24.png?Expires=1653868800&Signature=N~Q34WVYETnvzv4FDZ8DfSTE5mQNBR8eYuNYGnzeNV3J6valmlxLp4MPuqX1~lcV-RlvTCDXcZHenbWezXaX5m4p9dVjQE944Zw47wd2jKY5z3TvHFLivmL60cJHAXxOdgkvOyPXcv7r1CsIRHacW~trrH6hjGsEpckewcBPwOMCFme-xXs1xCK3STqFNIL8LpsMmXwQx6eRTDa4pdLoFnIQJtIyaFyQmAZBbeySM40du~Iak4Gz3ItNg2wEur0nSCuXFkEbOTqgRQ8YbZFzMQihu3IyhHuq0Z5yi1GYXyw1oUBnVYAzBLdy7bpVqX0fPg8ugwFy1b9tTuhBRkHatA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "header/3xl",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.735Z",
+                    "updated_at": "2022-05-09T18:36:06.735Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~qn"
+                },
+                {
+                    "key": "6a01cde1036049784471d5fda778883b94e98a77",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20472:3363",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/gDF/m79/gKPj6MyR0ytYSDWn/style_thumbnail_23.png?Expires=1653868800&Signature=RvSe2ioQTEaMRuhW-iH~yahZD62arpErVF5T8HXfWfTFoLCHJOmTQwJrn-J5kTjr4WufzpqUSlGLSnqZ3AXZKxzjRNYHSZjOJq8b7mKdt~rWlR2zVbwQhifxyN61QE9SlfKQEHjLU4d-ZG93ZsprXW~v5HQfCzboPllhC43LH4SdAkl6DJQHEuQf6r-1RQjYGXvsWLsFLN3bsfes8BNrst7upObcjMFx8m-Y5nQj~uIwgvXzHVaBMFaIDwDJ7fq9Fd9r4KM9ILxHcRZsSrY4gppOLTAVGVx3A8yE14DTqJVKYsi~A~voBrRc1w7SS8xTDGuQvOt1cGKVwDvrSldM7g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "header/2xl",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.729Z",
+                    "updated_at": "2022-05-09T18:36:06.729Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~qo"
+                },
+                {
+                    "key": "b690cbc53e8d99e62336d62bc9160e07181740f2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20472:3364",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/6FL/fjF/9piwfCLOcBVEFptE/style_thumbnail_22.png?Expires=1653868800&Signature=RwQwKzTq52JPG~9n3VSEBka-t2FsYh1qcOBCZ74RwuVSL-krKMMDK2rbOjweftDDTskdbBlBhpIUa69DknuH-AEAgIYaVEFy8EuGy4FkcTnCJ46nm7W84sDB-6w4hU89si5Jz6ufWsTqxvCY6JDDcdO27Q9oH1Z3dnbgz0gL8nkA7fsHKvW2Vsb8I2DViFMiSqVTTnc2LGTfxvl2vJ6e9XzEtzN95LEgzRXKv367Ci4lyABwIA~SSd59zJJjJAfndJHoqslFpDqQRIiafsHQoO-OqSIMJhr4ZgJNKiG0NduGFEBqaSwPThrK8Uf7UlC507C19W8zhU6OWMkQEsC9QA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "header/xl",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.724Z",
+                    "updated_at": "2022-05-09T18:36:06.724Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~qp"
+                },
+                {
+                    "key": "f021a110bc7e1d4bd448468a7ed795576784e561",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20519:3939",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/lCH/HJq/b9oYLFENrKsA2Zw9/style_thumbnail_21.png?Expires=1653868800&Signature=DtolbWW3htCnLSnfKZ72Mh5fIFjVLuOrKh76ZNvfjlSgtknAZkSm~byhLRljwNw2Ro6XJ9BOcdgbiNZ4bmM1P0qCTNnGr8jFnnLcEAH4RiJs5ZO4a6TnKIfLbqjeNECYVwrqb1lVjXA-tjchPL0iZyfYTIGnGX26A7GWjJVaA1K2~Zj68m2pMIy8cz1~lOG2surSsRB5mubEDWMlkzGvPqnvQJU3UWzy49EcFHHwI6hfpBIrDp1GLcqA~A0T~mpc4jQdK0wuz5zaRFUGIQwF9Ik8MnwNHg6kXcQTydRoZvFTXdtF47YOVZqn2TKQpS3~mLFtmczFfQ3c1EVK-nsxPA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "inline/m/active",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.719Z",
+                    "updated_at": "2022-05-09T18:36:06.719Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q}"
+                },
+                {
+                    "key": "368e7108ef7ff5ce2ece6c6db2c80cddaad0d731",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20519:3940",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/OyV/RWL/1cWJh0hPk6yNPrFm/style_thumbnail_20.png?Expires=1653868800&Signature=c12mtO6HMxqEbRRuEit~UKXCuBzXU04DaJiU3nLsHBY0Irqxcfdhr34MRi6WycMvESq7klCGglOi2g8lHawvZMLy1O0ESJZVhC6B6qlQj6r7T~EDGerieoZp3kY9ELO6Gnw0Rv3OuLhcwxzDvjkTwTQCQ8jJzrtWk35Gzs4IRpdTveUObF8Q7I4LcgsNLD0aQCiPQc16GS-K-3VvO-vzKIe-Rx~W4zecRjnum~ubEhRjPN5AuPx3odS0cP-NZKSPey0VK1CTVjCGmLu2~oWZ2A4mzx-FCdOE4D-itN0EAXVptYG6Sv2TlRswpyIfDMZquXKcxSkXyoGe40X6A7d0Vw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "inline/s/default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.713Z",
+                    "updated_at": "2022-05-09T18:36:06.713Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~"
+                },
+                {
+                    "key": "cd3d8d595500ce21c7824db2c8a1da1b4d300f1c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21287:7661",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Cyp/Cn8/7XrvcCWX7tSzNnmJ/style_thumbnail_19.png?Expires=1653868800&Signature=gwxjIJSio-0mzRQoStbGkc0CQjc084aOGdS1s9X2w8Xaf~1dUcHWC7piNCwTwf9RUWXJmzbDuToK~NVk3V74uYhbDuOQJNwZThpwAAEUof3ova~5mjnMA~p1esmLvJ4zxU8wTSU-02wddgu0freR4JLYLCY6wrNT-IM9-JTpUEKhU9mDomx0JdjmOgjox9UDUCdN-TVh70MyznxJmp~9Qf-YWBoGxhX3WJooHgnP7iZ0Uj40IC4Id4gl6kvQCtNOYLq9JThYOIwd3IVQGzQD8ZlghsTNNqD4rMoPPoEiajblOqd866jN7bO2sd24jzClo-GegJNQ3cCAoWKErEiasA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "- annotations/Annotation S",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.708Z",
+                    "updated_at": "2022-05-09T18:36:06.708Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~RO"
+                },
+                {
+                    "key": "6cb98feb81542192b424e5e05019701c7878a985",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21287:7662",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/id6/Dgb/TAvWjQ1cf5o63hKb/style_thumbnail_18.png?Expires=1653868800&Signature=PMIK4FVsMetV20ci-cWzFYJiTObP-QVLQblDaA-ZKsszeS01X-fpsTbEcOYZLkvrPPrYXA1916sEtiQnBLfs42diukj8JDF~o6iWXHVCcyRUvhWDRKAt7j-O3o6-lcA7wOu-nRxr5gcPHBsDKgb8OXwqaMSF0WEtYVEVqcma2VTTcgDA24hTtiAeCEevI3XoBKoJukyxpnviDk48i5SytCh6hY7G3DhskDuYr5JGr6QB5DGC6xON9ps~FJNPXmFKWCTMMLS-xLIj2cueS8bErcziOKkQNQMkvFPJYeYFNKxByy~wIfZUuO7d0pvpqw0j3AlN6Hxf1Guk1ttfS9bOmw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "- annotations/Annotation L",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.703Z",
+                    "updated_at": "2022-05-09T18:36:06.703Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~SO"
+                },
+                {
+                    "key": "d69043021a6f3cecd9b580fb59435d5a624cc68d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20521:4154",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/hXe/JS4/TpEoKtzZrBPcViGB/style_thumbnail_17.png?Expires=1653868800&Signature=eWVD71f2ACJWXBsbl62SgfSD45DoWHwMXrnmeNdF9f0qWORF~qzZovqDNuARfuzrFexSjnzGDuEZBlr6yVs4xRbeXMG5FBIcwHLu8Ja0lTj-WivnP2eYR0~x0XRTBRV6DqRtPQecx~xk7zqbPLXhzUhEYhawpmQEOfJiZ9kz5VLOJgFo8KTcuaXdfO3t4ATqKOOiaNtPmzXIeMuK2dnkDfQ~K-g7L1f8-0Gg0SBrYokq4uq91na4dWkhfBnVb5gA4IH4~Qs0pStBN4~vgDyTUTpKomPUuVU7nszePHDIgiXHcUsmUJSjfBo9Vjn7~OCuzuf~xMHVlHP4SZlqUj-xgA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "labels/m",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.698Z",
+                    "updated_at": "2022-05-09T18:36:06.698Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~qu7"
+                },
+                {
+                    "key": "0021faefe5985d3784e751588729bb25061baf46",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21287:7660",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/EzL/nD2/wyJYGbXLgw0nHLiI/style_thumbnail_16.png?Expires=1653868800&Signature=GC89Rl4vQL-tdVYYBWZCiGbCo8n8W9JGvBb6MbhIIg1KQyPl~CyqooI1HsHb1mefBTRyqzOc1dk-Yr61yolGyzc5ycJaDu4hFfqe8wK9tL~1ys5cr0UM0NBOHjx0~GWBF7jt3knz3sQLLVU-lvHMB5cULomLG4qvRxzE5xg-PcioKt0qKDHEbGJtIr7bYi5iOmA14yQaRZDo7GwmHHZiqMTOlp5GBhxdQDX1FXdQls836IQ4s2G6-yOk9udsr~JptdLGXCzRa6r1~tGg-8W1y55bwVva8sZKiff6~~IzA7RHpFbJJ4yqoNu6EwY2gOBzFHfCNb5r5gaA5frYKSFauw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "- annotations/Annotation M",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.693Z",
+                    "updated_at": "2022-05-09T18:36:06.693Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~QO"
+                },
+                {
+                    "key": "64d5eb8c7ec8db18203a0f17917b0ee690214d2a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21291:7423",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9rK/c12/rYImSieW9E50RU8j/style_thumbnail_15.png?Expires=1653868800&Signature=ORb822ZCjnB6w5zyj7qYGoSb8EZGYBY~aqAj4mktNHN46nXx1KaqBjjICifOEEJMZtBDIYfyZFp-1fXwLRqJ5MalMyJHesqrb1aBsVC4rpWojpLG7Nkp~j0LSDqveuzYGWK8wFmzdjoG-SbxXkxM0CLnQJp8kw-R8SQpT9jWTVR5W~fhFeEW0NvlOJzIVL1Jx-kamw2T~S~oIJErYxVE13C6nRKepPgBtPOiEJ3EiBwI~CLJXsW9zyK0CJn3Mo-dAnJQBfAmrpK1AumuZwlKjg7-MrfzmVYdGIE~O83YWLOr2RV4SPPKSMr0YQsQ5fZqfbW~biEu14Am81R3bm1UNg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "- annotations/Annotation XL",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.687Z",
+                    "updated_at": "2022-05-09T18:36:06.687Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~Sf"
+                },
+                {
+                    "key": "345f2b5d0aff165a9e488eea44bbf78f5952dde5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21440:14880",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/aCs/6Wi/foGtkU9O9PZYcK1q/style_thumbnail_14.png?Expires=1653868800&Signature=aRYyMRbnumqAD4stMkS9FaQk37vVVe43lo9cmJyI6I53lZitY-UwrppwUMW3uX6-pvIr9AsNhhdC7F6gujRYr2MipJ-jVWYVPfy5mKNd9U4-6IuS90fnjkSWz4XnafaJJfbNvVmG7mQvLSo9BI8UPa5lYR9ht35QGM~OGOZSmWkDjpdEdGgtOhel4BaJ6JeUoVVDcAvsxxg4IlBo6A7feOs7-p8--u4kr1-VLwkD18DPSXg6Bi8OuW~JwIQO8m87czvGtVds3V1mZ28a3TGIHjd~6hdrmFvGzZAmPTEiuZqQuuzv89Gt7az0x8hDntnL86HMshyjLsWKhu3G-3gIag__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "- annotations/Annotation XXL",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.681Z",
+                    "updated_at": "2022-05-09T18:36:06.681Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~Sg"
+                },
+                {
+                    "key": "f9b164d248ace903e06565a46e043f59d051e049",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10971",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/F6D/Yul/Kz923k10gfx20QxL/style_thumbnail_13.png?Expires=1653868800&Signature=GNAxo63ilXJ98Mcyc2cO7QVpEZGnN8kbJfP4kz~8L6qNQ10P1tr3f9GCBoTTxNyny82C8XQvdK0M9zopNlaZbJbIVneZxLlKhfh-aYALC5XqRcfAVy3WrEQwJ7YzmZmqrneP2O1WS1WeeKqdhhv8x1xj9XMJnNrLQ2bsLd8aXE2JJq0~CEjje2cPlZc4YoCHGNI3uBW9XHR9sOzKctiU804kxW1SCJTp8vj5vzc3K7yNmWUYrdhcCK5AJBTdksveKGNJ1qUilFGRXFS0Sv6pdwhI134WjX7RP2kPIxWwB6A68PwwsTLchPnt2qfGh~gU7F7pYUrQEplAV7li~2eK4g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "background/2",
+                    "description": "Colour Styles: --background-2-colour (#Token)",
+                    "created_at": "2022-05-09T18:36:06.675Z",
+                    "updated_at": "2022-05-09T18:36:06.675Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "\\"
+                },
+                {
+                    "key": "06a067cbf75e3fda25c50b3dd842a3fcb3db3d22",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20029:15095",
+                    "style_type": "GRID",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/zEV/gnn/QaY9lNmDFVcxE4U3/style_thumbnail_12.png?Expires=1653868800&Signature=I4pXbj8IjoBciDg9d2lKif2R0wx8fb~vR81itpuIN9pnB3B24~7mwZ2C-3EgiHDPlvSIjZuweMk2FhzHpNuFwtKwH-UTHDh4iR59~auo1ZsCsl5Ud-WEVqB6stYWS1Xf8zkct8Xfz0cR0AWOMnf64FZrqVfdJlM8AcIs0P6jZVXAXIpTMRZ2odjDmTq2sUdU8tf20CNnHWZ2W7Tfsk37ByfntKRJ-zr~-ij72orx9CpYFCcMwi~Rwytxunuclc29w22MU7RHYNMYfYN2RsYCb4H~nOHPBBIP8kDj0vEPcqioiSkPpoNzZXhCRdZJhAhN8Tdmckcp062P9LO-CoIqpA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "XL Desktop (1920px)",
+                    "description": "Grid Token: --xl-large-desktop-1920px-12-columns (#Token, #extra-large, #grid)",
+                    "created_at": "2022-05-09T18:36:06.670Z",
+                    "updated_at": "2022-05-09T18:36:06.670Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~x"
+                },
+                {
+                    "key": "9665200a30f37b84b5686d07b8d23ae26f634df2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10974",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/JAA/eUI/A7uOLd6PZYnzeVKO/style_thumbnail_11.png?Expires=1653868800&Signature=TLi9hIxpuF6Z7dl5EGKSJJqvifm8R1F52Kp~PW-CjwtD9dJ9fwC3pRjzncf~15C1D~ogZ2LIWByokq6z8YrnV-7QuUZJhRJEDsyObSZTxGnk~XBruBjRG64z7ar1P7PA9OFctW7dJsa9F9q~5LlCV4uB~EYGEr6oaXrDfixuyqPrS4Gb6bOyJnQKSmhNMqyU6dwje8pfX~5n5b6BX-VDoMJ2zpOgLZa-tqQUl1uPcjd~tF0bTzpKBi55GAnbCvtCfA2KQfHKWv-1KvXMKQff79KVo0nMS~o4RJlO4qD09BrBzA6JaCPWxNaA377PwILSMuxCVQlxbXxDAvQBEYijKg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "text/disabled",
+                    "description": "Colour Styles: --text-disabled-colour  (#Token)",
+                    "created_at": "2022-05-09T18:36:06.664Z",
+                    "updated_at": "2022-05-09T18:36:06.664Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "_"
+                },
+                {
+                    "key": "3fedd2719778ce41e38a0f58ecb209a3a3006d40",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "21291:7667",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/fNd/vsc/VrmfRXkEteNnSttL/style_thumbnail_10.png?Expires=1653868800&Signature=M-DS7HnPCf4VlXDwgkz-2yDb6B8ZMSEEvnAFzQQatwD8cxKCKdbI2B-KYog13bhsEsHo14UaSM60NldXnXOHWKN0hxeqtAdOy2Nyrmiiczjo-yQUznYANLS4rArUCzNgBwAseseytZRibaJ4b7jFIqYq8-0VQFipa7BeCOi7CuIvp4E0328BFQRNWRD7xyYGeyELo5JYWmJYjQNTv3iXn0U4A4XM~~88g7-FlQ8wlZi3byZ390RDAjxCHbEnfnXP7RldDCP9uEYWCFs2tiemATCZ01JnHGw2SBA4K5yOGsD8VTIrvFrt9kpCPeUNMHzds8pM0ipGmVVPm6bo9jyrLA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "background/- annotation",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.659Z",
+                    "updated_at": "2022-05-09T18:36:06.659Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "\\O"
+                },
+                {
+                    "key": "11ee8ffd6a463a26d1db2b4c07a11fdc7bd47607",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10975",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/PUU/ThC/kzZcKHooGWIaNVyY/style_thumbnail_9.png?Expires=1653868800&Signature=BFa32YNdR95KU~HNSVPIJc6RsAkJaOUF80vjqYkUpSEw3faLOzPM3CbLUXR2WIa41BXGqYbDqFSYmL0pIsH5g-ne7wUpzeZsM6Despg1lxtxRmiF-WAg2KNKqpxNvoKVxyrum5Agi4co8RGEaslYLqFHUnCHi-rizFFKMv69jfklJHrnfvIYP6Ig~zrMIchxl43O85IMXp4YAT5DvWe8DgV2uVCl5E94mF0ccSqxoMpOR9N51bEa1r8-QRaz3LRBnO4F~JUxz29hjVgZTM07qn7f87r5X3ZfQOaBINPB8N-bLWtmXhIk-YMN-8Kx2hxFx1hQWGDCDv9muXzGSyUGNQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "text/inversed",
+                    "description": "Colour Styles: --text-inversed-colour  (#Token)",
+                    "created_at": "2022-05-09T18:36:06.653Z",
+                    "updated_at": "2022-05-09T18:36:06.653Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "`"
+                },
+                {
+                    "key": "c2f61245ce67fef858727d77a065f08e0e3aaf66",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20003:10942",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/r6Y/0MD/NRzUiO5qBn1wHHCD/style_thumbnail_8.png?Expires=1653868800&Signature=dIAdX-P7oClS8K93fONogICJ1bn3YlQbDhXhUn0eE0LJxORlgN47hRcsF2FvttDXevjphYOb98gaD7fvanwoWFx~kFdogV7OS60Yc~r2ltTE2KWzxSZCWbuO2DvbMR9uom-qOw-UXVuzeJeuH~UID5mpOS154jiGdqQwreW2bA9oNTES6iwByLXWmcXqYELJybtKOlzI4-mQp2av~e8VAQwWF5Uzh4HEN4kghpB3rq~0DcS4VnUU8aD60DDI-1yBt8hAqDEDgALgJ~9FEo0G1Eo1MD2ORBE96p2XwT~k9THbZd9H6QI0juGPh0ou5dakTyuP9BA81j4Ap3zxwdKLSg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "brand/primary/light",
+                    "description": "Colour Styles: brand/primary/light (#Token)",
+                    "created_at": "2022-05-09T18:36:06.648Z",
+                    "updated_at": "2022-05-09T18:36:06.648Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "J"
+                },
+                {
+                    "key": "8cdc6d36a7823ce891d1e0eac329c22839ccc449",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10963",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/g0h/y8I/mfWv3Jr45f24Oue2/style_thumbnail_7.png?Expires=1653868800&Signature=FVxJVAjju4ckHtf3iE56QDtl9NnH~3~LcXQ8oDRQUKQ4QS7wyoyFpX0MRIusH6GWILN587zLklyqB17RFmdLHqZqXQfeXuBQPl5fQWIMDwj2v4EUlT41JUFVIQzpMrqVoSpDvzkIOeRps3h3x8DUDvZ6cOPGIyvM2h57f8trJDvwhv4GI2uCiPzy4LXnkjjOo37hH7vBAu6PEPtLaLGXyLlfKlgC1dH6XAsFQILHZVPrH-w6rACJ24nuiUYZtcJ0cssVqPaGklKdZcHQOPWPj1StkbjRmvXwy9i0loffJygXuFoR2cW6NC5EKEWkZB149dWvAhzYF4bJ~vMPE3DJ5w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/Grayscale/secondary",
+                    "description": "Colour Styles: ui/secondary (#Token)",
+                    "created_at": "2022-05-09T18:36:06.643Z",
+                    "updated_at": "2022-05-09T18:36:06.643Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "T"
+                },
+                {
+                    "key": "c443d4526f555a5357e6a0adaa83f73a509b5096",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20668:7336",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/yri/IFm/4szUDIj4s0nqsyCc/style_thumbnail_6.png?Expires=1653868800&Signature=ACagn53Ootg9jAfWqzibw4gPfD34pzdQ-EJXutPx60qOBYH5PiVQwPKwe-DbU2xkU1iDUivhzCrpsf9PEOl8apu3ivlVWOHPKTdtzBi2ApVx5mPNcHdA-PcE--UZIJ5ex25P8zGctk~~R9SJ1IgOpL8rrygvm~w2WHLccRMYGvi0Lb3gbt-5E0Z80O33XGNSlxlITQFteGwA5W0HpCL9ePw2rpuuBaLrxjSjPQpzwvJYynxu-op0nqR5UF9Bzsc4loja6ptyHysMUkCD8u9js5-N1gy-FW12Gm~hZT29YeAGa7hls9S4srJVVuDM2WM4OsCm9lQZJOZLua~B4RrNYw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "text/link",
+                    "description": "Colour Styles: --text-link-colour  (#Token)",
+                    "created_at": "2022-05-09T18:36:06.638Z",
+                    "updated_at": "2022-05-09T18:36:06.638Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "k"
+                },
+                {
+                    "key": "5f0c854e55a71f8bc96195595582bd5b3638ca0e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20472:3365",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/QEX/RdC/K5NkKzOdseHo6PmR/style_thumbnail_5.png?Expires=1653868800&Signature=dPD4qUlKlKW5U6JflkfCnGAh35EVTD6OnkCAq10rsWZYk2mpY0MPb~RKZr9rGir9Q3SImHyP-VaRajYPK6rXKcxXnRO8Fcy21Ccf2eKum7NLPoXgbCPYtq7SwOiNkZX8QzF7HSbIJwhEieA~9Z8xEXNHpLy0nPPIqq-VWnx3~dw2p7fMDTXCQ-z5kuwOEY4fO0WvOIFSaVXf9oWDY6oo731bYer-M6Im8QuGSia0m1Vt5vPdhdswWm9kWkWFoID4y1AAiuKtfNPjlNPvJOhz8Q9kooWKZe7En~hu5P6G5i8WKTzRPScmCSSRlReGQslggfKrMU4PPKY85ZTo2TEjTQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "header/l",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:06.632Z",
+                    "updated_at": "2022-05-09T18:36:06.632Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~qq"
+                },
+                {
+                    "key": "91821670c1e11f4e729ad2be6b24582132f4cd83",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20003:11700",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/bTH/Cql/WYNi3XYcB56Lw3T5/style_thumbnail_4.png?Expires=1653868800&Signature=CYCwNSEh9HEV-mtOAtBL9kfwSuFu33RzH3CwU9bxxOyvgiDi7u~iz2K53XizJV3mqlxh0lA8H6Dzw7RzU9XNojQbrej1A~TvUWxO9XlwZ0k17NdohLJxb-bANhzF-5-JGENhJUZbrSBEv0xJnxk9mCnU4VXkSmaZh-3hD5YcMtawbMAPHKcVqg9Oo50N4nt~yASzkGwUIj0Fm8MCNF0mDcq69xJt4wTS0urOYmHCLYF4rOsd7cOoKVDICJHyYoHItb1648O3uhAzbHP7lmER19j5FbMbmcXY3rnbcWKKj2tt2lj1i2faeju3RiqY8r-Dh1nboSFNUeus0Ilvh0EzRg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "brand/primary/dark",
+                    "description": "Colour Styles: brand/primary/dark (#Token)",
+                    "created_at": "2022-05-09T18:36:06.627Z",
+                    "updated_at": "2022-05-09T18:36:06.627Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "K"
+                },
+                {
+                    "key": "6c6ef9b8a12aac499427ac682e601499c438b274",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10976",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/sdk/oQS/wfwmpAilX7m043SE/style_thumbnail_3.png?Expires=1653868800&Signature=FBU3afI2ROwusmGKZDQiEkf2AyXfwvLOSeP86aw4aNiSOYuZOyzX1tfG8eW9qHrB4APMf7cVIBr0~px3YdhXETBBGc30Qad6XQ7r7WziQIDGMzH9GG085x8xFDdQp~nre9BA2P1iID2gNg-xpOHjd6s1iFU3-TwPcBJGJ4iubQQSTT7tJ9qJPeNdfxTHCZwcELIGfUX25PEWikBHIlKsrfoNoMGavQZPHCNVfdBvLYlOYXldvuFZHXkOBzWkMQhaMdL3U3ZC1vn0zYNK1l7BPc~iULujk5d9PKAjh1sXIh6afS978d1UM7qMubZ4xv6GuCNXKk0cbUPBPGwu8G-3LQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "text/error",
+                    "description": "Colour Styles: --text-error-colour (#Token)",
+                    "created_at": "2022-05-09T18:36:06.621Z",
+                    "updated_at": "2022-05-09T18:36:06.621Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "a"
+                },
+                {
+                    "key": "74fba58789de53c151206f867ef2396f66bcfb58",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20792:7350",
+                    "style_type": "EFFECT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/A9q/071/7pHIQGk2UiUHFdlc/style_thumbnail_2.png?Expires=1653868800&Signature=R-lV7jJF1NIHILayaDZJKD~jEViL~W0XSfKfawLU~vvgj7DItBh3HLreM2xBHuO9-Avl8TX8c8hpGtBD4LzyyCnQ5yJGRVDWQ1rB45VP2r1Et2fuICZ0dVLWr9-SmRv7YrLf1bguYvxiVuvaUsLNd12SrfaDILYyPrp~Muq3ibwkDT8xssGQQ8DY1WAPwXWzGXaBpQnUhA1ga0Fom3lHJB-r25dKV8RuQbhhCb9hcH7RY8Pi7vCG9xji9mP8VSqFBDTAjriNM5l8eveWOmuGK-Ah1webkUW-YGAe1tyHTD7pfXkc3wcKmDJ1ReYs8759uT5krq2fF0~XQx4cafeH~w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "elevation/light/60%",
+                    "description": "Elevation & Shadows Token: --elevation-light-60%\n(#Token, #60%)",
+                    "created_at": "2022-05-09T18:36:06.616Z",
+                    "updated_at": "2022-05-09T18:36:06.616Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~wW"
+                },
+                {
+                    "key": "fce66bd9067fcf7553be0f7d563e58d48f0ecdd7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20792:7349",
+                    "style_type": "EFFECT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/2dz/kyI/Vh4jEvifD8Kr6QG7/style_thumbnail_1.png?Expires=1653868800&Signature=XR4G5x8Cr1f7rCW6ArzU6wUKiswec5u-9sYwi9abJ9OqgdMGSrXpHoOnBVGubsQFRto5Q4-SFySzOdf2J-407M76ueX4dPTUh9kvFsy4t2MoKFSQzAtJRcxmUQAQ2SU4kn2Z95fM-3icsv5CUPk~gxQEf9~G7JcAe7JZuJNUkY0WzDhbU6736d0eipLugelAjL4TwU4qg1~0vKSQE4whOh8UOBmgQkfMVOdjzVyylZUFFCW~zk-52RfnLfV5Llm65UCwQnT~35LAldCmiMyNuddXYLVyTHgFqN1SEQ3swC1xb2ibv7fskd1KkT0NvvqdfPAEHtW4VSUyFayYyGKDhg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "elevation/light/40%",
+                    "description": "Elevation & Shadows Token: --elevation-light-40%\n(#Token, #40%)",
+                    "created_at": "2022-05-09T18:36:06.611Z",
+                    "updated_at": "2022-05-09T18:36:06.611Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~wV"
+                },
+                {
+                    "key": "c7bbbab40d232a7b2e245291cfa51c34da18d923",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10977",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/yFB/xsr/Yf6RjN5kYS6q6k3E/style_thumbnail_0.png?Expires=1653868800&Signature=fdifqP9NVMC45xwMVc6uDo39m-8-UzY8BuQNkGpXi~RGmVzwTYihv3KVTBVKC4YOOc20U-P6nQhVQ56LCSj51ViFs8NTveQS50yaA7mCvV-TVQzzv-IpAosZ53tE8Lco3JXgzStOZJN5fEC5W8SKhJJCNVTrEaeC76iHW8IXMksmiIjLqcflkBSN~jQLfAW42FO-sl83TohChzzzmLaV76GMDTZAqr0DGRHbKeoN5PZr5WPXc14rNQG3cAkny0E9lOuOoy8XnfaxcaMgU0t8M2GzSHN4ebjsupsLsqdQWvNJGGkb5m6~YxpeQIamx-RAqXDHXjwiwAwlmVCx4s4X3g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "text/success",
+                    "description": "Colour Styles: --text-success-colour  (#Token)",
+                    "created_at": "2022-05-09T18:36:06.606Z",
+                    "updated_at": "2022-05-09T18:36:06.606Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "b"
+                },
+                {
+                    "key": "cd4245890bf7287b8dea254bf85391682d6be154",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10965",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/XiG/3CV/4zlrlWjACV6fnVqT/style_thumbnail_29.png?Expires=1653868800&Signature=CfGX~XWnGlGQSeNbAcboqmB0iJL6H3G-mC~vznYjdsxkNiUFjFlNJNd10CgXaB6K6UYa77BemkZPLQsp0PqgTGxMplrC28Zh71ZH46jSk8t4ievf7iCUZqYqjwCrRhlQ1F1XRhzfO42yMSd2tEGP~v-RO1KRJlglmp9yKLANrWnNZK4S9ophGgrHa6jJX6e88lzbC3DHLjZxN~WFk5fTd4XrAi4A2yUgEciRypxlCZvdRQx1xIUjJHI6yLiQ2t90kWuM03bP3G9g48vBp2SYM2SF~CdVwZVISRlToxv2PuqDmzBgkkLbI-aLJ-jlZqMXI6XbgTZ2vW~LrQ3Ij14t2A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/Grayscale/quaternary",
+                    "description": "Colour Styles: ui/quaternary (#Token)",
+                    "created_at": "2022-05-09T18:36:03.588Z",
+                    "updated_at": "2022-05-09T18:36:03.588Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "WC"
+                },
+                {
+                    "key": "304add5ac09540eb1818e3c42037898ae94610d7",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7569",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/urm/veq/hF3nsMrNrNy43SoP/style_thumbnail_28.png?Expires=1653868800&Signature=QP-7AY3ffLEgTTu5xgT6~UEAirqLyfUanCvhKWxkamyWkoc2ublgrkHx06OLuSgmB7AIz-ew7hrA98HsL~MQZ3dop7SCYVzM8iLve5F~ivX77AOiZbAuzi~2TXxnx5oQGBd1AhKTn1H0VNLrbgUpH3Vq1X4TQaM3hHrYvOfo84M7hwvDAFUDPQNbo8GHSg7mIeo20RlGpLPWmt9A253VpJu8amMe-e7ped3GGBlxeqrjlyg-HEDbbgtHbCg7jLp-sw03UXvTlEha-G9UgLWbThNXk5IKg3wWNwmyrkVF2lJ7dtTfapgjSE9HiPnCq9E4rw0UyEoddhGH0fJp-eod4g__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/alert/dark",
+                    "description": "Colour Styles: ui/alert/dark (#Token)",
+                    "created_at": "2022-05-09T18:36:03.583Z",
+                    "updated_at": "2022-05-09T18:36:03.583Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "i"
+                },
+                {
+                    "key": "9bb1e967a769984f9b0f311da626f3216597f81c",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10973",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Hk0/Rh9/sNwncEjTDPdDfeui/style_thumbnail_27.png?Expires=1653868800&Signature=aYPg-weMQ32EktZ8jfDpGCVo5L7IUlkPsvAZvXYFxnERFJZz8xO8K7WHetoji2CcaIWOujTxDg6ftEr7AQ5ay75mSeikNX~x5iYKtxhsE-xUJBT4PmU~e8TfU79Q1CBpNLoaEnp8~WyAk6n6pKWY4mZOaWO28MveOVsjIVSYYEjvv~kSdXp-vt2vs65xROP6whIwgzXAbU19lhBTfXLl96b6WqemODDhRtKmmpNgDcGGZBJK-fYroLBcayOUzhkpZtqym~4EizqzW40AyFjat3hDLY0IGyUH~lZ4rEXaghhGF1vl3noyvFbOI4JViWB87iEkAKG9ly4pw~Z~WQxz7w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "text/secondary",
+                    "description": "Colour Styles: --text-secondary-colour  (#Token)",
+                    "created_at": "2022-05-09T18:36:03.578Z",
+                    "updated_at": "2022-05-09T18:36:03.578Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "^"
+                },
+                {
+                    "key": "f14ce4ab6e60abea77dd2ae94d4e61c14ece0913",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20668:7241",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/ZDY/atB/O0YaJ18kzylipxlI/style_thumbnail_26.png?Expires=1653868800&Signature=e3IU7viuv~oEzyI9dWOREWwffghjYp~IiZrgIUXCLX4k3bSZP9w2OPw3FkbXAQTtzF5n~Tg5ICPYND943m2R8K35cBn94icfochhtkxrDdsKUJoN42jt1v394DYrUvPL93y-00VngSPrHb5BD5UZTqIyZnoRBbbkWMNs2XMrm6tEtWHk7zdYY0UhIakNWysH~uu03hzOwtyWIOgiD~2Yq0JKAoFFdEs1oXgZtx4qqmtH6V30ty~ODAf3XxDQXaPoSaCWAma6ieW3SBtY9nKxUGyRCgfP2HHkNTwcfBwTHnA7FDCjtbneIlyPrLie9GJL416SI~Z5k7dbUfPUzNovxA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "sub-navigation/s",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.573Z",
+                    "updated_at": "2022-05-09T18:36:03.573Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~Q7"
+                },
+                {
+                    "key": "cea073fdd51415613e23a22ba7bd9e5733d61b6a",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10972",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/xd6/fBR/LeHImTgs8z0Jnkev/style_thumbnail_25.png?Expires=1653868800&Signature=eBf-8UX4XaxfQs3z9U7ZAVzPeYjsYFcruqubfzx9jcYQ5gjsIdL0ZXE0tLlEFBAjyJQX3nkRFqdcGPp33yjy8OiptuW2PRltvzlY3ymoiMiW3O573YXstf--9owckreYenRNvRac2fVcpjeb-cmd0xea968IbAGkKDkU1CNW7Hd6-lo607GphlcnDLR3ULXXHBG91J4v9lxCCas7S658sMPtZR3F-N6ST2Np8JJzgaOq5nz2RZBCf999A1XqdS~Dj2kv-6JqeF4FjveeIWIF9TL4zVgzyqmW1q9cGiuyOUon4gwq2cT7ZwxMkYlsw6WW7sF7ECSh1j-nnVG~gT1jOg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "text/primary",
+                    "description": "Colour Styles: --text-primary-colour (#Token)",
+                    "created_at": "2022-05-09T18:36:03.567Z",
+                    "updated_at": "2022-05-09T18:36:03.567Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "]"
+                },
+                {
+                    "key": "56d496b6ba2c65284c304d805e36d2a3d3bc7806",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20003:11701",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/sQ3/iLW/IaHS58qFJViWFweK/style_thumbnail_24.png?Expires=1653868800&Signature=W8wsFoWxhiMDHxwPO0vCoFeaWmJP3a5WDGt2tHT5QjfEeS7kmJz1siLI2XgcAEXtg7YU7NcGJXuu89wZgruzPcjNtklHppoIRJthwLApQPL5hmDuVBr2UpeJPeueRRV3BTok-XZKbWh9xRP7OW7p4wS0YkyQiQrOYiMnoL9M-vaCYoiVM1vKe7kepJR0W~9wpSrkownyCeuD99phzaIjfQc7uCMBVFwZwfV2ajLkddjiaEOPLr5ehuUYzIhXM7bnMq4rhXz2UrBfwmmBnoOZ5d-OYx1O-iPhXi5OLI1Py-CeeWNegteK6W-wa-nnztMuH4OSliCrdGGGLjekscWPTQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "brand/primary/darker",
+                    "description": "Colour Styles: brand/primary/darker (#Token)",
+                    "created_at": "2022-05-09T18:36:03.562Z",
+                    "updated_at": "2022-05-09T18:36:03.562Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "L"
+                },
+                {
+                    "key": "576115fb858c1c4b706cd36251f31a159fe6c704",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20003:11702",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9eA/e5v/0H4LmrdUbvood1Sr/style_thumbnail_23.png?Expires=1653868800&Signature=NpJNlcruup3ozpg1vAvZRez97JwT-e5hgnMOkLfdqh-4SkAjzgDR1uaOvEhj~YkOj3EJrIbboUTtfU2z3ZaBwdYoptK1G9txoIopDzaWSlk1M9VpExveWDgZiD1dTQc~VlPfriODeecWX6bS5FpToveg~FDDFVRG5oYTjAwU1N5kdJWlUM-TIbOWmZvO0GJ3jevwLDW9IBcAMfW0IsVvIaXbhOmS~Pm5Emm2wf5xZspHR~T7g9OUgRxnsK83a2VM5G-qIX9MF7~98g30IWHmhPxO369cOsGm7SVbQ5jETtAfz-wwnmfF6s5rF65gOsgBJMkjvtCGhJN5UMcvz6Kh6w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "brand/secondary/main",
+                    "description": "Colour Styles: --brand-secondary-main-colour (#Token)",
+                    "created_at": "2022-05-09T18:36:03.557Z",
+                    "updated_at": "2022-05-09T18:36:03.557Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "M"
+                },
+                {
+                    "key": "e480c3ad3eee62952ebd89ff18205f317d4f2567",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20003:11703",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/7Mn/ui8/BJeUAT5t1Eo3dI8L/style_thumbnail_22.png?Expires=1653868800&Signature=epNLzesI4l954uVZQca24LZpUEfL-g56xzGN0gWcivpFWV7roTylML23ADvfsSkQCavOpRG-iNxZ5LQEqM4fBHzziz5tSAM7mxPDgOAT-0a-9GU0duffGIA3Cr6imyGszXRWA4y8ajfu6FpYfiNwfUcN~jT91MI2Pnpp0d9gKpJdvjtUcsGdttf71XN6h8ZAB4m25VZtxfzchx13tfd-C9jvxtttlc2u2dAbKjxeFHlx-lfH6cnqRBD9pQUzTVB8eQaNxBwzYSIq1IWqfyyuEuSXG5olzkBUea04YnNgn7ES4x9sLedOZdsy7rqYSbX29nNd0q61~piaKODQPAFgtw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "brand/secondary/light",
+                    "description": "Colour Styles: --brand-secondary-light-colour (#Token)",
+                    "created_at": "2022-05-09T18:36:03.553Z",
+                    "updated_at": "2022-05-09T18:36:03.553Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "N"
+                },
+                {
+                    "key": "b44508ef97101e0055de683d37cb42f29305100e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20519:3941",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/05o/mW9/T838aKNtpN8rcu3O/style_thumbnail_21.png?Expires=1653868800&Signature=AGjH-4Bal9q7aiKgce6fHpJAvTLUQ3U2HCVrrWFMvSwY3hjuV05TpnjQA9peWAx1nhbjS3rgChSr6ZEddaG-QVNCYTxKaPfULEd5QZ~Fp3MYgjsnftfYZiew1Y0Yo1SElt7Ca2mMazWaW6tcPBA2woP7J3cFySciwyVZ7BKCDOIhTZsze6TlP3U622nW3Cs95qClEHddAtC6yCycmp4FnPLoUMkHhqIXpP6PwbeSC7iTLPIGeHDwEH6qYbQS~~j3uS4NsAsVXFbC2j9o41CfW-Ky0OyWulhtAcn5BFdTrHR5chZTwJvBIGDBBK8R6q3~CjU6ZircEIs9Z0XhlvNR9A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "inline/s/hover",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.548Z",
+                    "updated_at": "2022-05-09T18:36:03.548Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~O"
+                },
+                {
+                    "key": "1bf51ad2358aecfc54a7f794bb3ff1a714987cdd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20519:3942",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/EIU/gPi/PAUjFU0Hw8Xgwqok/style_thumbnail_20.png?Expires=1653868800&Signature=GzhcDRg1HgswwT16B6E6kwtJYf3lKe-ThZgP5w1Q~FzfOiHDZcfHX~sdi-VjSMrwounhSb-MWzW2wWh4JGaEo0blosJJ-GI0GLwj8Cm4otfONTjDETCHMDSq98qPZ4so7rgWTOdHx0OmOkXDtj-Trhk6DQVcL3qbgZ0jO7a7tRd-UR6Ugn5ip-Rqe0TuuWumHkO3~ccjlVMjBrXs30PUQt5r0M9lZe7Ge6CJiewEKi9qiyTWmXNF4Y8s7LX9badQWyxfT-Yfy2KbNvbu1Kge~to58nNRIR2gD0Rve1e2esOfD3gm-GeT3mRqGY-zM9Qv~Lje1CMXSiybMPNRtYYHgg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "inline/s/active",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.543Z",
+                    "updated_at": "2022-05-09T18:36:03.543Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q~P"
+                },
+                {
+                    "key": "072abb33e90400aab1115402bb2492c96a3b1a77",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20003:11705",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Jfj/w88/4GoPc1yZU4JgkodQ/style_thumbnail_19.png?Expires=1653868800&Signature=EVklVsxC57eVROJF-YSc34p3Pm6fmm1ed0UT6r~atE78K7A3HvTPDe6tigavb9aFRXJjMC-YBpDBIPmb1a-tAtBzoedJoGwEijV2T1sV3v-wormyol1FTUsGkvnzOMuHeWE3qEl2KywUoEVti63pPzzmGhYydkovh4Ebp-fDNCn17FeBeXO~pjPfGo7B2xpHvrPvBhWTJ54-2Ku2yNllgAm37-AB10Bn6LNWNGrNC80JaicZK7xINjviy~zFxMkp1uNfNx6~WHflWYzT7rdlMKh8DwDjcbvmE63zVmEjLL70wdUklFYAtKhIPZS15HrmQ97rJ10yEBECiGsF6qb9Qg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "brand/secondary/dark",
+                    "description": "Colour Styles: --brand-secondary-dark-colour (#Token)",
+                    "created_at": "2022-05-09T18:36:03.537Z",
+                    "updated_at": "2022-05-09T18:36:03.537Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "P"
+                },
+                {
+                    "key": "af84dc2f21b0dabf3a16fb621ada69bb048947ee",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20003:11706",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/cnB/OEz/MhchYNCMccgj9ybh/style_thumbnail_18.png?Expires=1653868800&Signature=XyG2bG9oUYQMQ22xTYaukp1OXyS1odU-aZf1P6NYe~OfTmJVpmBvHednQVjNj0mVcCSvPgEyR-7UvXWtFRrJyqX4B5ENEYkNYa3KYWipkHXrqIV2lp9q97QhX5~lj1PIGx-mpkjc8C5v0J-KPrAVHQq~punTNvXeV~YaQC0i7tF2gEECtcJE25uctdeIi67Fnim2uva-~iLjsCp04YbXdIUmckje6hLEhr2A41fvm8wfcy~veOFA-Zlzi9nHN7bjTuYjfauuqEq1TSwqrLMAfFrHN-K5tt6a33g1L4I7rGt4Tlp0ZX8Vrs9lNtBkzGeHkEZisOtMXpP9MtcxzewBGA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "brand/secondary/darker",
+                    "description": "Colour Styles: --brand-secondary-darker-colour (#Token)",
+                    "created_at": "2022-05-09T18:36:03.532Z",
+                    "updated_at": "2022-05-09T18:36:03.532Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "Q"
+                },
+                {
+                    "key": "631a242ba99e9d34b6a465ba2617a8baee9ff6f9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10962",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Cb4/6VZ/4JGEU1BamDK7CHh5/style_thumbnail_17.png?Expires=1653868800&Signature=IJn~e8NvYVY2usKCy6KGFnuqJBFfwDNBMPV5SSmLgG4wSw7Qj0IUS7mutl1481D0h8iW62ODOL1jJX3Vgbm0~0ciJXJSFoTn24otOQdEfkv-zuZiWv4icJ559k3vnJZ0t4h9S1P0VsvyFyfL4nyTGShkJdZqZefhAqv4JqBeprty012kkqJo4g4An2BgJ6-0fkgnmQO7XO~7RmAWJazoLD8wpl~iJYgYQ7IMYoXh6eLi3yaInybwEiIhPnZTqePirXpxlgfWkIleBC3KEhrtfh6V2FcRK4r1M56XqmT~YAwqb7JEBWFaukPQ5iWmhrIgRxL9Q29Kzy73YL0md8iRPQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/Grayscale/primary",
+                    "description": "Colour Styles: ui/primary (#Token)",
+                    "created_at": "2022-05-09T18:36:03.526Z",
+                    "updated_at": "2022-05-09T18:36:03.526Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "W7"
+                },
+                {
+                    "key": "b909c949fafd6f4b43fbf1e54e1cf993c78001c1",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10968",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/47W/2Od/PrbzCwgDonpC6GH7/style_thumbnail_16.png?Expires=1653868800&Signature=DnHD0nNmca3t1ftbpc-tc5Nbx1r6Y3qMo1cj4wyiimnN264ItmoMGPejYzwh3gBzA-10EpLJ~fSS~Ytx-ELZIgXylOLzxW67ABq7tVQ6RLLZH1Ri3Kh5GOXCIYmx4CMWtPRizuUZiAENaWwwbgK7-G~8QVH2KZTSUmJo7OBIfZ34SdUHVaeX3ykOTOXaxj0v0HUdtf5He~Tf3DKt7CMPaqY3q4XFCcN5HR7SMiJoj56SaVlgcXfmQ6FGMrm0nfNhUBGxoxo1AILa5nT77bVmY-DlWGd6M7hMc7P0gylXqJxt6YpYcDTHE0tCUd7tj0vMdSTNa015EtDLXXe1zMsMkg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/success/default",
+                    "description": "Colour Styles: ui/success/default (#Token)",
+                    "created_at": "2022-05-09T18:36:03.521Z",
+                    "updated_at": "2022-05-09T18:36:03.521Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "WO"
+                },
+                {
+                    "key": "288bb1a54a106381689c4a3d0ead7371a991105f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10967",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/9Pz/xRF/z0wGiH3aNVoNHk96/style_thumbnail_15.png?Expires=1653868800&Signature=grYFx~HqQBuhr15KADnaNOmnMbzjFQupu4UWYC3tMbdnvkMsSwZPgVbQth0eJJmZcEyOytQ-dAPfA0FrlfHOHwucgi8-KkVI9r~TbgLATTQduRoo50TYgxFAWpCq615~0jYcVD-XCAUJ3ZjAB93or-hCR7QouUjT8DZ5PO-NLCP5HUY~gAjWKPganpjjOugxortYyrW9s5jyExlUxhQps9VrgLVA~gnlt0D2paCxZsusZn5yqrX1CvdZLP~BY4PeK7XzjBc2s~y500mbbJkpjZzYtIzXRKZMVAvM2VPFJwkUrqziCJkO~DwIVAFtTMkKgB4l3CYxxH~GDCYQtSLXZQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/error/default",
+                    "description": "Colour Styles: --ui-error-default-color (#Token)",
+                    "created_at": "2022-05-09T18:36:03.516Z",
+                    "updated_at": "2022-05-09T18:36:03.516Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "X"
+                },
+                {
+                    "key": "0a0aba446af46b81639cbdaf5d8e5b586d9c83cd",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7564",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/O36/WjK/DVLAGH9bARus5wYI/style_thumbnail_14.png?Expires=1653868800&Signature=TLdOmSddZv-IEV6h9K1vlOIVCk~nBdSqC7HYDvBPngO7tw9g1FWckkoDlOKTRfJW3agggq0EIhC3WajIbqvTHLZGOE6p7mj8aRvNlQ19WbqbBPsiSSMEqn~DAeQ1gQGGEWV4NMzvljIg3PJ27qR~KDlzivWHCC0kyHy4PiW390MtwKxjJ-6H8I9wZq45Ejab2Y6XxsaXxbCRzzDj8w0eBsL8jzbU~~pj-E2-0w17H199cvRsCv6EZ4h4lbwL0-IQCw8-mBEeSHdO5R68e8ppJgg6uke23qg2P4AYi0V8QwuGrXy0bngOHRNRmP0l~uMV-sM3rXs4rUVcZ3-xZVQ4~A__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/error/light",
+                    "description": "Colour Styles: --ui-error-light-color (#Token)",
+                    "created_at": "2022-05-09T18:36:03.510Z",
+                    "updated_at": "2022-05-09T18:36:03.510Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "d"
+                },
+                {
+                    "key": "c510581b70f968a40556cddd9ec3829efe91ec11",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10970",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/yQW/TCw/UYZN5MtSPtWoDRUN/style_thumbnail_13.png?Expires=1653868800&Signature=SfJ0MJBE-j9Krn2CXBStQ~we8pKKVMm1gmawU1XCzundSqpnjgiXrOKYSzjeuzsp24--zrSRynA704RGIRvMyh77OMqXJw8ZAd9sPa8fIpyshWXOWzK6yCwlrniC-~DilXKEPAg045ZECDXaDoAvC7SO21m4ErUC27vqfXfBuuyVvVfWsq6kq2vkeVXek8rh7HOPhMCuvgNCxJhKCTjNKll3AanOExcrYpvqCFb95TNBbvGuMpkib9QB7mpsP9Wlp4PVPTxFJDoUE6fOPuXl5T-jpK6ie9ehO-6-yhz7dhlRWchIXd0k-hcREWicgSYPMipdnfNXV7R6ZWGo-bkwBg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "background/1",
+                    "description": "Colour Styles: --background-1-colour (#Token)",
+                    "created_at": "2022-05-09T18:36:03.504Z",
+                    "updated_at": "2022-05-09T18:36:03.504Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "["
+                },
+                {
+                    "key": "0adb2bb91a54e4e7fa163676c0779b7033af967f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7565",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/8Nx/m5c/eOkMkhiu3dT0AC0R/style_thumbnail_12.png?Expires=1653868800&Signature=T~0xWGXDaAS2frF-TV1ujN0Rd9-3L8UbF2mtDg5vkBbI5R888GX3~3eVyaZGnQrkROmJqeguQnTILvgfBSkPtaNhEob-lSQidJvlslXiTZuiMzaStREOzhmOzTyupcCM~-kD1lBvtTSaI4gMXHpNkpPTIEY~vIcYLjqfWW4a5frabWRRwbtByd6ZLtYhb-u6zkMu9TGjP63zK5l3nTVbRpdTJuuEZcFlgik2OnFuEAZFea6MDhlG1SD~KDfFRS0fAkPaB~wsxEV6iKLMiUSjso56xNI9RdBr3sHIV1v3XJwPx4Mv8LWwquWZv5SvD6tfdCDgYwWWOCB-I4WSuDeccQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/error/dark",
+                    "description": "Colour Styles: --ui-error-dark-color (#Token)",
+                    "created_at": "2022-05-09T18:36:03.498Z",
+                    "updated_at": "2022-05-09T18:36:03.498Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "e"
+                },
+                {
+                    "key": "076435ccf252656be6b3b8e3c2e74ad4f35153af",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7567",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Piw/IUp/5mzjRum3l9Or7mH5/style_thumbnail_11.png?Expires=1653868800&Signature=fYhxaltyCyYh4Aso~CrGzHTxTtFjsMuM5zCLIbaV2lbmGcI61A6e2YoCJHMiUIYspKHkL908T3V1hajCKrpLopA~6GSE6B2tBGY7Llnf6mWLm2Dtond8f~X86hV27BgbvPPDqZPsufXuBw-ktwxdNqb6XAD43uupwVkECIGqlKrCoRnKg~E1qmERNE6NqISSb~9MR8yav2BN9kq9PcywBqc82nVqFoK-ROb18J27Oocg-P0ZVtzUkRQwQL4HIePUP6IUjJjdORnBnhyvWuy3RGvYnoFinTOwNT6dmR-m0JgEMFdOj0lLpKROKAJfmAKljSM0tBFaX5BKE4zOWAiiwQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/success/dark",
+                    "description": "Colour Styles: ui/success/dark (#Token)",
+                    "created_at": "2022-05-09T18:36:03.493Z",
+                    "updated_at": "2022-05-09T18:36:03.493Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "Wr"
+                },
+                {
+                    "key": "fa55f423c9266499c422d52053b9cc8ea01aae2f",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7568",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/TdZ/4rr/O4hGkR18KmA9VSZt/style_thumbnail_10.png?Expires=1653868800&Signature=a3~1LflWbwRdrbUWiIOiOk~gQ2H4LBhIHFP5LsMiSIlUV8iW7A-EKh8wH-VrAbCThU75rYOsk-qg8QVXB4pGSl~kxIPjRduKpAO4KLnRRDC7UETKUGLTF6DY9a6dgPJCJ35pTUcdzGQ-4r5GhRIBeTlF-2nUfZkOhZjhL9rqyuVKBT57RGCLvqX8mjkcKX1uda47-ByxRgwdnnhCsPiz-VrOhw~E-3UWb4MKyQucq87VDo-9YU-hRThAng6KNRWGUffFMMOZlBGT9SuEcynxb65VUF8PkMjg0FXYHusYL5R7pDPmvzA-0-73VQq9rg1sI7ZkdnDyjwPEDPbglEo9IQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/alert/light",
+                    "description": "Colour Styles: ui/alert/light (#Token)",
+                    "created_at": "2022-05-09T18:36:03.488Z",
+                    "updated_at": "2022-05-09T18:36:03.488Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "h"
+                },
+                {
+                    "key": "47afbb4e9d4d9a02e54abd3d3139cf20c1dda89e",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10964",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/wKB/bk4/7ttwj2gvUT4xzras/style_thumbnail_9.png?Expires=1653868800&Signature=I8sWtz0wgZQuKdfBQsp8aAXpx4GaYxJcr4dTc1CXFsEfL3ghYCO6ojMJLKsbxIXMRu5I0ytLQhbbHonyixRG2leNFX7HX3g2nykJpotx33KJvWpaGN8XK6pKzm09qz0BPo2jJ6zD22pukzqhHouoG5MDniuURBxezPpg1iM54NC6RECNClP97M7i7HPv58evx4FnJFcO5smVTD7i1FQktJMFiTPZY-WTQHxYZ0HwzQT3ZsZPxqVO8HfZeSoHQOqtRof4JeU~gFx0lmWfDdgttLf5cVpg8gihJWvsegvgJXKcjdJOGbUlNGyZjSanHey2VOAKQiJXjTdcmCyYAp-WPA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/Grayscale/tertiary",
+                    "description": "Colour Styles: ui/tertiary (#Token)",
+                    "created_at": "2022-05-09T18:36:03.482Z",
+                    "updated_at": "2022-05-09T18:36:03.482Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "U"
+                },
+                {
+                    "key": "89c6479821813ffd4246ced68c735a521652f2b5",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20003:10941",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Y8f/kWQ/7nyQPbznQl19yALp/style_thumbnail_8.png?Expires=1653868800&Signature=RFl2WousRv8NQn301jn9s5WgGff0uMMZdjJ-QOEaF3OR4M97LlaIvUNY0-GPjxoMFbmRb~5r~27-hPIs-NLaV1DlhG-qheDkVdKjff5BBoW6D3BXJ9I0i~JozXtvHyt4HmnWXJ31CkwnUgwUvuXdkAzNH15nK1TRnc~m64rnxxsUb3K5O327EiCKuG4HQkZxCcvkQKhoJbWPjxgOr9DqxfGJhVgCGUhk89FRIHqU6pD2EclYRNU2knNks-LBAOZenf8g-39mGIfBhpzUkdknZMectThpSg1JBU2Ywnf2zLnixilcTrQtLcBxFS-W7Ty3CkpYjPu6K~udU3ovsa08Wg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "brand/primary/main",
+                    "description": "Colour Styles: brand/primary/main (#Token)",
+                    "created_at": "2022-05-09T18:36:03.477Z",
+                    "updated_at": "2022-05-09T18:36:03.477Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "I"
+                },
+                {
+                    "key": "fbce4a9e33801e2ef1ba8039b2113c686277b78b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20519:3926",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/yxb/qYc/aBRE9Ac0iW2TbIT4/style_thumbnail_7.png?Expires=1653868800&Signature=gzMup0Q-9DZkWEBHk4wNK6Gm7F3ZA4RdIdxlRHOTFjt~LoP0z7ZEgH~CtA-n3Tsz7iSnqlT8rN2k6UOyqApsTCaUKs1XOcOW1PhhV13heqJhcxHmDSNPUOeZ5S~442POuzYEGyPZQdDQ5YfxDboQpp6PVZaCzeD3z8k~uMyAT7K~uBrHGRFlo761yMSm6o4HZc~fKJeRuOFbIgq95GpXISQeB~KjR~5ALg29joOWn6~QCVyhVOid3GUU5T59i0Gr1qSoon0XSWkZc~35XI3uWpFyIq8pcyUPUf~j2WkNwhQ7VISPtZeRp0Div8Tmeb-beGkFiBQvVfZGwEfaApXN8w__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "inline/m/default",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.472Z",
+                    "updated_at": "2022-05-09T18:36:03.472Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q{"
+                },
+                {
+                    "key": "30391beffefd13e8c0c224fc3732183ef79cad2d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20519:3927",
+                    "style_type": "TEXT",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/eJi/GSE/ILSTTQkwcVGBVzUt/style_thumbnail_6.png?Expires=1653868800&Signature=eZoW0hIatB-Aruq60EIqob1fMhrMmk3iVFiYR~G0NvwDLdM5DhGQX3mSHQS0XxlrJaIZaWmeJJcqxiR3iwaZCxEShByCq5Ep9-gS9f9hn7hu4CJhSoUYt-7Zxh~c5eaECXlXO6H8TtRiRrnoxbWXpZvndSQ5EzD8zGXeYrypQiKQX87LNwKc8Ku6HTfLp8IQEG2hT7fR0yNoZQI3OEuf7hq6V0GBcBWXXSu2-DVOHkUHH~WCzIVvLZ0fEv1eREoShTgXIcxPKzn33xe1nQjx0Z7xkZVa8w4DwkMPcSqJ7yZo9ts7FiVDgjtDUA~lHE3WYzp6t-BG5h~9FCON0aKybA__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "inline/m/hover",
+                    "description": "",
+                    "created_at": "2022-05-09T18:36:03.466Z",
+                    "updated_at": "2022-05-09T18:36:03.466Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~q|"
+                },
+                {
+                    "key": "40c6ede7fc447275e33fb9b6afc600e2972693d2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20029:15096",
+                    "style_type": "GRID",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/Rle/LKQ/E5tc4MbBJsEcqmUk/style_thumbnail_5.png?Expires=1653868800&Signature=fWRsm5szvmRpZxCXuV9B2GUrEYdmH0hMA8KATr4zaN-z8fca~s1L99l2jj9YewZoddMlUattO9zm0SskU~FVKEscqAe1-4126FY28yQlzEF2~bnUaUqlN6i-F7MPUa8HQOfMTyUUEf3mHGJFgzfO5xAwBh9S09npPqFF3KVui3cyLlXZCiEO98DK1o4-s6s2kfu7Eujqys968Ff1-rZN93TztET1UxbMjqrr0Kqdm9Bw5bc2z9ZcqDiOGn~FsEv8JWiTwyhARGKykIBHmIS332oMOq76hsPOOD2JNRNoVdl7PAzQ2Uuj5yGVnXkSErb~cMlE3SSPDe6LPQ-w96osGw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Large Desktop (1440px)",
+                    "description": "Grid Token: --l-desktop-1440px-12-columns (#Token, #large, #grid)",
+                    "created_at": "2022-05-09T18:36:03.461Z",
+                    "updated_at": "2022-05-09T18:36:03.461Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~y"
+                },
+                {
+                    "key": "d357173388a0b2e95a1ab88b1c09e76074a6fbe2",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20029:15097",
+                    "style_type": "GRID",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/T8J/Py3/CjSO0EzabWPfxfFv/style_thumbnail_4.png?Expires=1653868800&Signature=SH7OQhE~9-E2i8F2sUvAtXhg8rxXioKefr1Y1To3K4HfqNtJ4AePXzrXHN4J-c1GUEle2GYcLPbyS8KAw6jcFa7IfypHQOfimQD6Cwh8zCpbHqwhP1yZ1rc7P0DIRxrIeNNVLAHzVBNNW-nQ-xzar-Chr08~oHdxul8VysGbpIpyZJGAAddwsog21uyz3Y2Li5Ute1gLpujfdE7eAlDZ9qMK5gEN5IjEoe6p~QsCQe18kKMEXAele-r4yLLqRoxGtXXfX~b6w~dDSRctb057g4q1wqRyAxjRgR1eP2yvsxYsl80dJz~jhOXznV2nEIsqHiUzGpGYZO3tWFAYKXn1Zw__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Tablet (768px)",
+                    "description": "Grid Token: --m-tablet-768px-8-columns (#Token, #medium, #grid)",
+                    "created_at": "2022-05-09T18:36:03.455Z",
+                    "updated_at": "2022-05-09T18:36:03.455Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~z"
+                },
+                {
+                    "key": "caa8e9b0cae7cbb0bc56d4ef2df86a162d8fbd7b",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20127:7566",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/lty/tNe/JDUDu7NkkEYcZChn/style_thumbnail_3.png?Expires=1653868800&Signature=abgVUZ16ZrGmQAucpfb92-7D0eQAH~rAph0SpD8TFoGBsXv9nP94kHOCm6E4~pFN5dYXnGpGU2WFqkWYZKwTDRW-Gpbza8A8KcQI873Gq5E4SqSYsape-iZHc-oafvp7U~YtpZIQvvZTIIucZqKZqrOdm6BQsgy5QhApNXms5vRPSnd~Om1acwDdlCMQBIrpbAY8pLi7MBfTN4PxBJk1debDT9QOZIivHhC9gqGDTMo-CdLusE2YtPX0bpy7DsM-WDLStBrRvfAenBbvanOq6kLK9jbH873zU4Nuceq09hvCubcJhrF3t2lH4J1pJKMzs6laJxcIvmvoDPoiptkotQ__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/success/light",
+                    "description": "Colour Styles: ui/success/light (#Token)",
+                    "created_at": "2022-05-09T18:36:03.450Z",
+                    "updated_at": "2022-05-09T18:36:03.450Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "Wf"
+                },
+                {
+                    "key": "e0db952545244f354d49f08bec2860002e22fd6d",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10969",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/5er/8FU/3M1CyQRaGHy4Jx0A/style_thumbnail_2.png?Expires=1653868800&Signature=fwcRgvA9dH~sy-08mMGyblgFtAjeBAIV6YnlhlppW1VUQMqcgTtoo-Oe4-qoF7S6BUo9oNwDWDhOCits8R4RU5dA49Ze6DU1Xdizyybz9aKFWAkJNfGGpZ~ZqnilW4G1690t0holPlU1rBTdPZbGDPzNEoqFEPDa6UGiFAZ7wVW0tt~ia-MeiA5JpPoi8JQ4EkdeN5GYtTEN3vOCwkD5hOgmaaBZMNdGevJmR66OMzwGxWDHd9XVHmWKxiXwbV1htButVS0pg0qA~phLSvcTgBLQPeULj44YoVcEDoenbykm7rudl8FjVpE9WYGzMPj8z2jmE8~scNm0E9yGymDTRg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/alert/default",
+                    "description": "Colour Styles: ui/alert/default (#Token)",
+                    "created_at": "2022-05-09T18:36:03.444Z",
+                    "updated_at": "2022-05-09T18:36:03.444Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "Z"
+                },
+                {
+                    "key": "18290da001f3b038eeaa3f1e941761c6812c07be",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20029:15098",
+                    "style_type": "GRID",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/y0Q/c6C/baJphLvh4J62vYpn/style_thumbnail_1.png?Expires=1653868800&Signature=bMp-dv-rYXFwt1NTaSu4eqaGCK~oeJbydeL631iLy8gl7q2JqZRgr8Ju4me9RSjRGeyE6nBJ7atfJDjEXWwXTmqe3zuWvg~asENwGBpbBUOdTaf3u~qlq1GvZ8VPo1yhA7ugLQWc8TT-WQmpqwkuUOQubBexoJdPV~ZEIob4ExLDoGi8MH~rh~OV3hYVj32p~QyaLd7gxqUGkCxtN1WzD1jlJkycHDiv4LKLBxrjgLc5qY8e5BCoSdNi4HhrUJ7pzlIio0rG690DKYKtUV5RU1jh84xTy07rCoQkyYO5~euwWtg3T9AVb~GW14183AywwirErwvoVpxEykeLp4u1ww__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "Mobile (360px)",
+                    "description": "Grid Token: --s-mobile-360px-4-columns (#Token, #small, #grid)",
+                    "created_at": "2022-05-09T18:36:03.438Z",
+                    "updated_at": "2022-05-09T18:36:03.438Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "!~~{"
+                },
+                {
+                    "key": "b495cd185b76fdfb8dd9b058c795baea5d0488e9",
+                    "file_key": "TJzz7ZB6pJvpLhjI5DWG3F",
+                    "node_id": "20008:10966",
+                    "style_type": "FILL",
+                    "thumbnail_url": "https://s3-alpha-sig.figma.com/checkpoints/eSK/vpa/yhyCltrzTfEro5ZD/style_thumbnail_0.png?Expires=1653868800&Signature=QTvRThliNnD2ZbEMbsPdcI9Ajv6041KUSSncOwYfIyqbNNisBovakHWkecU9xH0CexXMyzwO6UZ4CW6wpjl1xjgJ429bn4On4vIVBkP5wtvqXUxAGwqDWKQWo5Dbev2ylsz1OfbzuaHwdOCfdQ89DRmFAbTV72OO4a-CVnyegZSkVC7fL7JNqiUdJK-Bx8kT6l3W5M~PWHQO7xMmto0KVI4YgHOcbFDb3TsKb6F06im~5rNdhnCPoVf0YbDuutb2fBqOZyNz1-l0vtbaxbJeVC7D47jg8bCil0LUox-v3s33QXbnSpzKau1-Azz3SHBmL78t1f~hOPf6ZKlfLtmfUg__&Key-Pair-Id=APKAINTVSUGEWH5XD5UA",
+                    "name": "UI/Grayscale/disabled",
+                    "description": "Colour Styles: ui/disabled (#Token)",
+                    "created_at": "2022-05-09T18:36:03.431Z",
+                    "updated_at": "2022-05-09T18:36:03.431Z",
+                    "user": {
+                        "id": "716290236385945493",
+                        "handle": " ",
+                        "img_url": "https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd"
+                    },
+                    "sort_position": "W"
+                }
+            ]
+        },
+        "i18n": null
+    }
+}

--- a/packages/cli/src/commands/styles/lib/radius-styles.test.ts
+++ b/packages/cli/src/commands/styles/lib/radius-styles.test.ts
@@ -1,0 +1,38 @@
+import * as publishNodes from './__mocks__/publish.nodes.json';
+import * as publishStyles from './__mocks__/publish.styles.json';
+import * as publishComponents from './__mocks__/publish.components.json';
+import * as publishComponentsNodes from './__mocks__/publish.nodes.components.dt.json';
+
+import { generateGlobalStyles, Options } from './radius-styles';
+import axios from 'axios';
+// import { NodeDoc, NodeDocument } from './figma.utils';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('getStyles, getStyleNodes and processStyles', () => {
+  it('should fail', async() => {
+    mockedAxios.get
+      .mockResolvedValueOnce(publishStyles)
+      .mockResolvedValueOnce(publishNodes)
+      .mockResolvedValueOnce(publishComponents)
+      .mockResolvedValueOnce(publishComponentsNodes);
+
+    const options: Options = {
+      url:'https://api.figma.com/v1/file/TJzz7ZB6pJvpLhjI5DWG3F/',
+      userToken: 'xxxxxx-Token-xxxxxx',
+      outputDir: './generatedTokens',
+      dryRun:true,
+      consoleOutput:false,
+      template:'css-modules'
+    };
+    const files = await generateGlobalStyles(options);
+    
+    expect(!!files).toBe(true);
+    if(files){ 
+      expect(files.length).toBe(6);
+      expect(files[0][0]).toBe('./index.css');
+    }
+
+  });
+});

--- a/packages/cli/src/commands/styles/lib/radius-styles.ts
+++ b/packages/cli/src/commands/styles/lib/radius-styles.ts
@@ -39,26 +39,6 @@ export type Options = {
 
 export const groupByType = <T extends DesignToken>(list: T[]) => groupBy(list, 'type');
 
-//TODO -> it is not filtering duplicates 
-// type designTokenTypes = 'typography' | 'color' | 'spacing' | 'breakpoint' | 'grid' | 'elevation';
-
-// const removeDuplicateTokens = (tokenGroups: DesignTokenGroup, latestTokenGroups: DesignTokenGroup) => {
-//   let key: designTokenTypes;
-//   for(key in tokenGroups) {
-//     if(tokenGroups[key] && latestTokenGroups[key]){
-//       const listOfNames: string[] = [];
-//       tokenGroups[key] = [...tokenGroups[key], ...latestTokenGroups[key]].filter((designToken: DesignToken)=>{
-//         if(listOfNames.includes(designToken.name)){
-//           return false;
-//         }
-//         listOfNames.push(designToken.name);
-//         return true;
-//       });
-//     }
-//   }
-//   return tokenGroups;
-// };
-
 export const generateGlobalStyles = async ({
   url,
   userToken = token,
@@ -78,6 +58,7 @@ export const generateGlobalStyles = async ({
 
   const files = renderTemplate(designTokens);
 
+  if(dryRun) return files;
 
   if (consoleOutput) {
     // files.forEach(([fileName, content]) => {
@@ -87,9 +68,8 @@ export const generateGlobalStyles = async ({
     // });
   } else {
     logger.info(`output directory: ${ chalk.red(outputDir) }`);
-
+        
     files.forEach(([fileName, content]) => {
-
       const filePath = path.resolve(outputDir ?? '.', fileName);
       const fileDir = path.dirname(filePath);
 

--- a/packages/cli/src/commands/styles/lib/radius-styles.ts
+++ b/packages/cli/src/commands/styles/lib/radius-styles.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
-  DesignToken,
-  getTokens
+  DesignToken//,
+  // getTokens
 } from '../utils/figma.utils';
-// import { getFileKey, figmaAPIFactory } from '../utils/publish.main';
+import { figmaAPIFactory } from '../utils/publish.main';
 import { assert } from '../utils/common.utils';
 import { groupBy } from '../utils/common.utils';
 import renderers from './templates';
@@ -11,7 +11,7 @@ import path from 'path';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';
 import { logger } from '../../../logger';
 import chalk from 'chalk';
-import { loadFile } from '../utils/figma.loader';
+// import { loadFile } from '../utils/figma.loader';
 
 // import { TokenOption } from '../utils/figmaResolver.utils';
 // import { getColor2, getTypography2 } from '../utils/extractors/figmaExtractors';
@@ -71,12 +71,16 @@ export const generateGlobalStyles = async ({
   assert(typeof url === 'string', 'Figma url must be provided');
 
   const renderTemplate = renderers[template];
-  const tokenGroupsFigmaBlob = await loadFile({ url, token: userToken }).then(getTokens).then(groupByType);
-  // const figmaAPI = figmaAPIFactory(userToken);
+  // const tokenGroupsFigmaBlob = await loadFile({ url, token: userToken }).then(getTokens).then(groupByType);
   // const tokenGroupsFigmaApi = await figmaAPI.processStyles(getFileKey(url));
   // console.log(tokenGroupsFigmaApi);
 
-  const files = renderTemplate(tokenGroupsFigmaBlob);
+  const figmaAPI = figmaAPIFactory(userToken);
+  const designTokens = await figmaAPI.processStyles(url);
+  
+
+  // const tokenGroupsFigmaBlob = groupByType([{} as DesignToken]);
+  const files = renderTemplate(designTokens);
 
 
   if (consoleOutput) {

--- a/packages/cli/src/commands/styles/lib/radius-styles.ts
+++ b/packages/cli/src/commands/styles/lib/radius-styles.ts
@@ -71,15 +71,11 @@ export const generateGlobalStyles = async ({
   assert(typeof url === 'string', 'Figma url must be provided');
 
   const renderTemplate = renderers[template];
-  // const tokenGroupsFigmaBlob = await loadFile({ url, token: userToken }).then(getTokens).then(groupByType);
-  // const tokenGroupsFigmaApi = await figmaAPI.processStyles(getFileKey(url));
-  // console.log(tokenGroupsFigmaApi);
 
   const figmaAPI = figmaAPIFactory(userToken);
   const designTokens = await figmaAPI.processStyles(url);
   
 
-  // const tokenGroupsFigmaBlob = groupByType([{} as DesignToken]);
   const files = renderTemplate(designTokens);
 
 

--- a/packages/cli/src/commands/styles/lib/templates/css-modules/template.ts
+++ b/packages/cli/src/commands/styles/lib/templates/css-modules/template.ts
@@ -96,7 +96,6 @@ export const typography: RenderTokenFile = (tokens, _type, { breakpoints }) => {
     viewPort: k,
     value: breakpoints[k]
   }));
-
   return [
     './_typography.css',
     `

--- a/packages/cli/src/commands/styles/lib/templates/utils.spec.ts
+++ b/packages/cli/src/commands/styles/lib/templates/utils.spec.ts
@@ -91,7 +91,7 @@ describe('Styles - Utils - generateTypographyTokenBody', () => {
   * @presenter FontSize
   */
 
-       --ds-cale: 50;`);
+       --scale: 50;`);
   });
   
   it('with weight generate weight tokens', async () => {
@@ -102,7 +102,7 @@ describe('Styles - Utils - generateTypographyTokenBody', () => {
   * @presenter FontWeight
   */
 
-       --ds-eight: 50;`);
+       --weight: 50;`);
   });
 
 });

--- a/packages/cli/src/commands/styles/lib/templates/utils.spec.ts
+++ b/packages/cli/src/commands/styles/lib/templates/utils.spec.ts
@@ -91,7 +91,7 @@ describe('Styles - Utils - generateTypographyTokenBody', () => {
   * @presenter FontSize
   */
 
-       --dscale: 50;`);
+       --ds-cale: 50;`);
   });
   
   it('with weight generate weight tokens', async () => {
@@ -102,7 +102,7 @@ describe('Styles - Utils - generateTypographyTokenBody', () => {
   * @presenter FontWeight
   */
 
-       --dseight: 50;`);
+       --ds-eight: 50;`);
   });
 
 });

--- a/packages/cli/src/commands/styles/lib/templates/utils.ts
+++ b/packages/cli/src/commands/styles/lib/templates/utils.ts
@@ -6,6 +6,7 @@ export const createTokenContext = (
   tokenGroup: DesignTokenGroup
 ): TokenContext => {
   const { breakpoint } = tokenGroup;
+  if(breakpoint === undefined || !Array.isArray(breakpoint)) return breakpoint;
   const breakpoints = breakpoint.reduce((res, item) => {
     return {
       ...res,
@@ -35,7 +36,6 @@ export type typographyMap = {
 
 const extractFontBody = (tokens: DesignToken[], filterType: string, typographyCommentKey: string): string => {
   return tokens.filter((token) => token.name.includes(filterType)).map((token, index)=> {
-    // console.log( token);
     if(index ==0) {
       return `\n${ TYPOGRAPHY_FILE_COMMENTS[typographyCommentKey as keyof typeof TYPOGRAPHY_FILE_COMMENTS] }\n
        ${ generateTypographyCSS(token) }`; 
@@ -45,7 +45,6 @@ const extractFontBody = (tokens: DesignToken[], filterType: string, typographyCo
 };
 
 export const generateTypographyTokenBody = (tokens: DesignToken[]): string => {
-  // console.log(tokens);
   const scale = extractFontBody(tokens, 'Font scale', 'scale');
   const weight = extractFontBody(tokens, 'Font weight', 'weight');
   const spacing = extractFontBody(tokens, 'Letter spacing', 'spacing');

--- a/packages/cli/src/commands/styles/lib/templates/utils.ts
+++ b/packages/cli/src/commands/styles/lib/templates/utils.ts
@@ -35,6 +35,7 @@ export type typographyMap = {
 
 const extractFontBody = (tokens: DesignToken[], filterType: string, typographyCommentKey: string): string => {
   return tokens.filter((token) => token.name.includes(filterType)).map((token, index)=> {
+    // console.log( token);
     if(index ==0) {
       return `\n${ TYPOGRAPHY_FILE_COMMENTS[typographyCommentKey as keyof typeof TYPOGRAPHY_FILE_COMMENTS] }\n
        ${ generateTypographyCSS(token) }`; 
@@ -44,6 +45,7 @@ const extractFontBody = (tokens: DesignToken[], filterType: string, typographyCo
 };
 
 export const generateTypographyTokenBody = (tokens: DesignToken[]): string => {
+  // console.log(tokens);
   const scale = extractFontBody(tokens, 'Font scale', 'scale');
   const weight = extractFontBody(tokens, 'Font weight', 'weight');
   const spacing = extractFontBody(tokens, 'Letter spacing', 'spacing');

--- a/packages/cli/src/commands/styles/utils/cssGenerator.utils.test.ts
+++ b/packages/cli/src/commands/styles/utils/cssGenerator.utils.test.ts
@@ -9,12 +9,12 @@ import { DesignToken } from '../utils/figma.utils';
 
 describe('CSS Generator', () => {
   it('should generate color variables with the right name and value', () => {
-    const expectedOutput = '--ds-color-text-success: #138000;';
+    const expectedOutput = '--ds-color--colour-text-success: #138000;';
 
     const designToken: DesignToken = {
       type: 'color',
       name: 'color css test',
-      token: '--colour-text-success',
+      token: '-colour-text-success',
       value: '#138000'
     };
 
@@ -27,7 +27,7 @@ describe('CSS Generator', () => {
       {
         type: 'typography',
         name: 'typography css test',
-        token: '--typography-label-font-family',
+        token: '-typography-label-font-family',
         value: 'Roboto'
       };
 
@@ -42,7 +42,7 @@ describe('CSS Generator', () => {
       {
         type: 'spacing',
         name: 'spacing css test',
-        token: '--space-1',
+        token: '-space-1',
         value: '4'
       };
 
@@ -73,7 +73,7 @@ describe('CSS Generator', () => {
       {
         type: 'grid',
         name: 'grid css test',
-        token: '--grid-margin-l',
+        token: '-grid-margin-l',
         value: '154'
       };
 

--- a/packages/cli/src/commands/styles/utils/cssGenerator.utils.test.ts
+++ b/packages/cli/src/commands/styles/utils/cssGenerator.utils.test.ts
@@ -9,12 +9,12 @@ import { DesignToken } from '../utils/figma.utils';
 
 describe('CSS Generator', () => {
   it('should generate color variables with the right name and value', () => {
-    const expectedOutput = '--ds-color--colour-text-success: #138000;';
+    const expectedOutput = '--colour-text-success: #138000;';
 
     const designToken: DesignToken = {
       type: 'color',
       name: 'color css test',
-      token: '-colour-text-success',
+      token: 'colour-text-success',
       value: '#138000'
     };
 
@@ -27,11 +27,11 @@ describe('CSS Generator', () => {
       {
         type: 'typography',
         name: 'typography css test',
-        token: '-typography-label-font-family',
+        token: 'typography-label-font-family',
         value: 'Roboto'
       };
 
-    const expectedOutput = '--ds-typography-label-font-family: Roboto;';
+    const expectedOutput = '--typography-label-font-family: Roboto;';
 
     expect(generateTypographyCSS).toBeDefined();
     expect(generateTypographyCSS(designToken)).toBe(expectedOutput);
@@ -42,11 +42,11 @@ describe('CSS Generator', () => {
       {
         type: 'spacing',
         name: 'spacing css test',
-        token: '-space-1',
+        token: 'space-1',
         value: '4'
       };
 
-    const expectedOutput = '--ds-space-1: 0.25rem;';
+    const expectedOutput = '--space-1: 0.25rem;';
 
     expect(generateSpacingCSS).toBeDefined();
     expect(generateSpacingCSS(designToken)).toBe(expectedOutput);
@@ -61,7 +61,7 @@ describe('CSS Generator', () => {
         value: 'drop-shadow(0px 8px rgba(48 49 51 0.10)) drop-shadow(0px 0px rgba(48 49 51 0.05))'
       };
 
-    const expectedOutput = '--ds-elevation-80: drop-shadow(0px 8px rgba(48 49 51 0.10)) ' +
+    const expectedOutput = '--elevation-80: drop-shadow(0px 8px rgba(48 49 51 0.10)) ' +
       'drop-shadow(0px 0px rgba(48 49 51 0.05));';
 
     expect(generateElevationCSS).toBeDefined();
@@ -73,11 +73,11 @@ describe('CSS Generator', () => {
       {
         type: 'grid',
         name: 'grid css test',
-        token: '-grid-margin-l',
+        token: 'grid-margin-l',
         value: '154'
       };
 
-    const expectedOutput = '--ds-grid-margin-l: 154px;';
+    const expectedOutput = '--grid-margin-l: 154px;';
 
     expect(generateGridCSS).toBeDefined();
     expect(generateGridCSS(designToken)).toBe(expectedOutput);

--- a/packages/cli/src/commands/styles/utils/cssGenerator.utils.ts
+++ b/packages/cli/src/commands/styles/utils/cssGenerator.utils.ts
@@ -3,21 +3,21 @@ import { tokenizeName } from './figma.tokenizer';
 
 export const generateColorsCSS = (designToken: DesignToken) => {
   if(!designToken.token) designToken.token = tokenizeName(designToken.name);
-  const key = `--ds-color-${ designToken.token }`;
+  const key = `--${ designToken.token }`;
   const value = designToken.value;
   return `${ key }: ${ value };`;
 };
 
 export const generateTypographyCSS = (designToken: DesignToken) => {
   if(!designToken.token) designToken.token = tokenizeName(designToken.name);
-  const key = `--ds-${ designToken.token?.substring(1) }`;
+  const key = `--${ designToken.token }`;
   const value = designToken.value;
   return `${ key }: ${ value };`;
 };
 
 export const generateSpacingCSS = (designToken: DesignToken) => {
   if(!designToken.token) designToken.token = tokenizeName(designToken.name);
-  const key = `--ds-${ designToken.token?.substring(1) }`;
+  const key = `--${ designToken.token }`;
   const value = designToken.value;
   const remValue = Number(value)/16 + 'rem';
   return `${ key }: ${ remValue };`;
@@ -25,14 +25,14 @@ export const generateSpacingCSS = (designToken: DesignToken) => {
 
 export const generateElevationCSS = (designToken: DesignToken) => {
   if(!designToken.token) designToken.token = tokenizeName(designToken.name);
-  const key = `--ds-${ designToken.token }`;
+  const key = `--${ designToken.token }`;
   const value = designToken.value;
   return `${ key }: ${ value };`;
 };
 
 export const generateGridCSS = (designToken: DesignToken) => {
   if(!designToken.token) designToken.token = tokenizeName(designToken.name);
-  const key = `--ds-${ designToken.token?.substring(1) }`;
+  const key = `--${ designToken.token }`;
   const value = designToken.value+ 'px';
   return `${ key }: ${ value };`;
 };

--- a/packages/cli/src/commands/styles/utils/cssGenerator.utils.ts
+++ b/packages/cli/src/commands/styles/utils/cssGenerator.utils.ts
@@ -1,19 +1,19 @@
 import { DesignToken } from '../utils/figma.utils';
 
 export const generateColorsCSS = (designToken: DesignToken) => {
-  const key = `--ds-color${ designToken.token.substring(8) }`;
+  const key = `--ds-color${ designToken.token?.substring(8) }`;
   const value = designToken.value;
   return `${ key }: ${ value };`;
 };
 
 export const generateTypographyCSS = (designToken: DesignToken) => {
-  const key = `--ds${ designToken.token.substring(1) }`;
+  const key = `--ds${ designToken.token?.substring(1) }`;
   const value = designToken.value;
   return `${ key }: ${ value };`;
 };
 
 export const generateSpacingCSS = (designToken: DesignToken) => {
-  const key = `--ds${ designToken.token.substring(1) }`;
+  const key = `--ds${ designToken.token?.substring(1) }`;
   const value = designToken.value;
   const remValue = Number(value)/16 + 'rem';
   return `${ key }: ${ remValue };`;
@@ -26,7 +26,7 @@ export const generateElevationCSS = (designToken: DesignToken) => {
 };
 
 export const generateGridCSS = (designToken: DesignToken) => {
-  const key = `--ds${ designToken.token.substring(1) }`;
+  const key = `--ds${ designToken.token?.substring(1) }`;
   const value = designToken.value+ 'px';
   return `${ key }: ${ value };`;
 };

--- a/packages/cli/src/commands/styles/utils/cssGenerator.utils.ts
+++ b/packages/cli/src/commands/styles/utils/cssGenerator.utils.ts
@@ -1,32 +1,38 @@
 import { DesignToken } from '../utils/figma.utils';
+import { tokenizeName } from './figma.tokenizer';
 
 export const generateColorsCSS = (designToken: DesignToken) => {
-  const key = `--ds-color${ designToken.token?.substring(8) }`;
+  if(!designToken.token) designToken.token = tokenizeName(designToken.name);
+  const key = `--ds-color-${ designToken.token }`;
   const value = designToken.value;
   return `${ key }: ${ value };`;
 };
 
 export const generateTypographyCSS = (designToken: DesignToken) => {
-  const key = `--ds${ designToken.token?.substring(1) }`;
+  if(!designToken.token) designToken.token = tokenizeName(designToken.name);
+  const key = `--ds-${ designToken.token?.substring(1) }`;
   const value = designToken.value;
   return `${ key }: ${ value };`;
 };
 
 export const generateSpacingCSS = (designToken: DesignToken) => {
-  const key = `--ds${ designToken.token?.substring(1) }`;
+  if(!designToken.token) designToken.token = tokenizeName(designToken.name);
+  const key = `--ds-${ designToken.token?.substring(1) }`;
   const value = designToken.value;
   const remValue = Number(value)/16 + 'rem';
   return `${ key }: ${ remValue };`;
 };
 
 export const generateElevationCSS = (designToken: DesignToken) => {
+  if(!designToken.token) designToken.token = tokenizeName(designToken.name);
   const key = `--ds-${ designToken.token }`;
   const value = designToken.value;
   return `${ key }: ${ value };`;
 };
 
 export const generateGridCSS = (designToken: DesignToken) => {
-  const key = `--ds${ designToken.token?.substring(1) }`;
+  if(!designToken.token) designToken.token = tokenizeName(designToken.name);
+  const key = `--ds-${ designToken.token?.substring(1) }`;
   const value = designToken.value+ 'px';
   return `${ key }: ${ value };`;
 };

--- a/packages/cli/src/commands/styles/utils/figma.tokenizer.ts
+++ b/packages/cli/src/commands/styles/utils/figma.tokenizer.ts
@@ -1,0 +1,61 @@
+import { colorToHex, NodeDocument, DesignToken,  Color, processTypographyDesignToken, NodeDoc } from './figma.utils';
+// import { DesignToken, , FigmaFileNodes, NodeDocument, FigmaNodeKey,Styles } from './figma.utils';
+
+export const colorDesignTokenizer = (node: NodeDocument): DesignToken => {
+  colorToHex(node.fills[0].color);
+  const colorToken: DesignToken = {
+    type: 'color' ,
+    name: node.name,
+    node_id: node.id,
+    value: colorToHex(node.fills[0].color)
+  };
+  return colorToken;
+};
+
+export const processElevationTokenizer = (nodeDoc: NodeDocument): DesignToken[] => {
+  const { name, effects } = nodeDoc;
+  if(!effects) return [];
+
+  const token = name.toLowerCase().split('/').filter((item) => item !== 'light').join('-').replace('%','');
+
+  const rgbMap = effects.map((effect) =>  {
+    const objKeys = Object.keys(effect.color)as Array<keyof Color>;
+    return objKeys
+      .map((_key) => {
+        if(_key == 'a') {
+          return effect.color[_key].toFixed(2);
+        }
+        return Math.round(effect.color[_key]*255);
+      }).join(', ');
+  });
+  
+  const offsetMap = effects.map((effect)=> {
+    const offsetKeys = Object.keys(effect.offset) as Array<keyof { x: number, y: number }>;
+    const shadowValues = offsetKeys.map((_key) => {
+      return effect.offset[_key] + 'px ';
+    }).join('');
+    return shadowValues.concat(`${ effect.radius.toString() }px`);
+  });
+  
+  const tokenMap = Object.keys(rgbMap).map((_key, index) => {
+    if(offsetMap[index]) {
+      return `${ offsetMap[index] } rgba(${ rgbMap[index] })`;
+    }
+  });
+  
+  return [{
+    type: 'elevation',
+    name: `${ name }`,
+    token: `${ token }`,
+    value: tokenMap.join(', ')
+  }] as DesignToken[];
+};
+
+
+export const typographyTokenizer = (nodeDoc: NodeDocument): DesignToken[] => {
+  const allTypeography: DesignToken[] = [];
+  for(const style in nodeDoc.style){
+    allTypeography.push(processTypographyDesignToken(nodeDoc as NodeDoc,style)); 
+  }
+  return allTypeography;
+};

--- a/packages/cli/src/commands/styles/utils/figma.tokenizer.ts
+++ b/packages/cli/src/commands/styles/utils/figma.tokenizer.ts
@@ -1,8 +1,8 @@
 import { colorToHex, NodeDocument, DesignToken,  Color, processTypographyDesignToken, NodeDoc } from './figma.utils';
 // import { DesignToken, , FigmaFileNodes, NodeDocument, FigmaNodeKey,Styles } from './figma.utils';
+import { LayoutGrid } from 'figma-api/lib/ast-types';
 
 export const colorDesignTokenizer = (node: NodeDocument): DesignToken => {
-  colorToHex(node.fills[0].color);
   const colorToken: DesignToken = {
     type: 'color' ,
     name: node.name,
@@ -58,4 +58,71 @@ export const typographyTokenizer = (nodeDoc: NodeDocument): DesignToken[] => {
     allTypeography.push(processTypographyDesignToken(nodeDoc as NodeDoc,style)); 
   }
   return allTypeography;
+};
+
+export const gridTokenizer = (nodeDoc: NodeDocument): DesignToken[] => {
+  const designTokens: DesignToken[] = [];
+
+  if(!nodeDoc.layoutGrids || nodeDoc.layoutGrids.length === 0) return designTokens;
+
+  let layout: LayoutGrid|undefined = undefined;//nodeDoc.layoutGrids[0];
+
+  // there can be multiple layouts
+  // but most likely this the first one, with these properties should work
+  layout = nodeDoc.layoutGrids.filter((layoutGrid: LayoutGrid)=> {
+    return layoutGrid && layoutGrid.pattern === 'COLUMNS' && layoutGrid.count > 1;
+  })[0];
+
+  if(layout === undefined) return designTokens;
+  
+
+  // if the name has px in it, it's probably the breakpoint
+  if(nodeDoc.name.includes('px')){
+    const matched = nodeDoc.name.match(/([0-9]*)px/m);
+    if(matched && matched.length >= 2) {
+      designTokens.push({
+        type:'breakpoint',
+        name: `${ nodeDoc.name }`,
+        node_id: nodeDoc.id,
+        value: `${ matched[1] }px`
+      } as DesignToken);
+    }
+  }
+
+  // TODO: this is not actaully the column width - IDK what it actually is
+  // This is usually a negative number
+  // // /** Width of column grid or height of row grid or square grid spacing */
+  // designTokens.push({
+  //   type:'grid',
+  //   name: `${ nodeDoc.name } column size`,
+  //   node_id: nodeDoc.id,
+  //   value: `${ layout.sectionSize }`
+  // } as DesignToken);
+  
+
+  /** Spacing before the first column or row */
+  designTokens.push({
+    type:'grid',
+    name: `${ nodeDoc.name } margin`,
+    node_id: nodeDoc.id,
+    value: `${ layout.offset }px`
+  } as DesignToken);
+
+  // /** Spacing in between columns and rows */
+  designTokens.push({
+    type:'grid',
+    name: `${ nodeDoc.name } gutter`,
+    node_id: nodeDoc.id,
+    value: `${ layout.gutterSize }px`
+  } as DesignToken);
+
+  // /** Number of columns or rows */
+  designTokens.push({
+    type:'grid',
+    name: `${ nodeDoc.name } count`,
+    node_id: nodeDoc.id,
+    value: `${ layout.count }`
+  } as DesignToken);
+
+  return designTokens;
 };

--- a/packages/cli/src/commands/styles/utils/figma.tokenizer.ts
+++ b/packages/cli/src/commands/styles/utils/figma.tokenizer.ts
@@ -4,12 +4,14 @@ import { LayoutGrid } from 'figma-api/lib/ast-types';
 
 
 export const tokenizeName = (text: string) => {
-  return text.toString().replace(/[A-Z]/g, (newText: string) => '-' + newText.toLowerCase())
+  const out = text.toString().replace(/[A-Z]/g, (newText: string) => '-' + newText.toLowerCase())
     .replace(/\s+/g, '-')
     .replace(/[^\w-]+/g, '-')
     .replace(/--+/g, '-')
     .replace(/^-+/, '-')
     .replace(/-+$/, '-');
+  if(out.charAt(0) === '-') return out.substring(1);
+  return out;
 };
 
 
@@ -64,11 +66,11 @@ export const processElevationTokenizer = (nodeDoc: NodeDocument): DesignToken[] 
 
 
 export const typographyTokenizer = (nodeDoc: NodeDocument): DesignToken[] => {
-  const allTypeography: DesignToken[] = [];
+  const typographyTokens: DesignToken[] = [];
   for(const style in nodeDoc.style){
-    allTypeography.push(processTypographyDesignToken(nodeDoc as NodeDoc,style)); 
+    typographyTokens.push(processTypographyDesignToken(nodeDoc as NodeDoc,style)); 
   }
-  return allTypeography;
+  return typographyTokens;
 };
 
 export const gridTokenizer = (nodeDoc: NodeDocument): DesignToken[] => {

--- a/packages/cli/src/commands/styles/utils/figma.tokenizer.ts
+++ b/packages/cli/src/commands/styles/utils/figma.tokenizer.ts
@@ -2,6 +2,17 @@ import { colorToHex, NodeDocument, DesignToken,  Color, processTypographyDesignT
 // import { DesignToken, , FigmaFileNodes, NodeDocument, FigmaNodeKey,Styles } from './figma.utils';
 import { LayoutGrid } from 'figma-api/lib/ast-types';
 
+
+export const tokenizeName = (text: string) => {
+  return text.toString().replace(/[A-Z]/g, (newText: string) => '-' + newText.toLowerCase())
+    .replace(/\s+/g, '-')
+    .replace(/[^\w-]+/g, '-')
+    .replace(/--+/g, '-')
+    .replace(/^-+/, '-')
+    .replace(/-+$/, '-');
+};
+
+
 export const colorDesignTokenizer = (node: NodeDocument): DesignToken => {
   const colorToken: DesignToken = {
     type: 'color' ,
@@ -84,7 +95,7 @@ export const gridTokenizer = (nodeDoc: NodeDocument): DesignToken[] => {
         type:'breakpoint',
         name: `${ nodeDoc.name }`,
         node_id: nodeDoc.id,
-        value: `${ matched[1] }px`
+        value: `${ matched[1] }`
       } as DesignToken);
     }
   }
@@ -125,4 +136,21 @@ export const gridTokenizer = (nodeDoc: NodeDocument): DesignToken[] => {
   } as DesignToken);
 
   return designTokens;
+};
+
+
+
+export const spacingTokenizer = (node: NodeDocument): DesignToken|undefined => {
+  const spacingToken: DesignToken = {
+    type: 'spacing' ,
+    name: node.name,
+    node_id: node.id,
+    value: '0'
+  };
+  
+  const width = node?.absoluteBoundingBox ?
+    node.absoluteBoundingBox.width : node.children[0]?.absoluteBoundingBox?.width;
+  if(width) spacingToken.value = `${ width }`;
+  
+  return spacingToken;
 };

--- a/packages/cli/src/commands/styles/utils/figma.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figma.utils.ts
@@ -10,6 +10,7 @@ import {
   NodeKey,
   TokenTransform
 } from './figmaParser.utils';
+import { LayoutGrid } from 'figma-api/lib/ast-types';
 
 const tokensV2Flag = true;
 
@@ -101,7 +102,15 @@ export type NodeDocument = {
   }>,
   styles: ColorStyle | TypographyStyle,
   children: Array<NodeDocument>,
+  absoluteBoundingBox?: {
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  },
+  layoutGrids?: LayoutGrid[],
 };
+
 
 export type Styles = ColorStyle | TypographyStyle | ElevationStyle;
 

--- a/packages/cli/src/commands/styles/utils/figma.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figma.utils.ts
@@ -11,6 +11,7 @@ import {
   TokenTransform
 } from './figmaParser.utils';
 import { LayoutGrid } from 'figma-api/lib/ast-types';
+import { tokenizeName } from './figma.tokenizer';
 
 const tokensV2Flag = true;
 
@@ -530,42 +531,40 @@ const generateNodes =
   };
 
 export const processTypographyDesignToken = (nodeDoc: NodeDoc, parent?: string): DesignToken => {
-
-  if(nodeDoc.name?.includes('scale') && nodeDoc.name?.includes('$')) {
+  parent = parent?.toLowerCase();
+  if(parent?.includes('size')) {
     return {
       type: 'typography',
-      name: nodeDoc.name,
+      name: `${ nodeDoc.name } Font scale`,
       value: `${ nodeDoc.style.fontSize.toString() }px`,
-      token: `--${ nodeDoc.name.split(' ').join('-').toLowerCase() }${ nodeDoc.name.toLowerCase() }`
+      token: tokenizeName(`--${ parent }${ nodeDoc.name }`)
     } as DesignToken;
   }
 
   if(parent?.includes('weight')) {
     return {
       type: 'typography',
-      name: nodeDoc.parent,
+      name: `${ nodeDoc.name } ${ parent } Font weight`,
       value: nodeDoc.style.fontWeight.toString(),
-      token: `--${ parent.split(' ').join('-').toLowerCase() }${ nodeDoc.name.toLowerCase().split(' ').join('-') }`
+      token: tokenizeName(`--${ parent }${ nodeDoc.name }`)
     };
   }
 
-  if(parent?.toLowerCase().includes('line')) {
+  if(parent?.toLowerCase().includes('line') && parent?.toLowerCase().includes('percent')) {
     return {
       type: 'typography',
-      name: nodeDoc.parent,
+      name: `${ nodeDoc.name } Line height`,
       value: Math.round(nodeDoc.style.lineHeightPercentFontSize).toString() + '%',
-      token: `--${ parent.split(' ').join('-').toLowerCase() }${ nodeDoc.name.toLowerCase()
-        .split(' ').join('-').replace(/%/g, '') }`
+      token: tokenizeName(`--${ parent }${ nodeDoc.name }`)
     };
   }
 
   if(parent?.toLowerCase().includes('spacing')) {
     return {
       type: 'typography',
-      name: nodeDoc.parent,
+      name: `${ nodeDoc.name } Letter spacing`,
       value:`${ (nodeDoc.style.letterSpacing / 16).toString() }em`,
-      token: `--${ parent.split(' ').join('-').toLowerCase() }${ nodeDoc.name.toLowerCase().split(' ').join('-')
-        .replace(/%/g, '') }`
+      token: tokenizeName(`--${ parent }${ nodeDoc.name }`)
     };
   }
   return {} as DesignToken;

--- a/packages/cli/src/commands/styles/utils/figma.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figma.utils.ts
@@ -22,7 +22,7 @@ export type FigmaFileParams = {
 // type Unpromise<T extends Promise<any>> = T extends Promise<infer X> ? X : never;
 export type FigmaFileNodes = {
   nodes: {
-    [key: string]: NodeRoot | any ,
+    [key: string]: NodeRoot,
   },
 };
 
@@ -105,6 +105,7 @@ export type NodeDocument = {
 
 export type Styles = ColorStyle | TypographyStyle | ElevationStyle;
 
+
 export type BaseDef = {
   key: string,
   name: string,
@@ -186,17 +187,16 @@ type EffectType = {
   showShadowBehindNode: boolean,
 };
 
-export type NodeDoc = EffectsNode & RectangleNode & NodeDocument & {
-
-};
+export type NodeDoc = EffectsNode & RectangleNode & NodeDocument & {};
 
 export type DesignToken = {
   type: 'typography' | 'color' | 'spacing' | 'breakpoint' | 'grid' | 'elevation',
   name: string,
   viewPort?: string,
   cascade?: boolean,
-  token: string,
+  token?: string,
   value: string,
+  node_id?: string,
 };
 
 export type DesignTokenGroup = GroupOf<DesignToken, 'type'>;

--- a/packages/cli/src/commands/styles/utils/figmaResolver.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figmaResolver.utils.ts
@@ -55,8 +55,8 @@ export const getTokenWithOptions = (tOption?: TokenOption<NodeDoc>): FigmaTokenP
 
 export const transformNodes = (data: GetFileNodesResult[]) => {
   return data.flatMap((node) => {
-    const root: NodeRoot = extractFirstNode(node);
-  
+    const root: NodeRoot|undefined = extractFirstNode(node);
+    if(!root) return root;
     // If getTokensWithOptions(tokenOptions) has param tokenOptions, execute lines 66-68
     const tokenOptionsFunctions = getTokenWithOptions();
     if (tokenOptionsFunctions.length) 

--- a/packages/cli/src/commands/styles/utils/figmaResolver.utils.ts
+++ b/packages/cli/src/commands/styles/utils/figmaResolver.utils.ts
@@ -1,6 +1,7 @@
-import { GetFileNodesResult } from 'figma-api/lib/api-types';
+// import { GetFileNodesResult } from 'figma-api/lib/api-types';
 import { getColor2, getTypography2, getColor1, getTypography1 } from './extractors/figmaExtractors';
-import { extractFirstNode, NodeDoc, NodeRoot } from './figma.utils';
+// import { extractFirstNode, NodeDoc, NodeRoot } from './figma.utils';
+import {  NodeDoc, NodeRoot } from './figma.utils';
 import { isColor1, isColor2, isTypographyFormat1, isTypographyFormat2 } from './validators/figmaValidators';
 
 //FigmaResolver Types
@@ -53,23 +54,23 @@ export const getTokenWithOptions = (tOption?: TokenOption<NodeDoc>): FigmaTokenP
   return parserFunctions;
 };
 
-export const transformNodes = (data: GetFileNodesResult[]) => {
-  return data.flatMap((node) => {
-    const root: NodeRoot|undefined = extractFirstNode(node);
-    if(!root) return root;
-    // If getTokensWithOptions(tokenOptions) has param tokenOptions, execute lines 66-68
-    const tokenOptionsFunctions = getTokenWithOptions();
-    if (tokenOptionsFunctions.length) 
-      return tokenOptionsFunctions.flatMap((fParser) => fParser(root));
+// export const transformNodes = (data: GetFileNodesResult[]) => {
+//   return data.flatMap((node) => {
+//     const root: NodeRoot = extractFirstNode(node);
+//     if(!root) return root;
+//     // If getTokensWithOptions(tokenOptions) has param tokenOptions, execute lines 66-68
+//     const tokenOptionsFunctions = getTokenWithOptions();
+//     if (tokenOptionsFunctions.length) 
+//       return tokenOptionsFunctions.flatMap((fParser) => fParser(root));
   
-    // If no tokenOptions provided, execute lines 72-76
-    const colors = figmaResolver.parser.colors(root);
-    if(colors?.length) return colors;
+//     // If no tokenOptions provided, execute lines 72-76
+//     const colors = figmaResolver.parser.colors(root);
+//     if(colors?.length) return colors;
   
-    const parsedTypography = figmaResolver.parser.typography(root);
-    if(parsedTypography?.length) return parsedTypography;
-  }).filter((node) => node);
-};
+//     const parsedTypography = figmaResolver.parser.typography(root);
+//     if(parsedTypography?.length) return parsedTypography;
+//   }).filter((node) => node);
+// };
 
 const parseColors = generateParser([
   [isColor1, getColor1],

--- a/packages/cli/src/commands/styles/utils/publish.main.test.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.test.ts
@@ -123,7 +123,7 @@ describe('getStyles, getStyleNodes and processStyles', () => {
     expect.assertions(1);
     try {
       const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
-      await figmaAPI.getStyles('a bad url');
+      await figmaAPI._getStyles('a bad url');
     } catch (error: any){
       expect(error?.message).toBe('Failed to parse figma url');
     }
@@ -132,7 +132,7 @@ describe('getStyles, getStyleNodes and processStyles', () => {
   it('test geting style should return node list and style list', async ()  => {
     mockedAxios.get.mockResolvedValueOnce(publishStyles);
     const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
-    const styles = await figmaAPI.getStyles('TJzz7ZB6pJvpLhjI5DWG3F');
+    const styles = await figmaAPI._getStyles('TJzz7ZB6pJvpLhjI5DWG3F');
     expect(styles.length).toBe(66);
   });
 

--- a/packages/cli/src/commands/styles/utils/publish.main.test.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.test.ts
@@ -2,6 +2,8 @@
 import { figmaAPIFactory } from './publish.main';
 import * as publishNodes from '../lib/__mocks__/publish.nodes.json';
 import * as publishStyles from '../lib/__mocks__/publish.styles.json';
+import * as publishComponents from '../lib/__mocks__/publish.components.json';
+import * as publishComponentsNodes from '../lib/__mocks__/publish.nodes.components.dt.json';
 import axios from 'axios';
 // import { NodeDoc, NodeDocument } from './figma.utils';
 
@@ -143,10 +145,50 @@ describe('getStyles, getStyleNodes and processStyles', () => {
 
     const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
     const values = await figmaAPI.processStyles('TJzz7ZB6pJvpLhjI5DWG3F');
-    expect(Object.keys(values)).toStrictEqual(['elevation','typography', 'color']);    
+    expect(Object.keys(values)).toStrictEqual(['grid','elevation','typography', 'color','breakpoint']); 
+  });
+});
+
+
+describe('get components', () => {
+  it('should return undefined', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data:{} });
+    const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
+    const components = await figmaAPI._getComponents('TJzz7ZB6pJvpLhjI5DWG3F');
+    expect(components).toEqual(undefined);
   });
 
-});
+  it('should return the data', async () => {
+    mockedAxios.get.mockResolvedValueOnce(publishComponents);
+    const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
+    const components = await figmaAPI._getComponents('TJzz7ZB6pJvpLhjI5DWG3F');
+    if(components === undefined) {
+      expect(components).toBe(!undefined);
+    } else {
+      expect(components.length).toEqual(464);
+      expect(!!components[0]?.node_id).toEqual(true);
+      expect(!!components[0]?.created_at).toEqual(true);
+      expect(!!components[0]?.description).toEqual(true);
+    }
+  });
+
+  it('should create design tokens', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce(publishComponents)
+      .mockResolvedValueOnce(publishComponentsNodes);
+    const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
+    const components = await figmaAPI.processComponents('TJzz7ZB6pJvpLhjI5DWG3F');
+    expect(!!components).toBe(true);
+    // if(components === undefined) {
+    //   expect(components).toBe(!undefined);
+    // } else {
+    //   expect(components.length).toEqual(464);
+    //   expect(!!components[0]?.node_id).toEqual(true);
+    //   expect(!!components[0]?.created_at).toEqual(true);
+    //   expect(!!components[0]?.description).toEqual(true);
+    // }
+  });
+}); 
 
 
 

--- a/packages/cli/src/commands/styles/utils/publish.main.test.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.test.ts
@@ -147,7 +147,7 @@ describe('getStyles, getStyleNodes and processStyles', () => {
 
     const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
     const values = await figmaAPI.processStyles('TJzz7ZB6pJvpLhjI5DWG3F');
-    expect(Object.keys(values)).toStrictEqual(['grid','elevation','typography', 'color','breakpoint','spacing']);
+    expect(Object.keys(values)).toStrictEqual(['typography', 'elevation', 'grid', 'breakpoint','color','spacing']);
     expect(values['typography'][0].type).toStrictEqual('typography');
 
   });

--- a/packages/cli/src/commands/styles/utils/publish.main.test.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.test.ts
@@ -1,12 +1,12 @@
 // import { convertNodesToTokens, parseGRID, StyleDescriptor } from './publish.main';
-// import { figmaAPIFactory } from './publish.main';
-// import * as publishNodes from '../lib/__mocks__/publish.nodes.json';
-// import * as publishStyles from '../lib/__mocks__/publish.styles.json';
-// import axios from 'axios';
+import { figmaAPIFactory } from './publish.main';
+import * as publishNodes from '../lib/__mocks__/publish.nodes.json';
+import * as publishStyles from '../lib/__mocks__/publish.styles.json';
+import axios from 'axios';
 // import { NodeDoc, NodeDocument } from './figma.utils';
 
-// jest.mock('axios');
-// const mockedAxios = axios as jest.Mocked<typeof axios>;
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 // const exampleStyleData = {
 //   data:{
@@ -112,50 +112,44 @@
 // });
 
 
-describe('placeholder test', ()=> {
-  it('placeholder', ()=> {
-    expect(1).toEqual(1);
+// describe('placeholder test', ()=> {
+//   it('placeholder', ()=> {
+//     expect(1).toEqual(1);
+//   });
+// });
+describe('getStyles, getStyleNodes and processStyles', () => {
+  it('should fail', async() => {
+    mockedAxios.get.mockRejectedValue(publishStyles);
+    expect.assertions(1);
+    try {
+      const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
+      await figmaAPI.getStyles('a bad url');
+    } catch (error: any){
+      expect(error?.message).toBe('Failed to parse figma url');
+    }
   });
+
+  it('test geting style should return node list and style list', async ()  => {
+    mockedAxios.get.mockResolvedValueOnce(publishStyles);
+    const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
+    const styles = await figmaAPI.getStyles('TJzz7ZB6pJvpLhjI5DWG3F');
+    expect(styles.length).toBe(66);
+  });
+
+  it('gets data from full mock values', async ()  => {
+    mockedAxios.get
+      .mockResolvedValueOnce(publishStyles)
+      .mockResolvedValueOnce(publishNodes);
+
+    const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
+    const values = await figmaAPI.processStyles('TJzz7ZB6pJvpLhjI5DWG3F');
+    expect(Object.keys(values)).toStrictEqual(['elevation','typography', 'color']);    
+  });
+
 });
-// describe('getStyles, getStyleNodes and processStyles', () => {
-//   it('should fail', async() => {
-//     const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
-//     const styles = await figmaAPI.getStyles('a bad url');
-//     expect(styles.nodes).toStrictEqual([ '20008:10969', '20029:15098', '20008:10966' ]);
-//   });
-// });
 
-//   it('test geting style should return node list and style list', async ()  => {
-//     mockedAxios.get.mockResolvedValueOnce(exampleStyleData);
-//     const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
-//     const stylesListObj = await figmaAPI.getStyles('TJzz7ZB6pJvpLhjI5DWG3F');
-//     expect(stylesListObj.nodes).toStrictEqual([ '20008:10969', '20029:15098', '20008:10966' ]);
-//     expect(Object.keys(stylesListObj.styles).length).toBe(3);
-//   });
 
-//   it('gets the node styles', async ()  => {
-//     mockedAxios.get.mockResolvedValueOnce(exampleNodesData);
-//     const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
-//     const styles = await figmaAPI.getStyles(
-//       'TJzz7ZB6pJvpLhjI5DWG3F'
-//     );
-//     expect(styles.nodes).not.toBeFalsy();
-//     expect(Object.keys(styles)).toStrictEqual([ '20008:10969', '20029:15098', '20008:10966' ]);
-//     expect(Object.keys(styles.styles['20008:10969'])).toStrictEqual(
-//       [ 'document','components','componentSets','schemaVersion','styles' ]
-//     );    
-//   });
 
-//   it('gets data from full mock values', async ()  => {
-//     mockedAxios.get
-//       .mockResolvedValueOnce(publishStyles)
-//       .mockResolvedValueOnce(publishNodes);
-
-//     const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
-//     const values = await figmaAPI.processStyles('TJzz7ZB6pJvpLhjI5DWG3F');
-//     expect(Object.keys(values)).toStrictEqual(['typography', 'color','breakpoint']);    
-//   });
-// });
 
 // describe('parseGrid', ()=>{
 //   it('should parsetype Grid',() =>{

--- a/packages/cli/src/commands/styles/utils/publish.main.test.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.test.ts
@@ -127,7 +127,7 @@ describe('getStyles, getStyleNodes and processStyles', () => {
       const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
       await figmaAPI._getStyles('a bad url');
     } catch (error: any){
-      expect(error?.message).toBe('Failed to parse figma url');
+      expect(error?.message).toBe('Failed to parse figma url, https://api.figma.com/v1/files/a bad url/styles');
     }
   });
 
@@ -141,11 +141,15 @@ describe('getStyles, getStyleNodes and processStyles', () => {
   it('gets data from full mock values', async ()  => {
     mockedAxios.get
       .mockResolvedValueOnce(publishStyles)
-      .mockResolvedValueOnce(publishNodes);
+      .mockResolvedValueOnce(publishNodes)
+      .mockResolvedValueOnce(publishComponents)
+      .mockResolvedValueOnce(publishComponentsNodes);
 
     const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
     const values = await figmaAPI.processStyles('TJzz7ZB6pJvpLhjI5DWG3F');
-    expect(Object.keys(values)).toStrictEqual(['grid','elevation','typography', 'color','breakpoint']); 
+    expect(Object.keys(values)).toStrictEqual(['grid','elevation','typography', 'color','breakpoint','spacing']);
+    expect(values['typography'][0].type).toStrictEqual('typography');
+
   });
 });
 
@@ -177,249 +181,11 @@ describe('get components', () => {
       .mockResolvedValueOnce(publishComponents)
       .mockResolvedValueOnce(publishComponentsNodes);
     const figmaAPI = figmaAPIFactory('x-x-x-x-x-x');
-    const components = await figmaAPI.processComponents('TJzz7ZB6pJvpLhjI5DWG3F');
-    expect(!!components).toBe(true);
-    // if(components === undefined) {
-    //   expect(components).toBe(!undefined);
-    // } else {
-    //   expect(components.length).toEqual(464);
-    //   expect(!!components[0]?.node_id).toEqual(true);
-    //   expect(!!components[0]?.created_at).toEqual(true);
-    //   expect(!!components[0]?.description).toEqual(true);
-    // }
+    const componentsTokens = await figmaAPI._processStyleComponents('TJzz7ZB6pJvpLhjI5DWG3F');
+
+    expect(componentsTokens.length).toEqual(12);
+    expect(!!componentsTokens[0]?.node_id).toEqual(true);
+    expect(!!componentsTokens[0]?.type).toEqual(true);
+    expect(!!componentsTokens[0]?.name).toEqual(true);
   });
 }); 
-
-
-
-
-// describe('parseGrid', ()=>{
-//   it('should parsetype Grid',() =>{
-//     // ''
-//     const style: StyleDescriptor = {
-//       key: 'f9b164d248ace903e06565a46e043f59d051e049',
-//       file_key: 'TJzz7ZB6pJvpLhjI5DWG3F',
-//       node_id: '20008:10971',
-//       style_type: 'GRID',
-//       thumbnail_url: '',
-//       name: 'mobile (360px)',
-//       description: '--s-mobile-360px-4-columns',
-//       created_at: '2022-05-09T18:36:06.675Z',
-//       updated_at: '2022-05-09T18:36:06.675Z',
-//       user: {
-//         id: ' ',
-//         handle: ' ',
-//         img_url: ' '
-//       },
-//       sort_position: '\\'
-//     };
-
-//     const target: NodeDoc = {
-//       id: '20008:10971',
-//       name: 'background/2',
-//       type: 'RECTANGLE',
-//       blendMode: 'PASS_THROUGH',
-//       fills: [ { blendMode: 'NORMAL', type: 'SOLID', color: { r:0,g:0,b:0 } } ],
-//       strokes: [],
-//       strokeWeight: 1,
-//       strokeAlign: 'INSIDE',
-//       effects: [],
-//       parent:'',
-//       style:{
-//         fontFamily:'',
-//         fontWeight:0,
-//         fontSize:0,
-//         letterSpacing:0,
-//         lineHeightPx:0,
-//         lineHeightPercent:0,
-//         lineHeightPercentFontSize:0
-//       },
-//       styles:{ fill:'' },
-//       children:[],
-//       absoluteBoundingBox: {
-//         x: 0,
-//         y: 0,
-//         width: 0,
-//         height: 0
-//       },
-//       constraints: { 
-//         vertical: 'string', 
-//         horizontal: 'string' 
-//       }
-//     };
-
-//     expect(parseGRID(style,target)).toStrictEqual({
-//       type:'breakpoint',
-//       name:'background/2',
-//       token:'--s-mobile-360px-4-columns',
-//       value:'360',
-//       viewPort:'s'
-//     });
-//   });
-// });
-
-// describe('parse node to design token', () => {
-//   // const colorStyle: StyleDescriptor = {
-//   //   key: 'f9b164d248ace903e06565a46e043f59d051e049',
-//   //   file_key: 'TJzz7ZB6pJvpLhjI5DWG3F',
-//   //   node_id: '20008:10971',
-//   //   style_type: 'FILL',
-//   //   thumbnail_url: '',
-//   //   name: 'background/2',
-//   //   description: 'Colour Styles: --background-2-colour (#Token)',
-//   //   created_at: '2022-05-09T18:36:06.675Z',
-//   //   updated_at: '2022-05-09T18:36:06.675Z',
-//   //   user: {
-//   //     id: '716290236385945493',
-//   //     handle: ' ',
-//   //     img_url: 'https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd'
-//   //   },
-//   //   sort_position: '\\'
-//   // };
-//   const colorDoc: NodeDoc = {
-//     id: '20008:10971',
-//     name: 'background/2',
-//     type: 'RECTANGLE',
-//     blendMode: 'PASS_THROUGH',
-//     fills: [ { blendMode: 'NORMAL', type: 'SOLID', color: { r:0,g:0,b:0 } } ],
-//     strokes: [],
-//     strokeWeight: 1,
-//     strokeAlign: 'INSIDE',
-//     effects: [],
-//     parent:'',
-//     style:{
-//       fontFamily:'',
-//       fontWeight:0,
-//       fontSize:0,
-//       letterSpacing:0,
-//       lineHeightPx:0,
-//       lineHeightPercent:0,
-//       lineHeightPercentFontSize:0
-//     },
-//     styles:{ fill:'' },
-//     children:[],
-//     absoluteBoundingBox: {
-//       x: 0,
-//       y: 0,
-//       width: 0,
-//       height: 0
-//     },
-//     constraints: { 
-//       vertical: 'string', 
-//       horizontal: 'string' 
-//     }
-//   };
-
-//   it('should parse node to color design token', () =>{
-//     const nodeDocuments: NodeDocument[] = [];
-//     nodeDocuments.push(colorDoc);
-//     expect(convertNodesToTokens(nodeDocuments)).toStrictEqual([
-//       {
-//         type:'color',
-//         name:'background/2',
-//         token:'--background-2',
-//         value:'#000000'
-//       }
-//     ]);
-//   });
-  
-
-//   // const typeStyle: StyleDescriptor = {
-//   //   key: '30391beffefd13e8c0c224fc3732183ef79cad2d',
-//   //   file_key: 'TJzz7ZB6pJvpLhjI5DWG3F',
-//   //   node_id: '20519:3927',
-//   //   style_type: 'TEXT',
-//   //   thumbnail_url: '',
-//   //   name: 'inline/m/hover',
-//   //   description: '',
-//   //   created_at: '2022-05-09T18:36:03.466Z',
-//   //   updated_at: '2022-05-09T18:36:03.466Z',
-//   //   user: {
-//   //     id: '716290236385945493',
-//   //     handle: ' ',
-//   //     img_url: 'https://s3-alpha.figma.com/profile/e70a680e-ef91-44a3-aab5-b6be011f33dd'
-//   //   },
-//   //   sort_position: '!~~q|'
-//   // };
-//   // const typeDoc: NodeDoc = {
-//   //   id: '20519:3927',
-//   //   name: 'inline/m/hover',
-//   //   type: 'TEXT',
-//   //   blendMode: 'PASS_THROUGH',
-//   //   fills: [ { blendMode: 'NORMAL', type: 'SOLID', color: { r:0,g:0,b:0 } } ],
-//   //   strokes: [],
-//   //   strokeWeight: 0,
-//   //   strokeAlign: 'INSIDE',
-//   //   effects: [],
-//   //   style: {
-//   //     fontFamily: 'Roboto',
-//   //     fontPostScriptName: 'Roboto-Medium',
-//   //     fontWeight: 500,
-//   //     textAutoResize: 'WIDTH_AND_HEIGHT',
-//   //     textDecoration: 'UNDERLINE',
-//   //     fontSize: 16,
-//   //     textAlignHorizontal: 'LEFT',
-//   //     textAlignVertical: 'TOP',
-//   //     letterSpacing: 0,
-//   //     lineHeightPx: 24,
-//   //     lineHeightPercent: 128,
-//   //     lineHeightPercentFontSize: 150,
-//   //     lineHeightUnit: 'FONT_SIZE_%'
-//   //   },
-//   //   parent:'',
-//   //   styles:{ fill:'' },
-//   //   children:[],
-//   //   absoluteBoundingBox: {
-//   //     x: 0,
-//   //     y: 0,
-//   //     width: 0,
-//   //     height: 0
-//   //   },
-//   //   constraints: { 
-//   //     vertical: 'string', 
-//   //     horizontal: 'string' 
-//   //   }
-//   // };
-
-//   // it('should parseType typography', () =>{
-//   //   expect(parseType(typeStyle,typeDoc)).toStrictEqual([{
-//   //     cascade: false,
-//   //     name: 'inline/m/fontFamily',
-//   //     token: '--inline-m-font-family',
-//   //     type: 'typography',
-//   //     value: 'Roboto',
-//   //     viewPort: 'h'
-//   //   },{
-//   //     cascade: false,
-//   //     name: 'inline/m/fontWeight',
-//   //     token: '--inline-m-font-weight',
-//   //     type: 'typography',
-//   //     value: '500',
-//   //     viewPort: 'h'
-//   //   },{
-//   //     cascade: false,
-//   //     name: 'inline/m/fontSize',
-//   //     token: '--inline-m-font-size',
-//   //     type: 'typography',
-//   //     value: '16',
-//   //     viewPort: 'h'
-//   //   },{
-//   //     cascade: false,
-//   //     name: 'inline/m/letterSpacing',
-//   //     token: '--inline-m-letter-spacing',
-//   //     type: 'typography',
-//   //     value: '0',
-//   //     viewPort: 'h'
-//   //   },{
-//   //     cascade: false,
-//   //     name: 'inline/m/lineHeightPercent',
-//   //     token: '--inline-m-line-height-percent',
-//   //     type: 'typography',
-//   //     value: '128',
-//   //     viewPort: 'h'
-//   //   }]);
-//   // });
-  
-
-
-// });

--- a/packages/cli/src/commands/styles/utils/publish.main.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.ts
@@ -138,8 +138,8 @@ export const figmaAPIFactory = (token: string) => {
       // import fs from 'fs';
       // fs.writeFile(`${ new Date().getTime() }.json`, JSON.stringify({ data:res.data }),{},()=>{console.log(urlInput);});
     ).catch((_error: AxiosError)=>{
-      // console?.error(`Error ${ error?.response?.data } --- Error Code ${ error?.code }`);
-      throw new TypeError('Failed to parse figma url');
+      // console?.error(`Error ${ _error?.response?.data } --- Error Code ${ _error?.code }`);
+      throw new TypeError(`Failed to parse figma url, ${ urlInput }`);
     });
   };
 
@@ -191,12 +191,14 @@ export const figmaAPIFactory = (token: string) => {
     const nodeIds = figmaStyles.map((style: StyleMetadata)=>style.node_id);
     const nodes = await getNodes(fileKey, nodeIds);
 
-    const designTokens = convertStyleNodesToTokens(nodes,figmaStyles);
+    let designTokens = convertStyleNodesToTokens(nodes,figmaStyles);
+    const compoentTokens = await processStyleComponents(fileKey);
+    designTokens = [...designTokens,...compoentTokens];
     // // groups them all
     return groupByType(designTokens);
   };
 
-  const processComponents = async (fileKey: string) => {
+  const processStyleComponents = async (fileKey: string) => {
 
     // Get design tokens from components //Grid, Spacing, Border Radius
     const figmaComponents = await getComponents(fileKey);
@@ -211,8 +213,7 @@ export const figmaAPIFactory = (token: string) => {
       (data: [string, NodeRoot]) => compoentNodeDcuments.push(data[1].document)
     );
 
-    const designTokens = convertComponentNodesToTokens(compoentNodeDcuments);
-    return { designTokens };
+    return convertComponentNodesToTokens(compoentNodeDcuments);
   };
 
 
@@ -221,7 +222,7 @@ export const figmaAPIFactory = (token: string) => {
     _getData: getData,
     _getNodes: getNodes,
     _getStyles: getStyles,
-    processStyles,
-    processComponents
+    _processStyleComponents:processStyleComponents,
+    processStyles
   };
 };

--- a/packages/cli/src/commands/styles/utils/publish.main.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.ts
@@ -69,22 +69,25 @@ export const processStyleNodes = (data: NodeDocument, type: StyleType): DesignTo
 // filterFunctions.push(colorFilter,typographyFilter);
 // designTokenFunctions.push(colorDesignTokenizer);
 
+const isArray = (dToken: DesignToken | DesignToken[]): dToken is DesignToken[] => {
+  if(Array.isArray(dToken)) return true;
+  return false;
+}; 
+
 export const convertStyleNodesToTokens = (nodes: { [key: string]: NodeRoot }, styles: StyleMetadata[]) => {
   let designTokens: DesignToken[] = [];
   for(const index in styles){
-    const styleId = styles[index].node_id;
-    console.log(styleId);
-    const newTokens = processStyleNodes(nodes[styleId]?.document,styles[index].style_type);
-    if(newTokens){
-      if(Array.isArray(newTokens)){
-        designTokens = designTokens.concat(newTokens);
-      } else {
-        designTokens.push(newTokens);
-      }
+    const newDesignToken = processStyleNodes(nodes[styles[index].node_id]?.document,styles[index].style_type);
+    if(newDesignToken){
+      isArray(newDesignToken) ?
+        designTokens = [...designTokens, ...newDesignToken] : designTokens.push(newDesignToken);
     }
   }
   return designTokens;
 };
+
+
+
 
 
 //figmaAPIFactory is used in other files 

--- a/packages/cli/src/commands/styles/utils/publish.main.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.ts
@@ -158,7 +158,7 @@ export const figmaAPIFactory = (token: string) => {
     _getComponents: getComponents,
     _getData: getData,
     _getNodes: getNodes,
-    getStyles,
+    _getStyles:getStyles,
     processStyles
   };
 };

--- a/packages/cli/src/commands/styles/utils/publish.main.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.ts
@@ -5,7 +5,13 @@ import { StyleType } from 'figma-api/lib/ast-types';
 import { groupByType } from '../lib/radius-styles';
 import { DesignToken, FigmaFileNodes, NodeDocument, NodeRoot } from './figma.utils';
 import { NodeFilter, DesignTokenFilter } from './types/FigmaTypes';
-import { colorDesignTokenizer,processElevationTokenizer, typographyTokenizer, gridTokenizer } from './figma.tokenizer';
+import { 
+  colorDesignTokenizer,
+  processElevationTokenizer, 
+  typographyTokenizer, 
+  gridTokenizer, 
+  spacingTokenizer 
+} from './figma.tokenizer';
 
 
 //Utility methods 
@@ -58,20 +64,6 @@ const spacingFilter: NodeFilter = (
   return undefined;
 };
 
-export const spacingTokenizer = (node: NodeDocument): DesignToken|undefined => {
-  const spacingToken: DesignToken = {
-    type: 'spacing' ,
-    name: node.name,
-    node_id: node.id,
-    value: '0'
-  };
-  
-  const width = node?.absoluteBoundingBox ?
-    node.absoluteBoundingBox.width : node.children[0]?.absoluteBoundingBox?.width;
-  if(width) spacingToken.value = `${ width }px`;
-  
-  return spacingToken;
-};
 
 export const convertComponentNodesToTokens = (nodes: NodeDocument[]): DesignToken[] => {
   let designTokens: DesignToken[] = [];
@@ -134,9 +126,6 @@ export const figmaAPIFactory = (token: string) => {
       }
     }).then((res) => 
       res.data
-      // for saving mock data for testing
-      // import fs from 'fs';
-      // fs.writeFile(`${ new Date().getTime() }.json`, JSON.stringify({ data:res.data }),{},()=>{console.log(urlInput);});
     ).catch((_error: AxiosError)=>{
       // console?.error(`Error ${ _error?.response?.data } --- Error Code ${ _error?.code }`);
       throw new TypeError(`Failed to parse figma url, ${ urlInput }`);

--- a/packages/cli/src/commands/styles/utils/publish.main.ts
+++ b/packages/cli/src/commands/styles/utils/publish.main.ts
@@ -1,6 +1,7 @@
 //validator //loader/parse //tokenizer
 import axios, { AxiosError } from 'axios';
 import { StyleMetadata, ComponentMetadata } from 'figma-api/lib/api-types';
+import { StyleType } from 'figma-api/lib/ast-types';
 import { groupByType } from '../lib/radius-styles';
 import { DesignToken, FigmaFileNodes, NodeDocument, NodeRoot } from './figma.utils';
 import { NodeFilter, DesignTokenFilter } from './types/FigmaTypes';
@@ -23,18 +24,16 @@ export const filterFunctions: NodeFilter[] = [];
 export const designTokenFunctions: DesignTokenFilter[] = [];
 
 
-export const processStyleNodes = (data: NodeDocument, type: string): DesignToken[] | DesignToken | undefined => {
-  if(!data) return undefined;
+export const processStyleNodes = (data: NodeDocument, type: StyleType): DesignToken[] | DesignToken | undefined => {
   switch(type){
     case 'FILL':
-      // simple
       return colorDesignTokenizer(data);
     case 'TEXT':
       return typographyTokenizer(data);
     case 'EFFECT':
       return processElevationTokenizer(data);
     default:
-      return undefined;
+      break;
   }
 }; 
 
@@ -134,7 +133,6 @@ export const figmaAPIFactory = (token: string) => {
     // https://api.figma.com/v1/files/${fileKey}/nodes?ids=${nodeIds.join(",")}
     return getData(`https://api.figma.com/v1/files/${ fileKey }/nodes?ids=${ nodeIds.join(',') }`)
       .then((data: FigmaFileNodes) => { return data.nodes;});
-    // .then((figmaFileNode) => flattenNodes(figmaFileNode));
   };
 
   // const flattenNodes = (nodes: FigmaNodeKey): NodeDocument[] => {

--- a/packages/cli/src/commands/styles/utils/types/FigmaTypes.ts
+++ b/packages/cli/src/commands/styles/utils/types/FigmaTypes.ts
@@ -37,5 +37,5 @@ export type FigmaStyle = {
   [key: string]: StyleMetadata, 
 };
   
-export type DesignTokenFilter = (node: NodeDocument) => DesignToken;
-export  type NodeFilter = (data: NodeDocument, node: DesignTokenFilter) => DesignToken;
+export type DesignTokenFilter = (node: NodeDocument) => DesignToken|undefined;
+export  type NodeFilter = (data: NodeDocument, node: DesignTokenFilter) => DesignToken|undefined;


### PR DESCRIPTION
# Description

Switching over to a new model of how we're creating Design Tokens, using the styles to get a dictionary of styles that we can capture, Typography, Color and Shadow easily.

## Type of change

Reformatting and remove some functionality temporarily. 

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
I've added a few tests back for the figma api we're creating.


